### PR TITLE
fix(source-react-runtime): handle React types in props without skippi…

### DIFF
--- a/packages/xyd-source-react-runtime/__fixtures__/-2.vite-lib.react-types-resilience/input/package.json
+++ b/packages/xyd-source-react-runtime/__fixtures__/-2.vite-lib.react-types-resilience/input/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "xyd-fixture-rt-9-vite-lib-react-types-resilience",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build"
+  }
+}

--- a/packages/xyd-source-react-runtime/__fixtures__/-2.vite-lib.react-types-resilience/input/src/CardWrapper.tsx
+++ b/packages/xyd-source-react-runtime/__fixtures__/-2.vite-lib.react-types-resilience/input/src/CardWrapper.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+
+interface CardWrapperProps {
+    /** Card title */
+    title: string;
+
+    /** Card content — React types that typia cannot resolve */
+    children: React.ReactNode;
+
+    /** Optional icon element */
+    icon?: React.ReactElement;
+
+    /** Optional footer element */
+    footer?: React.ReactNode;
+
+    /** Whether the card has a border */
+    bordered?: boolean;
+}
+
+export function CardWrapper({ title, children, icon, footer, bordered }: CardWrapperProps) {
+    return (
+        <div className={`card ${bordered ? "bordered" : ""}`}>
+            <div className="card-header">
+                {icon && <span className="card-icon">{icon}</span>}
+                <h3>{title}</h3>
+            </div>
+            <div className="card-body">{children}</div>
+            {footer && <div className="card-footer">{footer}</div>}
+        </div>
+    );
+}

--- a/packages/xyd-source-react-runtime/__fixtures__/-2.vite-lib.react-types-resilience/input/src/StatusBadge.tsx
+++ b/packages/xyd-source-react-runtime/__fixtures__/-2.vite-lib.react-types-resilience/input/src/StatusBadge.tsx
@@ -1,0 +1,21 @@
+interface StatusBadgeProps {
+    /** Current status label */
+    label: string;
+
+    /** Visual variant */
+    variant: "success" | "warning" | "error" | "info";
+
+    /** Size of the badge */
+    size?: "small" | "medium" | "large";
+
+    /** Whether the badge should pulse */
+    animated?: boolean;
+}
+
+export function StatusBadge({ label, variant, size = "medium", animated }: StatusBadgeProps) {
+    return (
+        <span className={`badge badge-${variant} badge-${size} ${animated ? "pulse" : ""}`}>
+            {label}
+        </span>
+    );
+}

--- a/packages/xyd-source-react-runtime/__fixtures__/-2.vite-lib.react-types-resilience/input/src/index.ts
+++ b/packages/xyd-source-react-runtime/__fixtures__/-2.vite-lib.react-types-resilience/input/src/index.ts
@@ -1,0 +1,2 @@
+export { StatusBadge } from "./StatusBadge";
+export { CardWrapper } from "./CardWrapper";

--- a/packages/xyd-source-react-runtime/__fixtures__/-2.vite-lib.react-types-resilience/input/tsconfig.json
+++ b/packages/xyd-source-react-runtime/__fixtures__/-2.vite-lib.react-types-resilience/input/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2020",
+    "strict": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/xyd-source-react-runtime/__fixtures__/-2.vite-lib.react-types-resilience/input/vite.config.ts
+++ b/packages/xyd-source-react-runtime/__fixtures__/-2.vite-lib.react-types-resilience/input/vite.config.ts
@@ -1,0 +1,21 @@
+import {defineConfig} from 'vite';
+import react from '@vitejs/plugin-react';
+import {xydSourceReactRuntime} from '@xyd-js/source-react-runtime';
+
+export default defineConfig({
+    plugins: [
+        xydSourceReactRuntime(),
+        react(),
+    ],
+    build: {
+        lib: {
+            entry: 'src/index.ts',
+            formats: ['es'],
+            fileName: 'index',
+        },
+        rollupOptions: {
+            external: ['react', 'react/jsx-runtime', 'react/jsx-dev-runtime', 'react-dom'],
+        },
+        minify: false,
+    },
+});

--- a/packages/xyd-source-react-runtime/__fixtures__/-2.vite-lib.react-types-resilience/output.js
+++ b/packages/xyd-source-react-runtime/__fixtures__/-2.vite-lib.react-types-resilience/output.js
@@ -1,0 +1,15 @@
+// === index.js ===
+import { jsx, jsxs } from "react/jsx-runtime";
+function StatusBadge({ label, variant, size = "medium", animated }) {
+  return jsx("span", { className: `badge badge-${variant} badge-${size} ${animated ? "pulse" : ""}`, children: label });
+}
+StatusBadge.__xydUniform = JSON.parse('{"title":"StatusBadge","canonical":"","description":"","definitions":[{"title":"Props","properties":[{"name":"label","type":"string","description":"Current status label","meta":[{"name":"required","value":"true"}]},{"name":"variant","type":"$xor","description":"Visual variant","properties":[{"name":"variant","type":"object","description":"","meta":[{"name":"required","value":"true"}]},{"name":"variant","type":"object","description":"","meta":[{"name":"required","value":"true"}]},{"name":"variant","type":"object","description":"","meta":[{"name":"required","value":"true"}]},{"name":"variant","type":"object","description":"","meta":[{"name":"required","value":"true"}]}],"meta":[{"name":"required","value":"true"}]},{"name":"size","type":"$xor","description":"Size of the badge","properties":[{"name":"size","type":"object","description":"","meta":[]},{"name":"size","type":"object","description":"","meta":[]},{"name":"size","type":"object","description":"","meta":[]}],"meta":[]},{"name":"animated","type":"boolean","description":"Whether the badge should pulse","meta":[]}],"meta":[{"name":"type","value":"parameters"}]}],"examples":{"groups":[]}}');
+function CardWrapper({ title, children, icon, footer, bordered }) {
+  return jsxs("div", { className: `card ${bordered ? "bordered" : ""}`, children: [jsxs("div", { className: "card-header", children: [icon && jsx("span", { className: "card-icon", children: icon }), jsx("h3", { children: title })] }), jsx("div", { className: "card-body", children }), footer && jsx("div", { className: "card-footer", children: footer })] });
+}
+CardWrapper.__xydUniform = JSON.parse('{"title":"CardWrapper","canonical":"","description":"","definitions":[{"title":"Props","properties":[{"name":"title","type":"string","description":"Card title","meta":[{"name":"required","value":"true"}]},{"name":"children","type":"ReactNode","description":"Card content — React types that typia cannot resolve","meta":[{"name":"required","value":"true"}]},{"name":"icon","type":"ReactElement<unknown, string | JSXElementConstructor<any>> | undefined","description":"Optional icon element","meta":[]},{"name":"footer","type":"ReactNode","description":"Optional footer element","meta":[]},{"name":"bordered","type":"boolean","description":"Whether the card has a border","meta":[]}],"meta":[{"name":"type","value":"parameters"}]}],"examples":{"groups":[]}}');
+export {
+  CardWrapper,
+  StatusBadge
+};
+

--- a/packages/xyd-source-react-runtime/__fixtures__/-3.vite-app.iframe-multi-entry/input/index.html
+++ b/packages/xyd-source-react-runtime/__fixtures__/-3.vite-app.iframe-multi-entry/input/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Main App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/xyd-source-react-runtime/__fixtures__/-3.vite-app.iframe-multi-entry/input/package.json
+++ b/packages/xyd-source-react-runtime/__fixtures__/-3.vite-app.iframe-multi-entry/input/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "xyd-fixture-rt-neg3-vite-app-iframe-multi-entry",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "vite build"
+  }
+}

--- a/packages/xyd-source-react-runtime/__fixtures__/-3.vite-app.iframe-multi-entry/input/sample-app.html
+++ b/packages/xyd-source-react-runtime/__fixtures__/-3.vite-app.iframe-multi-entry/input/sample-app.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/sample-app-entry.ts"></script>
+  </body>
+</html>

--- a/packages/xyd-source-react-runtime/__fixtures__/-3.vite-app.iframe-multi-entry/input/src/main.tsx
+++ b/packages/xyd-source-react-runtime/__fixtures__/-3.vite-app.iframe-multi-entry/input/src/main.tsx
@@ -1,0 +1,38 @@
+import { createRoot } from "react-dom/client";
+
+interface NavBarProps {
+    /** Application title */
+    title: string;
+    /** Navigation links */
+    links: string[];
+    /** Whether to use dark theme */
+    dark?: boolean;
+}
+
+export function NavBar({ title, links, dark }: NavBarProps) {
+    return (
+        <nav style={{ background: dark ? "#222" : "#f5f5f5", padding: 8 }}>
+            <strong>{title}</strong>
+            <ul>
+                {links.map((link) => (
+                    <li key={link}>{link}</li>
+                ))}
+            </ul>
+        </nav>
+    );
+}
+
+function App() {
+    return (
+        <div>
+            <NavBar title="Playground" links={["Home", "About"]} />
+            <iframe
+                src="/sample-app.html"
+                style={{ width: "100%", height: 400, border: "none" }}
+            />
+        </div>
+    );
+}
+
+const root = createRoot(document.getElementById("root")!);
+root.render(<App />);

--- a/packages/xyd-source-react-runtime/__fixtures__/-3.vite-app.iframe-multi-entry/input/src/sample-app-entry.ts
+++ b/packages/xyd-source-react-runtime/__fixtures__/-3.vite-app.iframe-multi-entry/input/src/sample-app-entry.ts
@@ -1,0 +1,7 @@
+import("./sample-app").then(async ({ SampleApp }) => {
+    const React = await import("react");
+    const { createRoot } = await import("react-dom/client");
+
+    const root = createRoot(document.getElementById("root")!);
+    root.render(React.createElement(SampleApp));
+});

--- a/packages/xyd-source-react-runtime/__fixtures__/-3.vite-app.iframe-multi-entry/input/src/sample-app.tsx
+++ b/packages/xyd-source-react-runtime/__fixtures__/-3.vite-app.iframe-multi-entry/input/src/sample-app.tsx
@@ -1,0 +1,105 @@
+import { createContext, useContext, useState } from "react";
+
+// --- Types ---
+
+interface ThemeContextValue {
+    mode: "light" | "dark";
+    setMode: (mode: "light" | "dark") => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | null>(null);
+
+// --- Provider with React.ReactNode children ---
+
+function ThemeProvider({ children }: { children: React.ReactNode }) {
+    const [mode, setMode] = useState<"light" | "dark">("light");
+    return (
+        <ThemeContext.Provider value={{ mode, setMode }}>
+            {children}
+        </ThemeContext.Provider>
+    );
+}
+
+// --- Component with mixed props (simple + React types) ---
+
+interface User {
+    name: string;
+    email: string;
+    id: number;
+    joinedAt: Date;
+}
+
+interface UserCardProps {
+    user: User;
+    role: "admin" | "editor" | "viewer";
+    permissions: string[];
+    onEdit: (id: number) => void;
+    tags: Map<string, boolean>;
+    statusIndicator: React.ReactElement;
+    actionBar?: React.ReactNode;
+}
+
+function UserCard({ user, role, permissions, onEdit, tags, statusIndicator, actionBar }: UserCardProps) {
+    const [expanded, setExpanded] = useState(false);
+    const theme = useContext(ThemeContext);
+
+    return (
+        <div style={{ border: "1px solid #eee", padding: 12, borderRadius: 8, marginBottom: 8 }}>
+            <strong>{user.name}</strong> ({role})
+            <div style={{ fontSize: 12 }}>{user.email}</div>
+            <div>{permissions.join(", ")}</div>
+            <div>{statusIndicator}</div>
+            {actionBar}
+            <button type="button" onClick={() => setExpanded(!expanded)}>
+                {expanded ? "Hide" : "Show"}
+            </button>
+            {expanded && (
+                <div>
+                    <div>ID: {user.id}</div>
+                    <button type="button" onClick={() => onEdit(user.id)}>Edit</button>
+                </div>
+            )}
+        </div>
+    );
+}
+
+// --- Simple component (no React types) ---
+
+interface TodoItemProps {
+    id: number;
+    title: string;
+    completed: boolean;
+    priority: "low" | "medium" | "high";
+    onToggle: (id: number) => void;
+}
+
+function TodoItem({ id, title, completed, priority, onToggle }: TodoItemProps) {
+    return (
+        <div style={{ display: "flex", gap: 8, padding: 4 }}>
+            <input type="checkbox" checked={completed} onChange={() => onToggle(id)} />
+            <span style={{ textDecoration: completed ? "line-through" : "none" }}>{title}</span>
+            <span>({priority})</span>
+        </div>
+    );
+}
+
+// --- Main sample app ---
+
+function SampleApp() {
+    return (
+        <ThemeProvider>
+            <h3>Sample App (iframe)</h3>
+            <UserCard
+                user={{ name: "Alice", email: "alice@test.com", id: 1, joinedAt: new Date() }}
+                role="admin"
+                permissions={["read", "write"]}
+                onEdit={(id) => console.log("edit", id)}
+                tags={new Map([["verified", true]])}
+                statusIndicator={<span>Active</span>}
+            />
+            <TodoItem id={1} title="Write docs" completed={false} priority="high" onToggle={() => {}} />
+        </ThemeProvider>
+    );
+}
+
+export { ThemeProvider, ThemeContext, UserCard, TodoItem, SampleApp };

--- a/packages/xyd-source-react-runtime/__fixtures__/-3.vite-app.iframe-multi-entry/input/tsconfig.json
+++ b/packages/xyd-source-react-runtime/__fixtures__/-3.vite-app.iframe-multi-entry/input/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "outDir": "./dist",
+    "jsx": "react-jsx",
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "target": "ES2020",
+    "strict": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}

--- a/packages/xyd-source-react-runtime/__fixtures__/-3.vite-app.iframe-multi-entry/input/vite.config.ts
+++ b/packages/xyd-source-react-runtime/__fixtures__/-3.vite-app.iframe-multi-entry/input/vite.config.ts
@@ -1,0 +1,20 @@
+import {defineConfig} from 'vite';
+import {resolve} from 'node:path';
+import react from '@vitejs/plugin-react';
+import {xydSourceReactRuntime} from '@xyd-js/source-react-runtime';
+
+export default defineConfig({
+    plugins: [
+        xydSourceReactRuntime(),
+        react(),
+    ],
+    build: {
+        rollupOptions: {
+            input: {
+                main: resolve(__dirname, 'index.html'),
+                'sample-app': resolve(__dirname, 'sample-app.html'),
+            },
+        },
+        minify: false,
+    },
+});

--- a/packages/xyd-source-react-runtime/__fixtures__/-3.vite-app.iframe-multi-entry/output.js
+++ b/packages/xyd-source-react-runtime/__fixtures__/-3.vite-app.iframe-multi-entry/output.js
@@ -1,0 +1,48 @@
+// === assets/main-HASH.js ===
+import "./modulepreload-polyfill-HASH.js";
+import { j as jsxRuntimeExports } from "./jsx-runtime-HASH.js";
+import { a as clientExports } from "./client-HASH.js";
+import "./index-HASH.js";
+function NavBar({ title, links, dark }) {
+  return jsxRuntimeExports.jsxs("nav", { style: { background: dark ? "#222" : "#f5f5f5", padding: 8 }, children: [jsxRuntimeExports.jsx("strong", { children: title }), jsxRuntimeExports.jsx("ul", { children: links.map((link) => jsxRuntimeExports.jsx("li", { children: link }, link)) })] });
+}
+function App() {
+  return jsxRuntimeExports.jsxs("div", { children: [jsxRuntimeExports.jsx(NavBar, { title: "Playground", links: ["Home", "About"] }), jsxRuntimeExports.jsx("iframe", { src: "/sample-app.html", style: { width: "100%", height: 400, border: "none" } })] });
+}
+const root = clientExports.createRoot(document.getElementById("root"));
+root.render(jsxRuntimeExports.jsx(App, {}));
+NavBar.__xydUniform = JSON.parse('{"title":"NavBar","canonical":"","description":"","definitions":[{"title":"Props","properties":[{"name":"title","type":"string","description":"Application title","meta":[{"name":"required","value":"true"}]},{"name":"links","type":"$array","description":"Navigation links","meta":[{"name":"required","value":"true"}],"properties":[],"ofProperty":{"name":"","type":"string","properties":[],"description":"","meta":[{"name":"required","value":"true"}]}},{"name":"dark","type":"boolean","description":"Whether to use dark theme","meta":[]}],"meta":[{"name":"type","value":"parameters"}]}],"examples":{"groups":[]}}');
+
+
+// === assets/sample-app-HASH.js ===
+import { j as jsxRuntimeExports } from "./jsx-runtime-HASH.js";
+import { r as reactExports } from "./index-HASH.js";
+import "./index-HASH.js";
+const ThemeContext = reactExports.createContext(null);
+function ThemeProvider({ children }) {
+  const [mode, setMode] = reactExports.useState("light");
+  return jsxRuntimeExports.jsx(ThemeContext.Provider, { value: { mode, setMode }, children });
+}
+function UserCard({ user, role, permissions, onEdit, tags, statusIndicator, actionBar }) {
+  const [expanded, setExpanded] = reactExports.useState(false);
+  reactExports.useContext(ThemeContext);
+  return jsxRuntimeExports.jsxs("div", { style: { border: "1px solid #eee", padding: 12, borderRadius: 8, marginBottom: 8 }, children: [jsxRuntimeExports.jsx("strong", { children: user.name }), " (", role, ")", jsxRuntimeExports.jsx("div", { style: { fontSize: 12 }, children: user.email }), jsxRuntimeExports.jsx("div", { children: permissions.join(", ") }), jsxRuntimeExports.jsx("div", { children: statusIndicator }), actionBar, jsxRuntimeExports.jsx("button", { type: "button", onClick: () => setExpanded(!expanded), children: expanded ? "Hide" : "Show" }), expanded && jsxRuntimeExports.jsxs("div", { children: [jsxRuntimeExports.jsxs("div", { children: ["ID: ", user.id] }), jsxRuntimeExports.jsx("button", { type: "button", onClick: () => onEdit(user.id), children: "Edit" })] })] });
+}
+function TodoItem({ id, title, completed, priority, onToggle }) {
+  return jsxRuntimeExports.jsxs("div", { style: { display: "flex", gap: 8, padding: 4 }, children: [jsxRuntimeExports.jsx("input", { type: "checkbox", checked: completed, onChange: () => onToggle(id) }), jsxRuntimeExports.jsx("span", { style: { textDecoration: completed ? "line-through" : "none" }, children: title }), jsxRuntimeExports.jsxs("span", { children: ["(", priority, ")"] })] });
+}
+function SampleApp() {
+  return jsxRuntimeExports.jsxs(ThemeProvider, { children: [jsxRuntimeExports.jsx("h3", { children: "Sample App (iframe)" }), jsxRuntimeExports.jsx(UserCard, { user: { name: "Alice", email: "alice@test.com", id: 1, joinedAt: /* @__PURE__ */ new Date() }, role: "admin", permissions: ["read", "write"], onEdit: (id) => console.log("edit", id), tags: /* @__PURE__ */ new Map([["verified", true]]), statusIndicator: jsxRuntimeExports.jsx("span", { children: "Active" }) }), jsxRuntimeExports.jsx(TodoItem, { id: 1, title: "Write docs", completed: false, priority: "high", onToggle: () => {
+  } })] });
+}
+ThemeContext.__xydUniform = JSON.parse('{"title":"ThemeContext","canonical":"","description":"","definitions":[{"title":"Props","properties":[{"name":"mode","type":"$xor","description":"","properties":[{"name":"mode","type":"object","description":"","meta":[{"name":"required","value":"true"}]},{"name":"mode","type":"object","description":"","meta":[{"name":"required","value":"true"}]}],"meta":[{"name":"required","value":"true"}]}],"meta":[{"name":"type","value":"parameters"}]}],"examples":{"groups":[]}}');
+UserCard.__xydUniform = JSON.parse('{"title":"UserCard","canonical":"","description":"","definitions":[{"title":"Props","properties":[{"name":"user","type":"User","description":"","meta":[{"name":"required","value":"true"}]},{"name":"role","type":"$xor","description":"","properties":[{"name":"role","type":"string","description":"","meta":[{"name":"required","value":"true"}]},{"name":"role","type":"string","description":"","meta":[{"name":"required","value":"true"}]},{"name":"role","type":"string","description":"","meta":[{"name":"required","value":"true"}]}],"meta":[{"name":"required","value":"true"}]},{"name":"permissions","type":"$array","description":"","meta":[{"name":"required","value":"true"}],"properties":[],"ofProperty":{"name":"","type":"string","properties":[],"description":"","meta":[{"name":"required","value":"true"}]}},{"name":"onEdit","type":"(id: number) => void","description":"","meta":[{"name":"required","value":"true"}]},{"name":"tags","type":"Map<string, boolean>","description":"","meta":[{"name":"required","value":"true"}]},{"name":"statusIndicator","type":"ReactElement<unknown, string | JSXElementConstructor<any>>","description":"","meta":[{"name":"required","value":"true"}]},{"name":"actionBar","type":"ReactNode","description":"","meta":[]}],"meta":[{"name":"type","value":"parameters"}]}],"examples":{"groups":[]}}');
+TodoItem.__xydUniform = JSON.parse('{"title":"TodoItem","canonical":"","description":"","definitions":[{"title":"Props","properties":[{"name":"id","type":"number","description":"","meta":[{"name":"required","value":"true"}]},{"name":"title","type":"string","description":"","meta":[{"name":"required","value":"true"}]},{"name":"completed","type":"boolean","description":"","meta":[{"name":"required","value":"true"}]},{"name":"priority","type":"$xor","description":"","properties":[{"name":"priority","type":"object","description":"","meta":[{"name":"required","value":"true"}]},{"name":"priority","type":"object","description":"","meta":[{"name":"required","value":"true"}]},{"name":"priority","type":"object","description":"","meta":[{"name":"required","value":"true"}]}],"meta":[{"name":"required","value":"true"}]}],"meta":[{"name":"type","value":"parameters"}]}],"examples":{"groups":[]}}');
+export {
+  SampleApp,
+  ThemeContext,
+  ThemeProvider,
+  TodoItem,
+  UserCard
+};
+

--- a/packages/xyd-source-react-runtime/__tests__/source-react-runtime.test.ts
+++ b/packages/xyd-source-react-runtime/__tests__/source-react-runtime.test.ts
@@ -50,6 +50,10 @@ const tests: {
         name: '8.tanstack-router.app',
         description: 'tanstack router: file-based routing with createFileRoute, Link, useNavigate',
     },
+    {
+        name: '-2.vite-lib.react-types-resilience',
+        description: 'vite lib: components with React types in props do not break sibling components',
+    },
 ];
 
 describe('xyd-source-react-runtime', () => {

--- a/packages/xyd-source-react-runtime/__tests__/source-react-runtime.test.ts
+++ b/packages/xyd-source-react-runtime/__tests__/source-react-runtime.test.ts
@@ -54,6 +54,10 @@ const tests: {
         name: '-2.vite-lib.react-types-resilience',
         description: 'vite lib: components with React types in props do not break sibling components',
     },
+    {
+        name: '-3.vite-app.iframe-multi-entry',
+        description: 'vite app: multi-entry with iframe loading separate React app',
+    },
 ];
 
 describe('xyd-source-react-runtime', () => {

--- a/packages/xyd-source-react-runtime/__tests__/utils.ts
+++ b/packages/xyd-source-react-runtime/__tests__/utils.ts
@@ -86,7 +86,7 @@ export async function testSourceReactRuntime(fixtureName: string, propertyName: 
 
     // Save snapshot
     const snapshotPath = fullFixturePath(`${fixtureName}/output.js`);
-    fs.writeFileSync(snapshotPath, result);
+    // fs.writeFileSync(snapshotPath, result);
 
     // Compare
     const expected = fs.readFileSync(snapshotPath, 'utf8');

--- a/packages/xyd-source-react-runtime/src/index.ts
+++ b/packages/xyd-source-react-runtime/src/index.ts
@@ -137,7 +137,99 @@ async function buildTypiaSchemas(tsconfigPath: string): Promise<Map<string, stri
         modifiedSources.set(fileName, modified);
     }
 
-    // Step 3: Create a TS program with modified sources for typia transform
+    // Step 3: Try emitting all components at once; on failure, retry per-component
+    const emitResult = emitWithTypia(ts, parsedConfig, modifiedSources, typiaTransformModule, componentsByFile);
+
+    for (const [fileName, output] of emitResult) {
+        result.set(fileName, output);
+    }
+
+    // Step 4: For files that failed, retry each component individually
+    // Lazily create a clean program (no typia) for type-checker fallback
+    let cleanProgram: import('typescript').Program | null = null;
+
+    for (const [fileName, components] of componentsByFile) {
+        if (result.has(path.resolve(fileName))) continue;
+
+        const supported = components.filter(c => !c.propsType.includes('React.'));
+        if (supported.length === 0) continue;
+
+        const original = ts.sys.readFile(fileName)!;
+        let mergedOutput = '';
+
+        for (const comp of supported) {
+            const singleModified = new Map(modifiedSources);
+            // Replace this file's modified source with one that only has this component's typia call
+            const singleSource = `import typia from "typia";\n${original}\n${comp.name}.__xydSchema = typia.json.schemas<[${comp.propsType}]>();`;
+            singleModified.set(fileName, singleSource);
+
+            const singleResult = emitWithTypia(ts, parsedConfig, singleModified, typiaTransformModule, new Map([[fileName, [comp]]]));
+            const singleOutput = singleResult.get(path.resolve(fileName));
+
+            if (singleOutput) {
+                // Extract the __xydSchema assignment line from successful output
+                const schemaMatch = singleOutput.match(new RegExp(`${comp.name}\\.__xydSchema\\s*=\\s*\\{[\\s\\S]*?\\n\\};`));
+                if (schemaMatch) {
+                    if (!mergedOutput) {
+                        // Use the first successful output as the base (it has the full compiled file)
+                        mergedOutput = singleOutput;
+                    } else {
+                        // Append the schema assignment to the base output
+                        mergedOutput += `\n${schemaMatch[0]}`;
+                    }
+                }
+            } else {
+                // Typia can't handle this component's props (e.g. React types) —
+                // fall back to TS type checker to extract the schema manually
+                if (!cleanProgram) {
+                    cleanProgram = ts.createProgram({
+                        rootNames: parsedConfig.fileNames,
+                        options: {...parsedConfig.options, noEmit: false, declaration: false, sourceMap: false},
+                    });
+                }
+
+                // Get base compiled output if we don't have one yet
+                if (!mergedOutput) {
+                    const sf = cleanProgram.getSourceFile(fileName);
+                    if (sf) {
+                        cleanProgram.emit(sf, (_name, text) => {
+                            if (!_name.endsWith('.d.ts')) mergedOutput = text;
+                        });
+                    }
+                }
+
+                const schema = fallbackExtractSchema(ts, cleanProgram, fileName, comp);
+                if (schema) {
+                    const schemaStr = JSON.stringify(schema, null, 2);
+                    mergedOutput += `\n${comp.name}.__xydSchema = ${schemaStr};`;
+                } else {
+                    console.warn(`[xyd-source-react-runtime] could not extract schema for ${comp.name} in ${fileName}, skipping component`);
+                }
+            }
+        }
+
+        if (mergedOutput) {
+            result.set(path.resolve(fileName), mergedOutput);
+        }
+    }
+
+    return result;
+}
+
+/**
+ * Creates a TS program with modified sources and emits typia-transformed output.
+ * Returns a map of resolved file paths to their transformed output.
+ * Files that fail during transform are silently skipped (returns empty map for them).
+ */
+function emitWithTypia(
+    ts: typeof import('typescript'),
+    parsedConfig: import('typescript').ParsedCommandLine,
+    modifiedSources: Map<string, string>,
+    typiaTransformModule: any,
+    componentsByFile: Map<string, ComponentInfo[]>,
+): Map<string, string> {
+    const result = new Map<string, string>();
+
     const compilerHost = ts.createCompilerHost(parsedConfig.options);
     const origGetSourceFile = compilerHost.getSourceFile;
     const origFileExists = compilerHost.fileExists;
@@ -174,7 +266,6 @@ async function buildTypiaSchemas(tsconfigPath: string): Promise<Map<string, stri
 
     const factory = (typiaTransformModule.default || typiaTransformModule)(program);
 
-    // Step 4: Emit typia-transformed output for each file with components
     for (const fileName of componentsByFile.keys()) {
         const sourceFile = program.getSourceFile(fileName);
         if (!sourceFile) continue;
@@ -196,14 +287,136 @@ async function buildTypiaSchemas(tsconfigPath: string): Promise<Map<string, stri
             if (output) {
                 result.set(path.resolve(fileName), output);
             }
-        } catch (e) {
-            // typia transform can fail on files with unresolvable types (e.g. React.ReactNode)
-            // Skip these files — their components won't get __xydUniform
-            console.warn(`[xyd-source-react-runtime] typia transform failed for ${fileName}, skipping`);
+        } catch {
+            // Transform failed for this file — caller will handle retry
         }
     }
 
     return result;
+}
+
+/**
+ * Fallback: uses the TS type checker to extract a JSON Schema from a component's
+ * props type when typia can't handle it (e.g. props containing React.ReactNode).
+ */
+function fallbackExtractSchema(
+    ts: typeof import('typescript'),
+    program: import('typescript').Program,
+    fileName: string,
+    comp: ComponentInfo,
+): Record<string, any> | null {
+    const checker = program.getTypeChecker();
+    const sourceFile = program.getSourceFile(fileName);
+    if (!sourceFile) return null;
+
+    let propsType: import('typescript').Type | undefined;
+
+    const findPropsInNode = (node: import('typescript').Node) => {
+        if (propsType) return;
+
+        if (ts.isFunctionDeclaration(node) && node.name?.text === comp.name) {
+            const param = node.parameters[0];
+            if (param?.type) propsType = checker.getTypeAtLocation(param.type);
+        }
+
+        if (ts.isVariableStatement(node)) {
+            for (const decl of node.declarationList.declarations) {
+                if (!ts.isIdentifier(decl.name) || decl.name.text !== comp.name) continue;
+                if (decl.initializer && (ts.isArrowFunction(decl.initializer) || ts.isFunctionExpression(decl.initializer))) {
+                    const param = decl.initializer.parameters[0];
+                    if (param?.type) propsType = checker.getTypeAtLocation(param.type);
+                }
+            }
+        }
+    };
+
+    ts.forEachChild(sourceFile, findPropsInNode);
+    if (!propsType) return null;
+
+    const properties: Record<string, any> = {};
+    const required: string[] = [];
+
+    for (const symbol of checker.getPropertiesOfType(propsType)) {
+        const name = symbol.getName();
+        const memberType = checker.getTypeOfSymbolAtLocation(symbol, sourceFile);
+        const description = ts.displayPartsToString(symbol.getDocumentationComment(checker));
+        const isOptional = (symbol.flags & ts.SymbolFlags.Optional) !== 0;
+
+        const schema = tsTypeToJsonSchema(ts, checker, memberType, sourceFile);
+        if (description) schema.description = description;
+
+        properties[name] = schema;
+        if (!isOptional) required.push(name);
+    }
+
+    const rootSchema: any = { type: 'object', properties };
+    if (required.length > 0) rootSchema.required = required;
+
+    return {
+        version: '3.1',
+        components: { schemas: { [comp.propsType]: rootSchema } },
+        schemas: [{ $ref: `#/components/schemas/${comp.propsType}` }],
+    };
+}
+
+/**
+ * Converts a TS type to a JSON Schema object using the type checker.
+ * Handles primitives, string literal unions, arrays, and falls back to
+ * { type: "object", description } for complex types (React, DOM, etc.).
+ */
+function tsTypeToJsonSchema(
+    ts: typeof import('typescript'),
+    checker: import('typescript').TypeChecker,
+    type: import('typescript').Type,
+    location: import('typescript').Node,
+): any {
+    const typeStr = checker.typeToString(type);
+
+    if (type.flags & ts.TypeFlags.String) return {type: 'string'};
+    if (type.flags & ts.TypeFlags.Number) return {type: 'number'};
+    if (type.flags & (ts.TypeFlags.Boolean | ts.TypeFlags.BooleanLiteral)) return {type: 'boolean'};
+    if (type.flags & ts.TypeFlags.Null) return {type: 'null'};
+    if (type.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) return {};
+    if (type.flags & (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) return {};
+
+    if (type.isStringLiteral()) return {type: 'string', const: type.value};
+    if (type.isNumberLiteral()) return {type: 'number', const: type.value};
+
+    if (type.isUnion()) {
+        const types = type.types.filter(t => !(t.flags & ts.TypeFlags.Undefined));
+        // boolean is internally `true | false` — detect and collapse it
+        if (types.length <= 2 && types.every(t => !!(t.flags & ts.TypeFlags.BooleanLiteral))) {
+            return {type: 'boolean'};
+        }
+        if (types.every(t => t.isStringLiteral())) {
+            return {
+                oneOf: types.map(t => ({type: 'string', const: (t as import('typescript').StringLiteralType).value})),
+            };
+        }
+        // Simple unions with only primitives/literals
+        if (types.length <= 4 && types.every(t =>
+            (t.flags & (ts.TypeFlags.String | ts.TypeFlags.Number | ts.TypeFlags.Boolean |
+                ts.TypeFlags.BooleanLiteral | ts.TypeFlags.Null)) !== 0 ||
+            t.isStringLiteral() || t.isNumberLiteral()
+        )) {
+            if (types.length === 1) return tsTypeToJsonSchema(ts, checker, types[0], location);
+            return {oneOf: types.map(t => tsTypeToJsonSchema(ts, checker, t, location))};
+        }
+        return {type: typeStr};
+    }
+
+    // Simple array types
+    if (typeStr === 'string[]') return {type: 'array', items: {type: 'string'}};
+    if (typeStr === 'number[]') return {type: 'array', items: {type: 'number'}};
+    if (typeStr === 'boolean[]') return {type: 'array', items: {type: 'boolean'}};
+    if (typeStr.endsWith('[]') || typeStr.startsWith('Array<')) return {type: 'array'};
+
+    // Function types — use the signature as the type
+    const signatures = checker.getSignaturesOfType(type, ts.SignatureKind.Call);
+    if (signatures.length > 0) return {type: typeStr};
+
+    // Everything else — React types, DOM, Map, Set, Date, Record, etc.
+    return {type: typeStr};
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,103 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.9.0)(happy-dom@15.11.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)
 
+  .xyd/host:
+    dependencies:
+      '@react-router/dev':
+        specifier: ^7.7.1
+        version: 7.14.2(@react-router/serve@7.14.2(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3))(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+      '@react-router/node':
+        specifier: ^7.7.1
+        version: 7.14.2(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
+      '@react-router/serve':
+        specifier: ^7.7.1
+        version: 7.14.2(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
+      '@xyd-js/analytics':
+        specifier: workspace:*
+        version: link:../../packages/xyd-analytics
+      '@xyd-js/atlas':
+        specifier: workspace:*
+        version: link:../../packages/xyd-atlas
+      '@xyd-js/components':
+        specifier: workspace:*
+        version: link:../../packages/xyd-components
+      '@xyd-js/composer':
+        specifier: workspace:*
+        version: link:../../packages/xyd-composer
+      '@xyd-js/content':
+        specifier: workspace:*
+        version: link:../../packages/xyd-content
+      '@xyd-js/core':
+        specifier: workspace:*
+        version: link:../../packages/xyd-core
+      '@xyd-js/framework':
+        specifier: workspace:*
+        version: link:../../packages/xyd-framework
+      '@xyd-js/plugin-algolia':
+        specifier: workspace:*
+        version: link:../../packages/xyd-plugin-algolia
+      '@xyd-js/plugin-orama':
+        specifier: workspace:*
+        version: link:../../packages/xyd-plugin-orama
+      '@xyd-js/theme-cosmo':
+        specifier: workspace:*
+        version: link:../../packages/xyd-theme-cosmo
+      '@xyd-js/theme-gusto':
+        specifier: workspace:*
+        version: link:../../packages/xyd-theme-gusto
+      '@xyd-js/theme-opener':
+        specifier: workspace:*
+        version: link:../../packages/xyd-theme-opener
+      '@xyd-js/theme-picasso':
+        specifier: workspace:*
+        version: link:../../packages/xyd-theme-picasso
+      '@xyd-js/theme-poetry':
+        specifier: workspace:*
+        version: link:../../packages/xyd-theme-poetry
+      '@xyd-js/theme-solar':
+        specifier: workspace:*
+        version: link:../../packages/xyd-theme-solar
+      '@xyd-js/themes':
+        specifier: workspace:*
+        version: link:../../packages/xyd-themes
+      isbot:
+        specifier: ^5
+        version: 5.1.32
+      katex:
+        specifier: ^0.16.22
+        version: 0.16.27
+      openux-js:
+        specifier: 0.0.0-pre.1
+        version: 0.0.0-pre.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      pluganalytics:
+        specifier: 0.0.0-pre.3
+        version: 0.0.0-pre.3
+      react:
+        specifier: ^19.1.0
+        version: 19.2.3
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.3(react@19.2.3)
+      react-router:
+        specifier: ^7.5.2
+        version: 7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    devDependencies:
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.4.23(postcss@8.5.6)
+      postcss:
+        specifier: ^8.4.47
+        version: 8.5.6
+      semver:
+        specifier: ^7.6.3
+        version: 7.7.3
+      vite:
+        specifier: ^7.0.0
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+
   apps/apidocs-demo:
     dependencies:
       '@netlify/vite-plugin-react-router':
@@ -1821,46 +1918,6 @@ importers:
       vitest:
         specifier: ^1.3.1
         version: 1.6.1(@types/node@24.10.9)(happy-dom@15.11.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)
-
-  packages/xyd-source-react-babel-runtime:
-    dependencies:
-      '@xyd-js/sources':
-        specifier: workspace:*
-        version: link:../xyd-sources
-      '@xyd-js/uniform':
-        specifier: workspace:*
-        version: link:../xyd-uniform
-    devDependencies:
-      '@babel/core':
-        specifier: ^7.26.0
-        version: 7.28.6
-      '@types/babel__core':
-        specifier: ^7.20.5
-        version: 7.20.5
-      '@vitejs/plugin-react':
-        specifier: ^4.3.4
-        version: 4.7.0(vite@6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
-      react:
-        specifier: ^19.1.0
-        version: 19.2.3
-      react-dom:
-        specifier: ^19.1.0
-        version: 19.2.3(react@19.2.3)
-      rimraf:
-        specifier: ^3.0.2
-        version: 3.0.2
-      tsup:
-        specifier: ^8.3.0
-        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
-      typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
-      vite:
-        specifier: ^6.3.2
-        version: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vitest:
-        specifier: ^2.1.8
-        version: 2.1.9(@types/node@24.10.9)(happy-dom@15.11.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)
 
   packages/xyd-source-react-runtime:
     dependencies:
@@ -18939,7 +18996,7 @@ snapshots:
       find-up: 6.3.0
       minimatch: 9.0.5
       read-pkg: 7.1.0
-      semver: 7.6.3
+      semver: 7.7.3
       yaml: 2.8.2
       yargs: 17.7.2
 
@@ -18995,7 +19052,7 @@ snapshots:
       resolve: 2.0.0-next.5
       rfdc: 1.4.1
       safe-json-stringify: 1.2.0
-      semver: 7.6.3
+      semver: 7.7.3
       string-width: 5.1.2
       strip-ansi: 7.1.2
       supports-color: 9.4.0
@@ -19091,7 +19148,7 @@ snapshots:
       p-retry: 5.1.2
       p-wait-for: 4.1.0
       path-key: 4.0.0
-      semver: 7.6.3
+      semver: 7.7.3
       tmp-promise: 3.0.3
       urlpattern-polyfill: 8.0.2
       uuid: 9.0.1
@@ -19121,7 +19178,7 @@ snapshots:
       p-retry: 5.1.2
       p-wait-for: 4.1.0
       path-key: 4.0.0
-      semver: 7.6.3
+      semver: 7.7.3
       tmp-promise: 3.0.3
       urlpattern-polyfill: 8.0.2
       uuid: 9.0.1
@@ -19176,7 +19233,7 @@ snapshots:
       p-filter: 4.1.0
       p-locate: 6.0.0
       read-pkg-up: 9.1.0
-      semver: 7.6.3
+      semver: 7.7.3
 
   '@netlify/functions-utils@5.3.18(encoding@0.1.13)(rollup@4.55.1)(supports-color@9.4.0)':
     dependencies:
@@ -19284,9 +19341,9 @@ snapshots:
 
   '@netlify/vite-plugin-react-router@1.0.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(typescript@5.8.3)(vite@6.4.1(@types/node@20.9.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@react-router/node': 7.12.0(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
+      '@react-router/node': 7.14.2(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
       isbot: 5.1.32
-      react-router: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react-router: 7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       vite: 6.4.1(@types/node@20.9.0)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - react
@@ -19363,7 +19420,7 @@ snapshots:
       precinct: 11.0.5
       require-package-name: 2.0.1
       resolve: 2.0.0-next.5
-      semver: 7.6.3
+      semver: 7.7.3
       tmp-promise: 3.0.3
       toml: 3.0.0
       unixify: 1.0.0
@@ -19406,7 +19463,7 @@ snapshots:
       precinct: 11.0.5(supports-color@9.4.0)
       require-package-name: 2.0.1
       resolve: 2.0.0-next.5
-      semver: 7.6.3
+      semver: 7.7.3
       tmp-promise: 3.0.3
       toml: 3.0.0
       unixify: 1.0.0
@@ -20966,6 +21023,56 @@ snapshots:
       tinyglobby: 0.2.15
       valibot: 1.2.0(typescript@5.8.3)
       vite: 6.4.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+    optionalDependencies:
+      '@react-router/serve': 7.14.2(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  '@react-router/dev@7.14.2(@react-router/serve@7.14.2(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3))(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/generator': 7.28.6
+      '@babel/parser': 7.28.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.6)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.6)
+      '@babel/traverse': 7.28.6
+      '@babel/types': 7.28.6
+      '@react-router/node': 7.14.2(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
+      '@remix-run/node-fetch-server': 0.13.0
+      arg: 5.0.2
+      babel-dead-code-elimination: 1.0.12
+      chokidar: 4.0.3
+      dedent: 1.7.1
+      es-module-lexer: 1.7.0
+      exit-hook: 2.2.1
+      isbot: 5.1.32
+      jsesc: 3.0.2
+      lodash: 4.17.21
+      p-map: 7.0.4
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      pkg-types: 2.3.0
+      prettier: 3.8.0
+      react-refresh: 0.14.2
+      react-router: 7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      semver: 7.7.3
+      tinyglobby: 0.2.15
+      valibot: 1.2.0(typescript@5.8.3)
+      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-node: 3.2.4(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     optionalDependencies:
       '@react-router/serve': 7.14.2(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
@@ -23050,7 +23157,7 @@ snapshots:
       global-cache-dir: 4.4.0
       is-plain-obj: 4.1.0
       path-exists: 5.0.0
-      semver: 7.6.3
+      semver: 7.7.3
       write-file-atomic: 4.0.2
 
   ansi-align@3.0.1:
@@ -24074,7 +24181,7 @@ snapshots:
       js-string-escape: 1.0.1
       lodash: 4.17.21
       md5-hex: 3.0.1
-      semver: 7.6.3
+      semver: 7.7.3
       well-known-symbols: 2.0.0
 
   confbox@0.1.8: {}
@@ -25471,7 +25578,7 @@ snapshots:
       proxy-addr: 2.0.7
       rfdc: 1.4.1
       secure-json-parse: 2.7.0
-      semver: 7.6.3
+      semver: 7.7.3
       toad-cache: 3.7.0
 
   fastq@1.20.1:
@@ -25876,7 +25983,7 @@ snapshots:
     dependencies:
       '@xhmikosr/downloader': 13.0.1
       node-fetch: 3.3.2
-      semver: 7.6.3
+      semver: 7.7.3
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
@@ -27121,7 +27228,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.6.3
+      semver: 7.7.3
 
   jsonwebtoken@9.0.3:
     dependencies:
@@ -27602,7 +27709,7 @@ snapshots:
       jest-validate: 27.5.1
       map-obj: 5.0.2
       moize: 6.1.7
-      semver: 7.6.3
+      semver: 7.7.3
 
   log-symbols@4.1.0:
     dependencies:
@@ -28819,7 +28926,7 @@ snapshots:
       is-plain-obj: 4.1.0
       normalize-node-version: 12.4.0
       path-exists: 5.0.0
-      semver: 7.6.3
+      semver: 7.7.3
 
   nopt@5.0.0:
     dependencies:
@@ -28833,7 +28940,7 @@ snapshots:
     dependencies:
       all-node-versions: 11.3.0
       filter-obj: 5.1.0
-      semver: 7.6.3
+      semver: 7.7.3
 
   normalize-package-data@2.5.0:
     dependencies:
@@ -31032,7 +31139,7 @@ snapshots:
       detect-libc: 2.1.2
       node-addon-api: 6.1.0
       prebuild-install: 7.1.3
-      semver: 7.6.3
+      semver: 7.7.3
       simple-get: 4.0.1
       tar-fs: 3.1.1
       tunnel-agent: 0.6.0


### PR DESCRIPTION
…ng components

When a component's props contain types typia can't resolve (React.ReactNode, React.ReactElement, etc.), fall back to the TS type checker to extract prop schemas instead of skipping the component entirely. This ensures all components get __xydUniform metadata — React-typed props show their actual type name (e.g. "ReactNode") instead of being lost.

- Add per-component retry with TS type checker fallback
- Add fallbackExtractSchema and tsTypeToJsonSchema helpers
- Fix boolean detection (TS represents boolean as true|false union)
- Add -2.vite-lib.react-types-resilience test fixture