### PR TITLE
fix(documan): resolve icon set paths from settings dir instead of pro…

### DIFF
--- a/packages/xyd-documan/src/utils.ts
+++ b/packages/xyd-documan/src/utils.ts
@@ -860,6 +860,9 @@ ${mapEntries.join(",\n")}
 
 export function pluginIconSet(settings: Settings): VitePlugin {
     const DEFAULT_ICON_SET = "lucide";
+    // Capture cwd at plugin creation time to avoid race conditions
+    // with sourcesToUniformV2 which temporarily changes process.cwd()
+    const settingsDir = process.cwd();
 
     async function fetchIconSet(
         name: string,
@@ -905,7 +908,7 @@ export function pluginIconSet(settings: Settings): VitePlugin {
         }
 
         if (name.startsWith(".")) {
-            const fullPath = path.join(process.cwd(), name);
+            const fullPath = path.join(settingsDir, name);
             const result = tryReadFile(fullPath);
             if (result) return result;
         }

--- a/packages/xyd-sources/packages/ts/index.ts
+++ b/packages/xyd-sources/packages/ts/index.ts
@@ -33,6 +33,9 @@ export async function sourcesToUniformV2(
 } | undefined> {
     const cwd = extraOptions?.cwd ?? root;
     const originalCwd = process.cwd();
+    // TODO: process.chdir is unsafe — it mutates global state and causes race conditions
+    // with concurrent Vite plugins (e.g. pluginIconSet resolving relative paths via process.cwd()).
+    // Should be refactored to pass cwd explicitly to TypeDoc instead of changing global state.
     process.chdir(cwd);
 
     try {


### PR DESCRIPTION
…cess.cwd()

pluginIconSet was resolving relative icon paths (e.g. ./icons/iconify.json) using process.cwd() at async load time. This caused a race condition with sourcesToUniformV2 which temporarily changes process.cwd() via process.chdir() to process TypeScript files. When both ran concurrently during Vite build, the icon plugin would resolve paths from the wrong directory.

Fix: capture process.cwd() at plugin creation time and use that for relative path resolution.