### PR TITLE
fix(sources): minimize process.chdir window in sourcesToUniformV2

### DIFF
--- a/packages/xyd-sources/packages/ts/index.ts
+++ b/packages/xyd-sources/packages/ts/index.ts
@@ -32,23 +32,14 @@ export async function sourcesToUniformV2(
     projectJson: TypeDoc.JSONOutput.ProjectReflection;
 } | undefined> {
     const cwd = extraOptions?.cwd ?? root;
-    const originalCwd = process.cwd();
-    // TODO: process.chdir is unsafe — it mutates global state and causes race conditions
-    // with concurrent Vite plugins (e.g. pluginIconSet resolving relative paths via process.cwd()).
-    // Should be refactored to pass cwd explicitly to TypeDoc instead of changing global state.
-    process.chdir(cwd);
-
-    try {
-        return await _sourcesToUniformV2(root, entryPoints, extraOptions);
-    } finally {
-        process.chdir(originalCwd);
-    }
+    return await _sourcesToUniformV2(root, entryPoints, extraOptions, cwd);
 }
 
 async function _sourcesToUniformV2(
     root: string,
     entryPoints: string[],
     extraOptions?: SourcesToUniformV2Options,
+    cwd?: string,
 ): Promise<{
     references: Reference<ReferenceContext>[];
     projectJson: TypeDoc.JSONOutput.ProjectReflection;
@@ -106,9 +97,20 @@ async function _sourcesToUniformV2(
         options.tsconfig = extraOptions.tsconfig;
     }
 
-    // TOOD: if react will not work then add []
-    const app = await TypeDoc.Application.bootstrapWithPlugins(options);
-    const project = await app.convert()
+    // TypeDoc uses process.cwd() internally for tsconfig/path resolution.
+    // We chdir only during bootstrap+convert (which need it), then restore immediately
+    // to avoid corrupting cwd for concurrent async Vite plugins.
+    const originalCwd = process.cwd();
+    if (cwd) process.chdir(cwd);
+
+    let app: TypeDoc.Application;
+    let project: TypeDoc.ProjectReflection | undefined;
+    try {
+        app = await TypeDoc.Application.bootstrapWithPlugins(options);
+        project = await app.convert();
+    } finally {
+        process.chdir(originalCwd);
+    }
     if (!project) {
         console.error('Failed to generate documentation.');
         return


### PR DESCRIPTION
process.chdir was wrapping the entire async _sourcesToUniformV2 function, which allowed concurrent Vite plugins to observe the wrong cwd during await points. This caused race conditions with pluginIconSet, plugin-orama, and other plugins that resolve paths via process.cwd().

Now chdir is scoped only to TypeDoc bootstrap+convert (which require it for tsconfig resolution), and restored immediately in a finally block before any subsequent async work.