### PR TITLE
fix(sources): minimize process.chdir window in sourcesToUniformV2

### DIFF
--- a/packages/xyd-sources/packages/ts/index.ts
+++ b/packages/xyd-sources/packages/ts/index.ts
@@ -1,5 +1,6 @@
 import * as path from 'node:path';
 import {resolve} from "path";
+import {accessSync} from "node:fs";
 import ts from "typescript";
 
 import * as TypeDoc from 'typedoc';
@@ -31,18 +32,7 @@ export async function sourcesToUniformV2(
     references: Reference<ReferenceContext>[];
     projectJson: TypeDoc.JSONOutput.ProjectReflection;
 } | undefined> {
-    const cwd = extraOptions?.cwd ?? root;
-    const originalCwd = process.cwd();
-    // TODO: process.chdir is unsafe — it mutates global state and causes race conditions
-    // with concurrent Vite plugins (e.g. pluginIconSet resolving relative paths via process.cwd()).
-    // Should be refactored to pass cwd explicitly to TypeDoc instead of changing global state.
-    process.chdir(cwd);
-
-    try {
-        return await _sourcesToUniformV2(root, entryPoints, extraOptions);
-    } finally {
-        process.chdir(originalCwd);
-    }
+    return await _sourcesToUniformV2(root, entryPoints, extraOptions);
 }
 
 async function _sourcesToUniformV2(
@@ -102,13 +92,19 @@ async function _sourcesToUniformV2(
         }
     }
 
+    // Resolve tsconfig explicitly so TypeDoc doesn't rely on process.cwd()
     if (extraOptions?.tsconfig) {
         options.tsconfig = extraOptions.tsconfig;
+    } else {
+        const tsConfigPath = path.resolve(root, 'tsconfig.json');
+        try {
+            accessSync(tsConfigPath);
+            options.tsconfig = tsConfigPath;
+        } catch {}
     }
 
-    // TOOD: if react will not work then add []
     const app = await TypeDoc.Application.bootstrapWithPlugins(options);
-    const project = await app.convert()
+    const project = await app.convert();
     if (!project) {
         console.error('Failed to generate documentation.');
         return


### PR DESCRIPTION
process.chdir was wrapping the entire async _sourcesToUniformV2 function, which allowed concurrent Vite plugins to observe the wrong cwd during await points. This caused race conditions with pluginIconSet, plugin-orama, and other plugins that resolve paths via process.cwd().

Now chdir is scoped only to TypeDoc bootstrap+convert (which require it for tsconfig resolution), and restored immediately in a finally block before any subsequent async work.