### PR TITLE
feat(website): support XYD_VERSION env var for xyd-js version selection

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "build": "react-router build",
-    "build:full": "react-router build && cd ../docs && bunx xyd-js build && cd ../website && cp -r ../docs/.xyd/build/client/assets/* build/client/assets/ && cp -r ../docs/.xyd/build/client/docs build/client/ && rm -rf build/client/public && mkdir -p build/client/public && cp -r ../docs/.xyd/build/client/docs/public/* build/client/public/",
+    "build:full": "react-router build && cd ../docs && bunx xyd-js@${XYD_VERSION:-latest} build && cd ../website && cp -r ../docs/.xyd/build/client/assets/* build/client/assets/ && cp -r ../docs/.xyd/build/client/docs build/client/ && rm -rf build/client/public && mkdir -p build/client/public && cp -r ../docs/.xyd/build/client/docs/public/* build/client/public/",
     "dev": "react-router dev",
     "start": "react-router-serve ./build/server/index.js",
     "typecheck": "react-router typegen && tsc",


### PR DESCRIPTION
Allows overriding xyd-js version via XYD_VERSION environment variable in the build:full script. Defaults to latest when not set. Set XYD_VERSION=canary in Netlify UI to use canary builds.