### PR TITLE
feat(settings): add advanced.vite for custom Vite configuration overr…

### DIFF
--- a/__tests__/e2e/6.custom-vite-options/1.basic/custom-vite-options.test.ts
+++ b/__tests__/e2e/6.custom-vite-options/1.basic/custom-vite-options.test.ts
@@ -1,0 +1,43 @@
+import { test, expect } from '@playwright/test';
+
+import { createXydServerWithTemplate, XydServer } from '../../utils/xyd-server';
+
+test.describe('Custom Vite Options', () => {
+    let server: XydServer;
+
+    test.beforeAll(async () => {
+        server = await createXydServerWithTemplate(__dirname);
+    });
+
+    test.afterAll(async () => {
+        await server.stop();
+    });
+
+    test('allowedHosts: request with allowed host succeeds', async () => {
+        // docs.json sets allowedHosts to ["test.example.com"]
+        // Vite should accept requests with that Host header
+        const response = await fetch(server.getUrl('/overview'), {
+            headers: { 'Host': 'test.example.com' },
+        });
+
+        expect(response.status).toBe(200);
+    });
+
+    test('allowedHosts: request with disallowed host is rejected', async () => {
+        // Vite should reject requests with a Host header not in allowedHosts
+        const response = await fetch(server.getUrl('/overview'), {
+            headers: { 'Host': 'evil.example.com' },
+        });
+
+        expect(response.status).toBe(403);
+    });
+
+    test('allowedHosts: localhost is always allowed', async ({ page }) => {
+        // localhost is implicitly allowed by Vite regardless of allowedHosts
+        await page.goto(server.getUrl('/overview'));
+        await page.waitForLoadState('networkidle');
+
+        const heading = page.locator('h1');
+        await expect(heading).toHaveText('Overview');
+    });
+});

--- a/__tests__/e2e/6.custom-vite-options/1.basic/custom-vite-options.test.ts
+++ b/__tests__/e2e/6.custom-vite-options/1.basic/custom-vite-options.test.ts
@@ -1,6 +1,30 @@
 import { test, expect } from '@playwright/test';
+import * as http from 'node:http';
 
 import { createXydServerWithTemplate, XydServer } from '../../utils/xyd-server';
+
+/**
+ * Make an HTTP request with a custom Host header.
+ * Node's fetch may ignore the Host header (forbidden header),
+ * so we use http.request directly.
+ */
+function requestWithHost(url: string, host: string): Promise<number> {
+    return new Promise((resolve, reject) => {
+        const parsed = new URL(url);
+        const req = http.request({
+            hostname: parsed.hostname,
+            port: parsed.port,
+            path: parsed.pathname,
+            method: 'GET',
+            headers: { 'Host': host },
+        }, (res) => {
+            res.resume();
+            resolve(res.statusCode!);
+        });
+        req.on('error', reject);
+        req.end();
+    });
+}
 
 test.describe('Custom Vite Options', () => {
     let server: XydServer;
@@ -16,20 +40,14 @@ test.describe('Custom Vite Options', () => {
     test('allowedHosts: request with allowed host succeeds', async () => {
         // docs.json sets allowedHosts to ["test.example.com"]
         // Vite should accept requests with that Host header
-        const response = await fetch(server.getUrl('/overview'), {
-            headers: { 'Host': 'test.example.com' },
-        });
-
-        expect(response.status).toBe(200);
+        const status = await requestWithHost(server.getUrl('/overview'), 'test.example.com');
+        expect(status).toBe(200);
     });
 
     test('allowedHosts: request with disallowed host is rejected', async () => {
         // Vite should reject requests with a Host header not in allowedHosts
-        const response = await fetch(server.getUrl('/overview'), {
-            headers: { 'Host': 'evil.example.com' },
-        });
-
-        expect(response.status).toBe(403);
+        const status = await requestWithHost(server.getUrl('/overview'), 'evil.example.com');
+        expect(status).toBe(403);
     });
 
     test('allowedHosts: localhost is always allowed', async ({ page }) => {

--- a/__tests__/e2e/6.custom-vite-options/1.basic/docs.json
+++ b/__tests__/e2e/6.custom-vite-options/1.basic/docs.json
@@ -1,0 +1,14 @@
+{
+    "advanced": {
+        "vite": {
+            "server": {
+                "allowedHosts": ["test.example.com"]
+            }
+        }
+    },
+    "navigation": {
+        "sidebar": [
+            "overview"
+        ]
+    }
+}

--- a/__tests__/e2e/6.custom-vite-options/1.basic/overview.md
+++ b/__tests__/e2e/6.custom-vite-options/1.basic/overview.md
@@ -1,0 +1,8 @@
+---
+title: Overview
+description: Test page for advanced vite options
+---
+
+# Overview
+
+This is a test page for verifying custom Vite configuration options.

--- a/apps/docs/guides/settings.md
+++ b/apps/docs/guides/settings.md
@@ -50,7 +50,6 @@ LS_TRACK_ID=YOUR_TRACK_ID
 }
 ```
 
-
 ## JSON Schema Validation
 The `docs.json` file is validated against a JSON schema to ensure proper configuration. You can reference the schema by including:
 
@@ -59,6 +58,35 @@ The `docs.json` file is validated against a JSON schema to ensure proper configu
     "$schema": "https://xyd.dev/public/docs.json"
 }
 ```
+
+## Custom Vite Configuration {label="Beta"}
+
+You can customize the Vite configuration via `advanced.vite`. This is useful for remote development environments, custom aliases, and other Vite-level settings.
+
+The config is merged with xyd's internal Vite config using Vite's [`mergeConfig`](https://vite.dev/guide/api-javascript#mergeconfig):
+
+```json
+// docs.json
+{
+    "advanced": {
+        "vite": {
+            "server": {
+                "allowedHosts": ["my-remote-env.example.com"]
+            }
+        }
+    }
+}
+```
+
+Common use cases:
+- **`server.allowedHosts`** — allow access from remote dev environments (e.g., code-server, Gitpod)
+- **`server.port`** — override the default dev server port
+- **`resolve.alias`** — add custom import aliases
+- **`define`** — inject compile-time constants
+
+:::callout
+The `vite` option applies to both the dev server and production builds. See the [Vite configuration reference](https://vitejs.dev/config/) for all available options.
+:::
 
 ## Code-Based Settings {label="Coming Soon"}
 If you feel that the JSON configuration is not enough, you can use the TypeScript/React based configuration
@@ -73,4 +101,3 @@ export default {
     // ... your settings configuration here
 } satisfies Settings
 ```
-

--- a/apps/docs/public/docs.json
+++ b/apps/docs/public/docs.json
@@ -442,6 +442,258 @@
         "basename": {
           "description": "basename",
           "type": "string"
+        },
+        "vite": {
+          "additionalProperties": false,
+          "description": "Custom Vite configuration overrides. Merged with xyd's internal Vite config.",
+          "properties": {
+            "appType": {
+              "enum": [
+                "spa",
+                "mpa",
+                "custom"
+              ],
+              "type": "string"
+            },
+            "base": {
+              "type": "string"
+            },
+            "build": {
+              "additionalProperties": false,
+              "properties": {
+                "assetsDir": {
+                  "type": "string"
+                },
+                "assetsInlineLimit": {
+                  "type": "number"
+                },
+                "chunkSizeWarningLimit": {
+                  "type": "number"
+                },
+                "cssCodeSplit": {
+                  "type": "boolean"
+                },
+                "emptyOutDir": {
+                  "type": "boolean"
+                },
+                "minify": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "const": "esbuild",
+                      "type": "string"
+                    },
+                    {
+                      "const": "terser",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "outDir": {
+                  "type": "string"
+                },
+                "reportCompressedSize": {
+                  "type": "boolean"
+                },
+                "sourcemap": {
+                  "anyOf": [
+                    {
+                      "type": "boolean"
+                    },
+                    {
+                      "const": "inline",
+                      "type": "string"
+                    },
+                    {
+                      "const": "hidden",
+                      "type": "string"
+                    }
+                  ]
+                },
+                "target": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    }
+                  ]
+                }
+              },
+              "type": "object"
+            },
+            "cacheDir": {
+              "type": "string"
+            },
+            "clearScreen": {
+              "type": "boolean"
+            },
+            "define": {
+              "type": "object"
+            },
+            "envDir": {
+              "type": "string"
+            },
+            "envPrefix": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              ]
+            },
+            "logLevel": {
+              "enum": [
+                "info",
+                "warn",
+                "error",
+                "silent"
+              ],
+              "type": "string"
+            },
+            "mode": {
+              "type": "string"
+            },
+            "preview": {
+              "additionalProperties": false,
+              "properties": {
+                "host": {
+                  "type": [
+                    "string",
+                    "boolean"
+                  ]
+                },
+                "open": {
+                  "type": [
+                    "string",
+                    "boolean"
+                  ]
+                },
+                "port": {
+                  "type": "number"
+                },
+                "strictPort": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "publicDir": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "const": false,
+                  "type": "boolean"
+                }
+              ]
+            },
+            "resolve": {
+              "additionalProperties": false,
+              "properties": {
+                "alias": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "conditions": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "dedupe": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "extensions": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "mainFields": {
+                  "items": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                "preserveSymlinks": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            },
+            "root": {
+              "type": "string"
+            },
+            "server": {
+              "additionalProperties": false,
+              "properties": {
+                "allowedHosts": {
+                  "anyOf": [
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "const": true,
+                      "type": "boolean"
+                    }
+                  ]
+                },
+                "cors": {
+                  "type": "boolean"
+                },
+                "headers": {
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "type": "object"
+                },
+                "host": {
+                  "type": [
+                    "string",
+                    "boolean"
+                  ]
+                },
+                "https": {
+                  "type": "boolean"
+                },
+                "open": {
+                  "type": [
+                    "string",
+                    "boolean"
+                  ]
+                },
+                "port": {
+                  "type": "number"
+                },
+                "strictPort": {
+                  "type": "boolean"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "type": "object"
         }
       },
       "type": "object"

--- a/docs/ConfigurationSystem.md
+++ b/docs/ConfigurationSystem.md
@@ -27,6 +27,7 @@ The configuration is represented by the `Settings` interface, which defines all 
 | `seo` | Search engine optimization | `domain`, metadata |
 | `ai` | AI-related features | `llmsTxt` configuration |
 | `components` | UI component overrides | `banner`, `footer` |
+| `advanced` | Low-level configuration | `basename`, `vite` |
 | `engine` | Build and processing | `paths`, `uniform` |
 
 ## Configuration Processing Pipeline

--- a/docs/DevelopmentServer.md
+++ b/docs/DevelopmentServer.md
@@ -19,3 +19,26 @@ Vite-based dev server with HMR, file watching, and live preview.
 - Live Preview
 - Error Recovery
 - Virtual Modules access
+
+## Custom Vite Configuration
+
+The dev server's Vite config can be customized via `advanced.vite` in `docs.json` or `docs.ts`. The user config is merged on top of xyd's internal config using Vite's `mergeConfig`.
+
+```json
+{
+  "advanced": {
+    "vite": {
+      "server": {
+        "allowedHosts": ["my-remote-env.example.com"],
+        "port": 4000
+      }
+    }
+  }
+}
+```
+
+Common use cases:
+- `server.allowedHosts` — allow access from remote dev environments (e.g., code-server)
+- `server.port` — override the default port
+- `resolve.alias` — add custom import aliases
+- `define` — inject compile-time constants

--- a/docs/SettingsSchemaAndDocsJson.md
+++ b/docs/SettingsSchemaAndDocsJson.md
@@ -94,7 +94,27 @@ The `llmsTxt` property can be:
 
 ### Advanced Configuration
 
-The `advanced` property provides low-level configuration options including basename, build paths, and module resolution.
+The `advanced` property provides low-level configuration options including basename and custom Vite configuration.
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `basename` | `string` | Base path for routing (e.g., `"/docs"`) |
+| `vite` | `ViteUserConfig` | Custom Vite configuration merged with xyd's internal config via `mergeConfig` |
+
+The `vite` property accepts any valid Vite `UserConfig` and is merged into both the dev server and build configurations. Common use cases include setting `server.allowedHosts` for remote development environments, custom `resolve.alias`, and `define` constants.
+
+```json
+{
+  "advanced": {
+    "basename": "/docs",
+    "vite": {
+      "server": {
+        "allowedHosts": ["my-remote-env.example.com"]
+      }
+    }
+  }
+}
+```
 
 ## Preset Processing
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "pnpm run --filter=\"./packages/**/*\" build",
     "build:storybook": "pnpm run build && pnpm run --filter=\"./packages/**/*\" build:storybook",
     "build:apidocs-demo": "pnpm --filter \"./packages/**/*\" --filter \"@xyd-js/apidocs-demo\" build",
-    "schema:docs.json": "cd ./packages/xyd-core && npx ts-json-schema-generator --path ./src/types/settings.ts --type 'Settings' --no-top-ref --out ../../apps/docs/public/docs.json",
+    "schema:docs.json": "node scripts/generate-schema.mjs",
     "clean": "./clear.sh",
     "prepare": "husky",
     "pretest:unit": "pnpm build",
@@ -40,6 +40,7 @@
     "lint-staged": "^15.2.10",
     "nx": "^20.3.2",
     "rimraf": "^3.0.2",
+    "ts-json-schema-generator": "^2.3.0",
     "typescript": "^5.6.2",
     "vitest": "^2.1.8"
   },

--- a/packages/xyd-core/package.json
+++ b/packages/xyd-core/package.json
@@ -19,9 +19,18 @@
     "watch": "tsup --watch"
   },
   "dependencies": {},
+  "peerDependencies": {
+    "vite": "^7.0.0"
+  },
+  "peerDependenciesMeta": {
+    "vite": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "tsup": "^8.3.0",
     "rimraf": "^3.0.2",
-    "typescript": "^4.5.5"
+    "typescript": "^4.5.5",
+    "vite": "^7.0.0"
   }
 }

--- a/packages/xyd-core/src/types/settings.ts
+++ b/packages/xyd-core/src/types/settings.ts
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import type { Theme as SyntaxHighlight } from "@code-hike/lighter";
+import type { UserConfig as ViteUserConfig } from "vite";
 
 /**
  * Main settings interface for the application
@@ -1424,6 +1425,13 @@ export interface Advanced {
    * basename
    */
   basename?: string;
+
+  /**
+   * Custom Vite configuration overrides.
+   * Merged with xyd's internal Vite config.
+   * @see https://vitejs.dev/config/
+   */
+  vite?: ViteUserConfig;
 }
 
 // ------ END  settings for redirects END ------
@@ -1684,3 +1692,60 @@ export interface AccessControlSessionConfig {
 
 // #endregion
 // ------ END settings for access control END ------
+
+// ------ START ViteUserConfigInline (for schema generation) START ------
+/**
+ * Schema-safe subset of Vite's UserConfig.
+ * Used by the schema generator since the real vite types can't be resolved.
+ * @internal
+ */
+export interface ViteUserConfigInline {
+  root?: string;
+  base?: string;
+  mode?: string;
+  publicDir?: string | false;
+  cacheDir?: string;
+  envDir?: string;
+  envPrefix?: string | string[];
+  logLevel?: 'info' | 'warn' | 'error' | 'silent';
+  clearScreen?: boolean;
+  appType?: 'spa' | 'mpa' | 'custom';
+  server?: {
+    host?: string | boolean;
+    port?: number;
+    strictPort?: boolean;
+    https?: boolean;
+    open?: string | boolean;
+    cors?: boolean;
+    headers?: Record<string, string>;
+    allowedHosts?: string[] | true;
+  };
+  preview?: {
+    host?: string | boolean;
+    port?: number;
+    strictPort?: boolean;
+    open?: string | boolean;
+  };
+  build?: {
+    target?: string | string[];
+    outDir?: string;
+    assetsDir?: string;
+    assetsInlineLimit?: number;
+    cssCodeSplit?: boolean;
+    sourcemap?: boolean | 'inline' | 'hidden';
+    minify?: boolean | 'esbuild' | 'terser';
+    emptyOutDir?: boolean;
+    reportCompressedSize?: boolean;
+    chunkSizeWarningLimit?: number;
+  };
+  resolve?: {
+    alias?: Record<string, string>;
+    dedupe?: string[];
+    conditions?: string[];
+    mainFields?: string[];
+    extensions?: string[];
+    preserveSymlinks?: boolean;
+  };
+  define?: Record<string, any>;
+}
+// ------ END ViteUserConfigInline END ------

--- a/packages/xyd-documan/src/build.ts
+++ b/packages/xyd-documan/src/build.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
 
-import { build as viteBuild, Plugin as VitePlugin, PluginOption } from 'vite';
+import { build as viteBuild, mergeConfig, Plugin as VitePlugin, PluginOption } from 'vite';
 import tsconfigPaths from "vite-tsconfig-paths";
 
 import {
@@ -50,9 +50,11 @@ export async function build() {
     const enableMermaid = !!respPluginDocs?.settings?.integrations?.diagrams
     const externalPackages = enableMermaid ? [] : ["rehype-mermaid", "rehype-graphviz", "@hpcc-js/wasm"]
 
+    const userViteConfig = respPluginDocs.settings?.advanced?.vite || {};
+
     try {
         // Build the client-side bundle
-        await viteBuild({
+        let clientConfig: any = {
             mode: "production",
             root: appRoot,
             plugins: [
@@ -71,7 +73,7 @@ export async function build() {
                 alias: {
                     process: 'process/browser',
                     // When rehype-mermaid is externalized, resolve it from CLI's node_modules
-                    ...(enableMermaid ? {} : { 
+                    ...(enableMermaid ? {} : {
                         "rehype-mermaid": path.resolve(getHostPath(), "./node_modules/rehype-mermaid"),
                         "rehype-graphviz": path.resolve(getHostPath(), "./node_modules/rehype-graphviz"),
                         "@hpcc-js/wasm": path.resolve(getHostPath(), "./node_modules/@hpcc-js/wasm"),
@@ -89,10 +91,16 @@ export async function build() {
             // ssr: {
             //     noExternal: ["react", "react-dom", "react-router"]
             // }
-        });
+        };
+
+        if (userViteConfig) {
+            clientConfig = mergeConfig(clientConfig, userViteConfig);
+        }
+
+        await viteBuild(clientConfig);
 
         // Build the SSR bundle
-        await viteBuild({
+        let ssrConfig: any = {
             mode: "production",
             root: appRoot,
             build: {
@@ -129,7 +137,7 @@ export async function build() {
                 alias: {
                     process: 'process/browser',
                     // When rehype-mermaid is externalized, resolve it from CLI's node_modules
-                    ...(enableMermaid ? {} : { 
+                    ...(enableMermaid ? {} : {
                         "rehype-mermaid": path.resolve(getHostPath(), "./node_modules/rehype-mermaid"),
                         "rehype-graphviz": path.resolve(getHostPath(), "./node_modules/rehype-graphviz"),
                         "@hpcc-js/wasm": path.resolve(getHostPath(), "./node_modules/@hpcc-js/wasm"),
@@ -142,7 +150,13 @@ export async function build() {
             // ssr: {
             //     noExternal: ["react", "react-dom", "react-router"]
             // }
-        });
+        };
+
+        if (userViteConfig) {
+            ssrConfig = mergeConfig(ssrConfig, userViteConfig);
+        }
+
+        await viteBuild(ssrConfig);
     } catch (error) {
         console.error('Build failed:', error);  // TODO: better message
     }

--- a/packages/xyd-documan/src/dev.ts
+++ b/packages/xyd-documan/src/dev.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import fs from "node:fs";
 
-import { createServer, searchForWorkspaceRoot, ViteDevServer, Plugin as VitePlugin, PluginOption } from "vite";
+import { createServer, mergeConfig, searchForWorkspaceRoot, ViteDevServer, Plugin as VitePlugin, PluginOption } from "vite";
 
 import { API, APIFile, Navigation, Settings, SidebarNavigation, } from "@xyd-js/core";
 
@@ -170,7 +170,7 @@ export async function dev(options?: DevOptions) {
         }
     }
 
-    const preview = await createServer({    
+    let viteConfig: any = {
         root: appRoot,
         publicDir: '/public',
         server: {
@@ -191,7 +191,7 @@ export async function dev(options?: DevOptions) {
             alias: {
                 process: 'process/browser',
                 // When rehype-mermaid is externalized, resolve it from CLI's node_modules
-                ...(enableMermaid ? {} : { 
+                ...(enableMermaid ? {} : {
                     "rehype-mermaid": path.resolve(getHostPath(), "./node_modules/rehype-mermaid"),
                     "rehype-graphviz": path.resolve(getHostPath(), "./node_modules/rehype-graphviz"),
                     "@hpcc-js/wasm": path.resolve(getHostPath(), "./node_modules/@hpcc-js/wasm"),
@@ -225,7 +225,13 @@ export async function dev(options?: DevOptions) {
                 }
             }
         ],
-    });
+    };
+
+    if (respPluginDocs.settings?.advanced?.vite) {
+        viteConfig = mergeConfig(viteConfig, respPluginDocs.settings.advanced.vite);
+    }
+
+    const preview = await createServer(viteConfig);
 
 
     // Set up manual file watcher for markdown files TODO: better way? + HMR only for specific components instead or reload a pag

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,109 +38,15 @@ importers:
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
+      ts-json-schema-generator:
+        specifier: ^2.3.0
+        version: 2.9.0
       typescript:
         specifier: ^5.6.2
         version: 5.8.3
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.9.0)(happy-dom@15.11.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)
-
-  .xyd/host:
-    dependencies:
-      '@react-router/dev':
-        specifier: ^7.7.1
-        version: 7.14.2(@react-router/serve@7.14.2(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3))(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
-      '@react-router/node':
-        specifier: ^7.7.1
-        version: 7.14.2(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
-      '@react-router/serve':
-        specifier: ^7.7.1
-        version: 7.14.2(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
-      '@xyd-js/analytics':
-        specifier: workspace:*
-        version: link:../../packages/xyd-analytics
-      '@xyd-js/atlas':
-        specifier: workspace:*
-        version: link:../../packages/xyd-atlas
-      '@xyd-js/components':
-        specifier: workspace:*
-        version: link:../../packages/xyd-components
-      '@xyd-js/composer':
-        specifier: workspace:*
-        version: link:../../packages/xyd-composer
-      '@xyd-js/content':
-        specifier: workspace:*
-        version: link:../../packages/xyd-content
-      '@xyd-js/core':
-        specifier: workspace:*
-        version: link:../../packages/xyd-core
-      '@xyd-js/framework':
-        specifier: workspace:*
-        version: link:../../packages/xyd-framework
-      '@xyd-js/plugin-algolia':
-        specifier: workspace:*
-        version: link:../../packages/xyd-plugin-algolia
-      '@xyd-js/plugin-orama':
-        specifier: workspace:*
-        version: link:../../packages/xyd-plugin-orama
-      '@xyd-js/theme-cosmo':
-        specifier: workspace:*
-        version: link:../../packages/xyd-theme-cosmo
-      '@xyd-js/theme-gusto':
-        specifier: workspace:*
-        version: link:../../packages/xyd-theme-gusto
-      '@xyd-js/theme-opener':
-        specifier: workspace:*
-        version: link:../../packages/xyd-theme-opener
-      '@xyd-js/theme-picasso':
-        specifier: workspace:*
-        version: link:../../packages/xyd-theme-picasso
-      '@xyd-js/theme-poetry':
-        specifier: workspace:*
-        version: link:../../packages/xyd-theme-poetry
-      '@xyd-js/theme-solar':
-        specifier: workspace:*
-        version: link:../../packages/xyd-theme-solar
-      '@xyd-js/themes':
-        specifier: workspace:*
-        version: link:../../packages/xyd-themes
-      isbot:
-        specifier: ^5
-        version: 5.1.32
-      katex:
-        specifier: ^0.16.22
-        version: 0.16.27
-      openux-js:
-        specifier: 0.0.0-pre.1
-        version: 0.0.0-pre.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      pluganalytics:
-        specifier: 0.0.0-pre.3
-        version: 0.0.0-pre.3
-      react:
-        specifier: ^19.1.0
-        version: 19.2.3
-      react-dom:
-        specifier: ^19.1.0
-        version: 19.2.3(react@19.2.3)
-      react-router:
-        specifier: ^7.5.2
-        version: 7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-    devDependencies:
-      autoprefixer:
-        specifier: ^10.4.20
-        version: 10.4.23(postcss@8.5.6)
-      postcss:
-        specifier: ^8.4.47
-        version: 8.5.6
-      semver:
-        specifier: ^7.6.3
-        version: 7.7.3
-      vite:
-        specifier: ^7.0.0
-        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vite-tsconfig-paths:
-        specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   apps/apidocs-demo:
     dependencies:
@@ -258,7 +164,7 @@ importers:
         version: 6.0.8
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@24.10.9)(happy-dom@15.11.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)
@@ -453,7 +359,7 @@ importers:
     devDependencies:
       openapi-typescript:
         specifier: ^7.9.1
-        version: 7.10.1(typescript@5.8.3)
+        version: 7.10.1(typescript@5.9.3)
 
   packages/xyd-ask-ai/examples/edge:
     dependencies:
@@ -585,13 +491,13 @@ importers:
         version: 15.3.1(rollup@4.55.1)
       '@rollup/plugin-typescript':
         specifier: ^12.1.1
-        version: 12.3.0(rollup@4.55.1)(tslib@2.8.1)(typescript@5.8.3)
+        version: 12.3.0(rollup@4.55.1)(tslib@2.8.1)(typescript@5.9.3)
       '@storybook/react':
         specifier: ^8.6.15
-        version: 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.8.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@8.6.15(prettier@3.8.0))(typescript@5.8.3)
+        version: 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.8.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@8.6.15(prettier@3.8.0))(typescript@5.9.3)
       '@storybook/react-vite':
         specifier: ^8.6.15
-        version: 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.8.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.55.1)(storybook@8.6.15(prettier@3.8.0))(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.8.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.55.1)(storybook@8.6.15(prettier@3.8.0))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@storybook/test':
         specifier: ^8.6.15
         version: 8.6.15(storybook@8.6.15(prettier@3.8.0))
@@ -606,10 +512,10 @@ importers:
         version: 4.7.0(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@wyw-in-js/rollup':
         specifier: ^0.5.5
-        version: 0.5.5(rollup@4.55.1)(typescript@5.8.3)
+        version: 0.5.5(rollup@4.55.1)(typescript@5.9.3)
       '@wyw-in-js/vite':
         specifier: ^0.5.5
-        version: 0.5.5(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 0.5.5(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       rimraf:
         specifier: ^3.0.2
         version: 3.0.2
@@ -621,7 +527,7 @@ importers:
         version: 4.5.5(rollup@4.55.1)
       rollup-plugin-dts:
         specifier: ^6.1.1
-        version: 6.3.0(rollup@4.55.1)(typescript@5.8.3)
+        version: 6.3.0(rollup@4.55.1)(typescript@5.9.3)
       rollup-plugin-terser:
         specifier: ^7.0.2
         version: 7.0.2(rollup@4.55.1)
@@ -688,7 +594,7 @@ importers:
         version: 6.0.8
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@24.10.9)(happy-dom@15.11.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)
@@ -753,7 +659,7 @@ importers:
         version: 6.3.0
       '@linaria/rollup':
         specifier: ^5.0.4
-        version: 5.0.4(rollup@4.55.1)(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 5.0.4(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@rollup/plugin-babel':
         specifier: ^6.0.4
         version: 6.1.0(@babel/core@7.28.6)(@types/babel__core@7.20.5)(rollup@4.55.1)
@@ -768,7 +674,7 @@ importers:
         version: 0.4.0(@swc/core@1.15.8)(rollup@4.55.1)
       '@rollup/plugin-typescript':
         specifier: ^12.1.1
-        version: 12.3.0(rollup@4.55.1)(tslib@2.8.1)(typescript@5.8.3)
+        version: 12.3.0(rollup@4.55.1)(tslib@2.8.1)(typescript@5.9.3)
       '@rollup/plugin-url':
         specifier: ^8.0.2
         version: 8.0.2(rollup@4.55.1)
@@ -777,7 +683,7 @@ importers:
         version: 19.2.8
       '@wyw-in-js/rollup':
         specifier: ^0.5.5
-        version: 0.5.5(rollup@4.55.1)(typescript@5.8.3)
+        version: 0.5.5(rollup@4.55.1)(typescript@5.9.3)
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.23(postcss@8.5.6)
@@ -798,16 +704,16 @@ importers:
         version: 4.5.5(rollup@4.55.1)
       rollup-plugin-dts:
         specifier: ^6.1.1
-        version: 6.3.0(rollup@4.55.1)(typescript@5.8.3)
+        version: 6.3.0(rollup@4.55.1)(typescript@5.9.3)
       rollup-plugin-postcss:
         specifier: ^4.0.2
-        version: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.8)(@types/node@24.10.9)(typescript@5.8.3))
+        version: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.8)(@types/node@24.10.9)(typescript@5.9.3))
       rollup-plugin-terser:
         specifier: ^7.0.2
         version: 7.0.2(rollup@4.55.1)
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
 
   packages/xyd-composer:
     dependencies:
@@ -1030,6 +936,9 @@ importers:
       typescript:
         specifier: ^4.5.5
         version: 4.9.5
+      vite:
+        specifier: ^7.0.0
+        version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/xyd-documan:
     dependencies:
@@ -1154,13 +1063,13 @@ importers:
         version: 15.3.1(rollup@4.55.1)
       '@rollup/plugin-typescript':
         specifier: ^12.1.1
-        version: 12.3.0(rollup@4.55.1)(tslib@2.8.1)(typescript@5.8.3)
+        version: 12.3.0(rollup@4.55.1)(tslib@2.8.1)(typescript@5.9.3)
       '@wyw-in-js/rollup':
         specifier: ^0.5.5
-        version: 0.5.5(rollup@4.55.1)(typescript@5.8.3)
+        version: 0.5.5(rollup@4.55.1)(typescript@5.9.3)
       '@wyw-in-js/vite':
         specifier: ^0.5.5
-        version: 0.5.5(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 0.5.5(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.23(postcss@8.5.6)
@@ -1181,16 +1090,16 @@ importers:
         version: 4.5.5(rollup@4.55.1)
       rollup-plugin-dts:
         specifier: ^6.1.1
-        version: 6.3.0(rollup@4.55.1)(typescript@5.8.3)
+        version: 6.3.0(rollup@4.55.1)(typescript@5.9.3)
       rollup-plugin-postcss:
         specifier: ^4.0.2
-        version: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.8)(@types/node@24.10.9)(typescript@5.8.3))
+        version: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.8)(@types/node@24.10.9)(typescript@5.9.3))
       rollup-plugin-terser:
         specifier: ^7.0.2
         version: 7.0.2(rollup@4.55.1)
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
 
   packages/xyd-framework:
     dependencies:
@@ -1300,13 +1209,13 @@ importers:
     dependencies:
       '@react-router/dev':
         specifier: ^7.7.1
-        version: 7.12.0(@react-router/serve@7.12.0(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3))(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
+        version: 7.12.0(@react-router/serve@7.12.0(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3))(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)
       '@react-router/node':
         specifier: ^7.7.1
-        version: 7.12.0(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
+        version: 7.12.0(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       '@react-router/serve':
         specifier: ^7.7.1
-        version: 7.12.0(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
+        version: 7.12.0(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       '@xyd-js/analytics':
         specifier: workspace:*
         version: link:../xyd-analytics
@@ -1394,7 +1303,7 @@ importers:
         version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 5.1.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/xyd-mcp:
     dependencies:
@@ -1495,7 +1404,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.6
+        version: 1.3.13
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -1544,7 +1453,7 @@ importers:
         version: 3.0.2
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@24.10.9)(happy-dom@15.11.7)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)
@@ -1661,7 +1570,7 @@ importers:
         version: 3.0.2
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       vite:
         specifier: ^7.0.0
         version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -1686,7 +1595,7 @@ importers:
         version: 3.0.2
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       vite:
         specifier: ^7.0.0
         version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -1799,7 +1708,7 @@ importers:
         version: 3.0.2
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       vite:
         specifier: ^7.0.0
         version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -1817,7 +1726,7 @@ importers:
         version: 3.0.2
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       vite:
         specifier: ^7.0.0
         version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -1835,7 +1744,7 @@ importers:
         version: 3.0.2
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       vite:
         specifier: ^7.0.0
         version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -1856,7 +1765,7 @@ importers:
         version: 0.7.0(@stencil/core@4.27.0)(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@orama/searchbox':
         specifier: 1.0.0-rc53
-        version: 1.0.0-rc53(@orama/highlight@0.1.9)(@orama/orama@3.1.18)(@oramacloud/client@2.1.4)(@preact/signals-core@1.12.1)(@preact/signals-react@2.3.0(react@19.2.3))(@r2wc/react-to-web-component@2.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react-markdown@9.1.0(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)(ws@8.19.0)(zod@3.24.3)
+        version: 1.0.0-rc53(@orama/highlight@0.1.9)(@orama/orama@3.1.18)(@oramacloud/client@2.1.4)(@preact/signals-core@1.12.1)(@preact/signals-react@2.3.0(react@19.2.3))(@r2wc/react-to-web-component@2.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react-markdown@9.1.0(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(ws@8.19.0)(zod@3.24.3)
       '@xyd-js/analytics':
         specifier: workspace:*
         version: link:../xyd-analytics
@@ -1902,7 +1811,7 @@ importers:
         version: 3.0.2
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       vite:
         specifier: ^7.0.0
         version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -1920,7 +1829,7 @@ importers:
         version: 3.0.2
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       vite:
         specifier: ^7.0.0
         version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -1954,7 +1863,7 @@ importers:
         version: 3.0.2
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       vite:
         specifier: ^7.0.0
         version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -1979,7 +1888,7 @@ importers:
         version: 3.0.2
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       vite:
         specifier: ^7.0.0
         version: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
@@ -2328,13 +2237,13 @@ importers:
         version: 15.3.1(rollup@4.55.1)
       '@rollup/plugin-typescript':
         specifier: ^12.1.1
-        version: 12.3.0(rollup@4.55.1)(tslib@2.8.1)(typescript@5.8.3)
+        version: 12.3.0(rollup@4.55.1)(tslib@2.8.1)(typescript@5.9.3)
       '@wyw-in-js/rollup':
         specifier: ^0.5.5
-        version: 0.5.5(rollup@4.55.1)(typescript@5.8.3)
+        version: 0.5.5(rollup@4.55.1)(typescript@5.9.3)
       '@wyw-in-js/vite':
         specifier: ^0.5.5
-        version: 0.5.5(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 0.5.5(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.23(postcss@8.5.6)
@@ -2355,16 +2264,16 @@ importers:
         version: 4.5.5(rollup@4.55.1)
       rollup-plugin-dts:
         specifier: ^6.1.1
-        version: 6.3.0(rollup@4.55.1)(typescript@5.8.3)
+        version: 6.3.0(rollup@4.55.1)(typescript@5.9.3)
       rollup-plugin-postcss:
         specifier: ^4.0.2
-        version: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.8)(@types/node@24.10.9)(typescript@5.8.3))
+        version: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.8)(@types/node@24.10.9)(typescript@5.9.3))
       rollup-plugin-terser:
         specifier: ^7.0.2
         version: 7.0.2(rollup@4.55.1)
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
 
   packages/xyd-theme-picasso:
     dependencies:
@@ -2609,7 +2518,7 @@ importers:
         version: 15.3.1(rollup@4.55.1)
       '@rollup/plugin-typescript':
         specifier: ^12.1.1
-        version: 12.3.0(rollup@4.55.1)(tslib@2.8.1)(typescript@5.8.3)
+        version: 12.3.0(rollup@4.55.1)(tslib@2.8.1)(typescript@5.9.3)
       '@types/react':
         specifier: ^19.1.0
         version: 19.2.8
@@ -2618,10 +2527,10 @@ importers:
         version: 19.2.3(@types/react@19.2.8)
       '@wyw-in-js/rollup':
         specifier: ^0.5.5
-        version: 0.5.5(rollup@4.55.1)(typescript@5.8.3)
+        version: 0.5.5(rollup@4.55.1)(typescript@5.9.3)
       '@wyw-in-js/vite':
         specifier: ^0.5.5
-        version: 0.5.5(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+        version: 0.5.5(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       autoprefixer:
         specifier: ^10.4.20
         version: 10.4.23(postcss@8.5.6)
@@ -2645,16 +2554,16 @@ importers:
         version: 4.5.5(rollup@4.55.1)
       rollup-plugin-dts:
         specifier: ^6.1.1
-        version: 6.3.0(rollup@4.55.1)(typescript@5.8.3)
+        version: 6.3.0(rollup@4.55.1)(typescript@5.9.3)
       rollup-plugin-postcss:
         specifier: ^4.0.2
-        version: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.8)(@types/node@24.10.9)(typescript@5.8.3))
+        version: 4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.8)(@types/node@24.10.9)(typescript@5.9.3))
       rollup-plugin-terser:
         specifier: ^7.0.2
         version: 7.0.2(rollup@4.55.1)
       tsup:
         specifier: ^8.3.0
-        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.8.3)(yaml@2.8.2)
+        version: 8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
 
   packages/xyd-uniform:
     dependencies:
@@ -5252,6 +5161,7 @@ packages:
   '@lerna/create@8.2.4':
     resolution: {integrity: sha512-A8AlzetnS2WIuhijdAzKUyFpR5YbLLfV3luQ4lzBgIBgRfuoBDZeF+RSZPhra+7A6/zTUlrbhKZIOi/MNhqgvQ==}
     engines: {node: '>=18.0.0'}
+    deprecated: This package is an implementation detail of Lerna and is no longer published separately.
 
   '@linaria/atomic@6.3.0':
     resolution: {integrity: sha512-l8Ypak9s6AhEbBJ+I0OkRL1X7mipld+tzg0L3tpxSAmpWGwWpBSksSLu1uRNoHTf80hrx/3Bt0nA/i/rJnkRSg==}
@@ -7783,8 +7693,8 @@ packages:
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
-  '@types/bun@1.3.6':
-    resolution: {integrity: sha512-uWCv6FO/8LcpREhenN1d1b6fcspAB+cefwD7uti8C8VffIv0Um08TKMn98FynpTiU38+y2dUO55T11NgDt8VAA==}
+  '@types/bun@1.3.13':
+    resolution: {integrity: sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw==}
 
   '@types/clean-css@4.2.11':
     resolution: {integrity: sha512-Y8n81lQVTAfP2TOdtJJEsCoYl1AnOkqDqMvXb9/7pfgZZ7r8YrEyurrAvAoAjHOGXKRybay+5CsExqIH6liccw==}
@@ -8675,6 +8585,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   bare-events@2.8.2:
     resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
     peerDependencies:
@@ -8787,6 +8701,10 @@ packages:
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
 
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
+
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
@@ -8829,8 +8747,8 @@ packages:
   builtins@5.1.0:
     resolution: {integrity: sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg==}
 
-  bun-types@1.3.6:
-    resolution: {integrity: sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ==}
+  bun-types@1.3.13:
+    resolution: {integrity: sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -9251,6 +9169,10 @@ packages:
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
     engines: {node: '>=18'}
+
+  commander@14.0.3:
+    resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
+    engines: {node: '>=20'}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -10779,6 +10701,7 @@ packages:
   git-raw-commits@3.0.0:
     resolution: {integrity: sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==}
     engines: {node: '>=14'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -10792,6 +10715,7 @@ packages:
   git-semver-tags@5.0.1:
     resolution: {integrity: sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==}
     engines: {node: '>=14'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -10825,24 +10749,30 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@13.0.0:
     resolution: {integrity: sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==}
     engines: {node: 20 || >=22}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@9.3.5:
     resolution: {integrity: sha512-e1LleDykUz2Iu+MTYdkSsuWX8lvAjAcs0Xef0lNIu0S2wOAzuTxCJtcd9S3cijlwYF18EsU3rzb8jPVobxDh9Q==}
     engines: {node: '>=16 || 14 >=14.17'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   global-cache-dir@4.4.0:
     resolution: {integrity: sha512-bk0gI6IbbphRjAaCJJn5H+T/CcEck5B3a5KBO2BXSDzjFSV+API17w8GA7YPJ6IXJiasW8M0VsEIig1PCHdfOQ==}
@@ -12640,6 +12570,10 @@ packages:
     resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
     engines: {node: 20 || >=22}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.0.5:
     resolution: {integrity: sha512-tUpxzX0VAzJHjLu0xUfFv1gwVp9ba3IOuRAVH2EGuRW8a5emA2FlACLqiT/lDVtS1W+TGNwqz3sWaNyLgDJWuw==}
 
@@ -12706,6 +12640,10 @@ packages:
 
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@2.1.2:
@@ -13461,6 +13399,10 @@ packages:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   path-to-regexp@0.1.12:
     resolution: {integrity: sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==}
 
@@ -13870,6 +13812,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   precinct@11.0.5:
@@ -15198,10 +15141,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.5.2:
     resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp-dir@1.0.0:
     resolution: {integrity: sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==}
@@ -15411,6 +15356,11 @@ packages:
     resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
     engines: {node: '>=8'}
 
+  ts-json-schema-generator@2.9.0:
+    resolution: {integrity: sha512-NR5ZE108uiPtBHBJNGnhwoUaUx5vWTDJzDFG9YlRoqxPU76n+5FClRh92dcGgysbe1smRmYalM9Saj97GW1J4Q==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   ts-morph@22.0.0:
     resolution: {integrity: sha512-M9MqFGZREyeb5fTl6gNHKZLqBQA0TjA1lea+CR48R8EBTDuWrNqW6ccC5QvjNR4s6wDumD3LTCjOFSp9iwlzaw==}
 
@@ -15577,6 +15527,11 @@ packages:
 
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -15872,6 +15827,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -15884,6 +15840,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -18461,6 +18418,15 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.5.0(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      glob: 10.5.0
+      magic-string: 0.27.0
+      react-docgen-typescript: 2.4.0(typescript@5.9.3)
+      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -18793,7 +18759,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@linaria/babel-preset@5.0.4(typescript@5.8.3)':
+  '@linaria/babel-preset@5.0.4(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.28.6
       '@babel/generator': 7.28.6
@@ -18806,7 +18772,7 @@ snapshots:
       '@linaria/shaker': 5.0.3
       '@linaria/tags': 5.0.2
       '@linaria/utils': 5.0.2
-      cosmiconfig: 8.3.6(typescript@5.8.3)
+      cosmiconfig: 8.3.6(typescript@5.9.3)
       happy-dom: 10.8.0
       source-map: 0.7.6
       stylis: 3.5.4
@@ -18850,12 +18816,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@linaria/rollup@5.0.4(rollup@4.55.1)(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@linaria/rollup@5.0.4(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@linaria/babel-preset': 5.0.4(typescript@5.8.3)
+      '@linaria/babel-preset': 5.0.4(typescript@5.9.3)
       '@linaria/logger': 5.0.0
       '@linaria/utils': 5.0.2
-      '@linaria/vite': 5.0.4(rollup@4.55.1)(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@linaria/vite': 5.0.4(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
       '@rollup/pluginutils': 5.3.0(rollup@4.55.1)
       rollup: 4.55.1
     transitivePeerDependencies:
@@ -18901,9 +18867,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@linaria/vite@5.0.4(rollup@4.55.1)(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@linaria/vite@5.0.4(rollup@4.55.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
-      '@linaria/babel-preset': 5.0.4(typescript@5.8.3)
+      '@linaria/babel-preset': 5.0.4(typescript@5.9.3)
       '@linaria/logger': 5.0.0
       '@linaria/utils': 5.0.2
       '@rollup/pluginutils': 5.3.0(rollup@4.55.1)
@@ -19849,9 +19815,9 @@ snapshots:
       dpack: 0.6.22
       seqproto: 0.2.3
 
-  '@orama/plugin-secure-proxy@2.1.1(encoding@0.1.13)(typescript@5.8.3)(ws@8.19.0)(zod@3.24.3)':
+  '@orama/plugin-secure-proxy@2.1.1(encoding@0.1.13)(typescript@5.9.3)(ws@8.19.0)(zod@3.24.3)':
     dependencies:
-      '@oramacloud/client': 1.3.20(encoding@0.1.13)(typescript@5.8.3)(ws@8.19.0)(zod@3.24.3)
+      '@oramacloud/client': 1.3.20(encoding@0.1.13)(typescript@5.9.3)(ws@8.19.0)(zod@3.24.3)
     transitivePeerDependencies:
       - encoding
       - typescript
@@ -19869,12 +19835,12 @@ snapshots:
       - '@types/react'
       - babel-plugin-macros
 
-  '@orama/searchbox@1.0.0-rc53(@orama/highlight@0.1.9)(@orama/orama@3.1.18)(@oramacloud/client@2.1.4)(@preact/signals-core@1.12.1)(@preact/signals-react@2.3.0(react@19.2.3))(@r2wc/react-to-web-component@2.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react-markdown@9.1.0(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)(typescript@5.8.3)(ws@8.19.0)(zod@3.24.3)':
+  '@orama/searchbox@1.0.0-rc53(@orama/highlight@0.1.9)(@orama/orama@3.1.18)(@oramacloud/client@2.1.4)(@preact/signals-core@1.12.1)(@preact/signals-react@2.3.0(react@19.2.3))(@r2wc/react-to-web-component@2.1.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(encoding@0.1.13)(react-dom@19.2.3(react@19.2.3))(react-markdown@9.1.0(@types/react@19.2.8)(react@19.2.3))(react@19.2.3)(typescript@5.9.3)(ws@8.19.0)(zod@3.24.3)':
     dependencies:
       '@orama/highlight': 0.1.9
       '@orama/orama': 3.1.18
       '@orama/plugin-analytics': 2.1.1
-      '@orama/plugin-secure-proxy': 2.1.1(encoding@0.1.13)(typescript@5.8.3)(ws@8.19.0)(zod@3.24.3)
+      '@orama/plugin-secure-proxy': 2.1.1(encoding@0.1.13)(typescript@5.9.3)(ws@8.19.0)(zod@3.24.3)
       '@oramacloud/client': 2.1.4
       '@phosphor-icons/react': 2.1.10(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@preact/signals-core': 1.12.1
@@ -19922,14 +19888,14 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@oramacloud/client@1.3.20(encoding@0.1.13)(typescript@5.8.3)(ws@8.19.0)(zod@3.24.3)':
+  '@oramacloud/client@1.3.20(encoding@0.1.13)(typescript@5.9.3)(ws@8.19.0)(zod@3.24.3)':
     dependencies:
       '@orama/cuid2': 2.2.3
       '@orama/orama': 2.1.1
       lodash: 4.17.21
       openai: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.24.3)
       react: 18.3.1
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.26(typescript@5.9.3)
     transitivePeerDependencies:
       - encoding
       - typescript
@@ -21010,6 +20976,56 @@ snapshots:
       - tsx
       - yaml
 
+  '@react-router/dev@7.12.0(@react-router/serve@7.12.0(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3))(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)':
+    dependencies:
+      '@babel/core': 7.28.6
+      '@babel/generator': 7.28.6
+      '@babel/parser': 7.28.6
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.6)
+      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.6)
+      '@babel/traverse': 7.28.6
+      '@babel/types': 7.28.6
+      '@react-router/node': 7.12.0(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
+      '@remix-run/node-fetch-server': 0.9.0
+      arg: 5.0.2
+      babel-dead-code-elimination: 1.0.12
+      chokidar: 4.0.3
+      dedent: 1.7.1
+      es-module-lexer: 1.7.0
+      exit-hook: 2.2.1
+      isbot: 5.1.32
+      jsesc: 3.0.2
+      lodash: 4.17.21
+      p-map: 7.0.4
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      pkg-types: 2.3.0
+      prettier: 3.8.0
+      react-refresh: 0.14.2
+      react-router: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      semver: 7.7.3
+      tinyglobby: 0.2.15
+      valibot: 1.2.0(typescript@5.9.3)
+      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+      vite-node: 3.2.4(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+    optionalDependencies:
+      '@react-router/serve': 7.12.0(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   '@react-router/dev@7.12.0(@react-router/serve@7.12.0(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3))(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@22.19.7)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)':
     dependencies:
       '@babel/core': 7.28.6
@@ -21110,56 +21126,6 @@ snapshots:
       - tsx
       - yaml
 
-  '@react-router/dev@7.14.2(@react-router/serve@7.14.2(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3))(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))(yaml@2.8.2)':
-    dependencies:
-      '@babel/core': 7.28.6
-      '@babel/generator': 7.28.6
-      '@babel/parser': 7.28.6
-      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.28.6)
-      '@babel/preset-typescript': 7.28.5(@babel/core@7.28.6)
-      '@babel/traverse': 7.28.6
-      '@babel/types': 7.28.6
-      '@react-router/node': 7.14.2(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
-      '@remix-run/node-fetch-server': 0.13.0
-      arg: 5.0.2
-      babel-dead-code-elimination: 1.0.12
-      chokidar: 4.0.3
-      dedent: 1.7.1
-      es-module-lexer: 1.7.0
-      exit-hook: 2.2.1
-      isbot: 5.1.32
-      jsesc: 3.0.2
-      lodash: 4.17.21
-      p-map: 7.0.4
-      pathe: 1.1.2
-      picocolors: 1.1.1
-      pkg-types: 2.3.0
-      prettier: 3.8.0
-      react-refresh: 0.14.2
-      react-router: 7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      semver: 7.7.3
-      tinyglobby: 0.2.15
-      valibot: 1.2.0(typescript@5.8.3)
-      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-      vite-node: 3.2.4(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
-    optionalDependencies:
-      '@react-router/serve': 7.14.2(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
-      typescript: 5.8.3
-    transitivePeerDependencies:
-      - '@types/node'
-      - babel-plugin-macros
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   '@react-router/express@7.12.0(express@4.22.1)(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)':
     dependencies:
       '@react-router/node': 7.12.0(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
@@ -21167,6 +21133,14 @@ snapshots:
       react-router: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
     optionalDependencies:
       typescript: 5.8.3
+
+  '@react-router/express@7.12.0(express@4.22.1)(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)':
+    dependencies:
+      '@react-router/node': 7.12.0(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
+      express: 4.22.1
+      react-router: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@react-router/express@7.12.0(express@4.22.1)(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)':
     dependencies:
@@ -21191,6 +21165,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
+  '@react-router/node@7.12.0(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)':
+    dependencies:
+      '@mjackson/node-fetch-server': 0.2.0
+      react-router: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+    optionalDependencies:
+      typescript: 5.9.3
+
   '@react-router/node@7.12.0(react-router@7.14.2(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)':
     dependencies:
       '@mjackson/node-fetch-server': 0.2.0
@@ -21210,6 +21191,21 @@ snapshots:
       '@mjackson/node-fetch-server': 0.2.0
       '@react-router/express': 7.12.0(express@4.22.1)(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
       '@react-router/node': 7.12.0(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.8.3)
+      compression: 1.8.1
+      express: 4.22.1
+      get-port: 5.1.1
+      morgan: 1.10.1
+      react-router: 7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      source-map-support: 0.5.21
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  '@react-router/serve@7.12.0(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)':
+    dependencies:
+      '@mjackson/node-fetch-server': 0.2.0
+      '@react-router/express': 7.12.0(express@4.22.1)(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
+      '@react-router/node': 7.12.0(react-router@7.12.0(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(typescript@5.9.3)
       compression: 1.8.1
       express: 4.22.1
       get-port: 5.1.1
@@ -21408,6 +21404,15 @@ snapshots:
       '@rollup/pluginutils': 5.3.0(rollup@4.55.1)
       resolve: 1.22.11
       typescript: 5.8.3
+    optionalDependencies:
+      rollup: 4.55.1
+      tslib: 2.8.1
+
+  '@rollup/plugin-typescript@12.3.0(rollup@4.55.1)(tslib@2.8.1)(typescript@5.9.3)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.55.1)
+      resolve: 1.22.11
+      typescript: 5.9.3
     optionalDependencies:
       rollup: 4.55.1
       tslib: 2.8.1
@@ -21849,6 +21854,28 @@ snapshots:
       - supports-color
       - typescript
 
+  '@storybook/react-vite@8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.8.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(rollup@4.55.1)(storybook@8.6.15(prettier@3.8.0))(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+    dependencies:
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@rollup/pluginutils': 5.3.0(rollup@4.55.1)
+      '@storybook/builder-vite': 8.6.15(storybook@8.6.15(prettier@3.8.0))(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
+      '@storybook/react': 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.8.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@8.6.15(prettier@3.8.0))(typescript@5.9.3)
+      find-up: 5.0.0
+      magic-string: 0.30.21
+      react: 19.2.3
+      react-docgen: 7.1.1
+      react-dom: 19.2.3(react@19.2.3)
+      resolve: 1.22.11
+      storybook: 8.6.15(prettier@3.8.0)
+      tsconfig-paths: 4.2.0
+      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+    optionalDependencies:
+      '@storybook/test': 8.6.15(storybook@8.6.15(prettier@3.8.0))
+    transitivePeerDependencies:
+      - rollup
+      - supports-color
+      - typescript
+
   '@storybook/react@8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.8.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@8.6.15(prettier@3.8.0))(typescript@5.8.3)':
     dependencies:
       '@storybook/components': 8.6.15(storybook@8.6.15(prettier@3.8.0))
@@ -21863,6 +21890,21 @@ snapshots:
     optionalDependencies:
       '@storybook/test': 8.6.15(storybook@8.6.15(prettier@3.8.0))
       typescript: 5.8.3
+
+  '@storybook/react@8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.8.0)))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@8.6.15(prettier@3.8.0))(typescript@5.9.3)':
+    dependencies:
+      '@storybook/components': 8.6.15(storybook@8.6.15(prettier@3.8.0))
+      '@storybook/global': 5.0.0
+      '@storybook/manager-api': 8.6.15(storybook@8.6.15(prettier@3.8.0))
+      '@storybook/preview-api': 8.6.15(storybook@8.6.15(prettier@3.8.0))
+      '@storybook/react-dom-shim': 8.6.15(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(storybook@8.6.15(prettier@3.8.0))
+      '@storybook/theming': 8.6.15(storybook@8.6.15(prettier@3.8.0))
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      storybook: 8.6.15(prettier@3.8.0)
+    optionalDependencies:
+      '@storybook/test': 8.6.15(storybook@8.6.15(prettier@3.8.0))
+      typescript: 5.9.3
 
   '@storybook/source-loader@8.6.15(storybook@8.6.15(prettier@3.8.0))':
     dependencies:
@@ -22229,9 +22271,9 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/node': 20.9.0
 
-  '@types/bun@1.3.6':
+  '@types/bun@1.3.13':
     dependencies:
-      bun-types: 1.3.6
+      bun-types: 1.3.13
 
   '@types/clean-css@4.2.11':
     dependencies:
@@ -22873,11 +22915,11 @@ snapshots:
       '@vue/shared': 3.5.26
       csstype: 3.2.3
 
-  '@vue/server-renderer@3.5.26(vue@3.5.26(typescript@5.8.3))':
+  '@vue/server-renderer@3.5.26(vue@3.5.26(typescript@5.9.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.26
       '@vue/shared': 3.5.26
-      vue: 3.5.26(typescript@5.8.3)
+      vue: 3.5.26(typescript@5.9.3)
 
   '@vue/shared@3.5.26': {}
 
@@ -22934,11 +22976,11 @@ snapshots:
       - supports-color
       - typescript
 
-  '@wyw-in-js/rollup@0.5.5(rollup@4.55.1)(typescript@5.8.3)':
+  '@wyw-in-js/rollup@0.5.5(rollup@4.55.1)(typescript@5.9.3)':
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.55.1)
       '@wyw-in-js/shared': 0.5.5
-      '@wyw-in-js/transform': 0.5.5(typescript@5.8.3)
+      '@wyw-in-js/transform': 0.5.5(typescript@5.9.3)
       rollup: 4.55.1
     transitivePeerDependencies:
       - supports-color
@@ -22981,7 +23023,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@wyw-in-js/transform@0.5.5(typescript@5.8.3)':
+  '@wyw-in-js/transform@0.5.5(typescript@5.9.3)':
     dependencies:
       '@babel/core': 7.28.6
       '@babel/generator': 7.28.6
@@ -22993,7 +23035,7 @@ snapshots:
       '@wyw-in-js/processor-utils': 0.5.5
       '@wyw-in-js/shared': 0.5.5
       babel-merge: 3.0.0(@babel/core@7.28.6)
-      cosmiconfig: 8.3.6(typescript@5.8.3)
+      cosmiconfig: 8.3.6(typescript@5.9.3)
       happy-dom: 15.11.7
       source-map: 0.7.6
       stylis: 4.3.6
@@ -23011,10 +23053,10 @@ snapshots:
       - supports-color
       - typescript
 
-  '@wyw-in-js/vite@0.5.5(typescript@5.8.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
+  '@wyw-in-js/vite@0.5.5(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@wyw-in-js/shared': 0.5.5
-      '@wyw-in-js/transform': 0.5.5(typescript@5.8.3)
+      '@wyw-in-js/transform': 0.5.5(typescript@5.9.3)
       vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
@@ -23505,6 +23547,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   bare-events@2.8.2: {}
 
   bare-fs@4.5.2:
@@ -23671,6 +23715,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -23713,7 +23761,7 @@ snapshots:
     dependencies:
       semver: 7.7.3
 
-  bun-types@1.3.6:
+  bun-types@1.3.13:
     dependencies:
       '@types/node': 20.9.0
 
@@ -24155,6 +24203,8 @@ snapshots:
 
   commander@13.1.0: {}
 
+  commander@14.0.3: {}
+
   commander@2.20.3: {}
 
   commander@4.1.1: {}
@@ -24388,14 +24438,14 @@ snapshots:
     optionalDependencies:
       typescript: 5.6.2
 
-  cosmiconfig@8.3.6(typescript@5.8.3):
+  cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
       js-yaml: 4.1.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
 
   cosmiconfig@9.0.0(typescript@5.8.3):
     dependencies:
@@ -26119,6 +26169,12 @@ snapshots:
       minimatch: 10.1.1
       minipass: 7.1.2
       path-scurry: 2.0.1
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
 
   glob@7.2.3:
     dependencies:
@@ -28579,6 +28635,10 @@ snapshots:
     dependencies:
       '@isaacs/brace-expansion': 5.0.0
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
   minimatch@3.0.5:
     dependencies:
       brace-expansion: 1.1.12
@@ -28648,6 +28708,8 @@ snapshots:
   minipass@5.0.0: {}
 
   minipass@7.1.2: {}
+
+  minipass@7.1.3: {}
 
   minizlib@2.1.2:
     dependencies:
@@ -29284,6 +29346,16 @@ snapshots:
       typescript: 5.8.3
       yargs-parser: 21.1.1
 
+  openapi-typescript@7.10.1(typescript@5.9.3):
+    dependencies:
+      '@redocly/openapi-core': 1.34.6(supports-color@10.2.2)
+      ansi-colors: 4.1.3
+      change-case: 5.4.4
+      parse-json: 8.3.0
+      supports-color: 10.2.2
+      typescript: 5.9.3
+      yargs-parser: 21.1.1
+
   openux-js@0.0.0-pre.1(react-dom@19.2.3(react@19.2.3))(react@19.2.3):
     dependencies:
       react: 19.2.3
@@ -29648,6 +29720,11 @@ snapshots:
       lru-cache: 11.2.4
       minipass: 7.1.2
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.2.4
+      minipass: 7.1.3
+
   path-to-regexp@0.1.12: {}
 
   path-to-regexp@8.3.0: {}
@@ -29815,6 +29892,14 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.6
       ts-node: 10.9.2(@swc/core@1.15.8)(@types/node@24.10.9)(typescript@5.8.3)
+
+  postcss-load-config@3.1.4(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.8)(@types/node@24.10.9)(typescript@5.9.3)):
+    dependencies:
+      lilconfig: 2.1.0
+      yaml: 1.10.2
+    optionalDependencies:
+      postcss: 8.5.6
+      ts-node: 10.9.2(@swc/core@1.15.8)(@types/node@24.10.9)(typescript@5.9.3)
 
   postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
@@ -30311,6 +30396,10 @@ snapshots:
   react-docgen-typescript@2.4.0(typescript@5.8.3):
     dependencies:
       typescript: 5.8.3
+
+  react-docgen-typescript@2.4.0(typescript@5.9.3):
+    dependencies:
+      typescript: 5.9.3
 
   react-docgen@7.1.1:
     dependencies:
@@ -30904,6 +30993,14 @@ snapshots:
     optionalDependencies:
       '@babel/code-frame': 7.28.6
 
+  rollup-plugin-dts@6.3.0(rollup@4.55.1)(typescript@5.9.3):
+    dependencies:
+      magic-string: 0.30.21
+      rollup: 4.55.1
+      typescript: 5.9.3
+    optionalDependencies:
+      '@babel/code-frame': 7.28.6
+
   rollup-plugin-minify-html-literals@1.2.6(rollup@4.55.1):
     dependencies:
       minify-html-literals: 1.3.5
@@ -30939,6 +31036,25 @@ snapshots:
       pify: 5.0.0
       postcss: 8.5.6
       postcss-load-config: 3.1.4(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.8)(@types/node@24.10.9)(typescript@5.8.3))
+      postcss-modules: 4.3.1(postcss@8.5.6)
+      promise.series: 0.2.0
+      resolve: 1.22.11
+      rollup-pluginutils: 2.8.2
+      safe-identifier: 0.4.2
+      style-inject: 0.3.0
+    transitivePeerDependencies:
+      - ts-node
+
+  rollup-plugin-postcss@4.0.2(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.8)(@types/node@24.10.9)(typescript@5.9.3)):
+    dependencies:
+      chalk: 4.1.2
+      concat-with-sourcemaps: 1.1.0
+      cssnano: 5.1.15(postcss@8.5.6)
+      import-cwd: 3.0.0
+      p-queue: 6.6.2
+      pify: 5.0.0
+      postcss: 8.5.6
+      postcss-load-config: 3.1.4(postcss@8.5.6)(ts-node@10.9.2(@swc/core@1.15.8)(@types/node@24.10.9)(typescript@5.9.3))
       postcss-modules: 4.3.1(postcss@8.5.6)
       promise.series: 0.2.0
       resolve: 1.22.11
@@ -31922,6 +32038,17 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  ts-json-schema-generator@2.9.0:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      commander: 14.0.3
+      glob: 13.0.6
+      json5: 2.2.3
+      normalize-path: 3.0.0
+      safe-stable-stringify: 2.5.0
+      tslib: 2.8.1
+      typescript: 5.9.3
+
   ts-morph@22.0.0:
     dependencies:
       '@ts-morph/common': 0.23.0
@@ -31968,9 +32095,34 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.15.8
 
+  ts-node@10.9.2(@swc/core@1.15.8)(@types/node@24.10.9)(typescript@5.9.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.12
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 24.10.9
+      acorn: 8.15.0
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.9.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+    optionalDependencies:
+      '@swc/core': 1.15.8
+    optional: true
+
   tsconfck@3.1.6(typescript@5.8.3):
     optionalDependencies:
       typescript: 5.8.3
+
+  tsconfck@3.1.6(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -32063,6 +32215,35 @@ snapshots:
       '@swc/core': 1.15.8
       postcss: 8.5.6
       typescript: 5.8.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsup@8.5.1(@swc/core@1.15.8)(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.2)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3(supports-color@10.2.2)
+      esbuild: 0.27.2
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(yaml@2.8.2)
+      resolve-from: 5.0.0
+      rollup: 4.55.1
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      '@swc/core': 1.15.8
+      postcss: 8.5.6
+      typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
       - supports-color
@@ -32167,6 +32348,8 @@ snapshots:
   typescript@5.6.2: {}
 
   typescript@5.8.3: {}
+
+  typescript@5.9.3: {}
 
   typia@12.0.2(@types/node@24.10.9)(typescript@5.8.3):
     dependencies:
@@ -32443,6 +32626,10 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
+  valibot@1.2.0(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+
   validate-npm-package-license@3.0.4:
     dependencies:
       spdx-correct: 3.2.0
@@ -32653,6 +32840,17 @@ snapshots:
       debug: 4.4.3(supports-color@10.2.2)
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.8.3)
+    optionalDependencies:
+      vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
+  vite-tsconfig-paths@5.1.4(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)):
+    dependencies:
+      debug: 4.4.3(supports-color@10.2.2)
+      globrex: 0.1.2
+      tsconfck: 3.1.6(typescript@5.9.3)
     optionalDependencies:
       vite: 7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sugarss@5.0.1(postcss@8.5.6))(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
     transitivePeerDependencies:
@@ -32945,15 +33143,15 @@ snapshots:
       - supports-color
       - terser
 
-  vue@3.5.26(typescript@5.8.3):
+  vue@3.5.26(typescript@5.9.3):
     dependencies:
       '@vue/compiler-dom': 3.5.26
       '@vue/compiler-sfc': 3.5.26
       '@vue/runtime-dom': 3.5.26
-      '@vue/server-renderer': 3.5.26(vue@3.5.26(typescript@5.8.3))
+      '@vue/server-renderer': 3.5.26(vue@3.5.26(typescript@5.9.3))
       '@vue/shared': 3.5.26
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.3
 
   wait-port@1.1.0:
     dependencies:

--- a/scripts/generate-schema.mjs
+++ b/scripts/generate-schema.mjs
@@ -1,0 +1,48 @@
+import { createGenerator } from 'ts-json-schema-generator';
+import { readFileSync, writeFileSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+const ROOT = resolve('.');
+const SETTINGS_PATH = join(ROOT, 'packages/xyd-core/src/types/settings.ts');
+const TEMP_PATH = join(ROOT, 'packages/xyd-core/src/types/settings.schema.ts');
+const OUTPUT_PATH = join(ROOT, 'apps/docs/public/docs.json');
+
+// Read the original settings file
+let source = readFileSync(SETTINGS_PATH, 'utf-8');
+
+// Replace the vite import with a type alias pointing to ViteUserConfigInline.
+// ViteUserConfigInline is defined in the same file as a schema-safe subset.
+source = source.replace(
+  /import\s+type\s*\{[^}]*UserConfig\s+as\s+ViteUserConfig[^}]*\}\s*from\s*["']vite["'];?\s*/,
+  'type ViteUserConfig = ViteUserConfigInline;\n'
+);
+
+// Write modified file next to the original so all imports resolve correctly
+writeFileSync(TEMP_PATH, source);
+
+try {
+  const schema = createGenerator({
+    path: TEMP_PATH,
+    type: 'Settings',
+    topRef: false,
+    skipTypeCheck: true,
+    sortProps: true,
+  }).createSchema('Settings');
+
+  // Sort all object keys alphabetically to match the previous CLI output format
+  const sortedJson = JSON.stringify(schema, (_, value) => {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      const sorted = {};
+      for (const key of Object.keys(value).sort()) {
+        sorted[key] = value[key];
+      }
+      return sorted;
+    }
+    return value;
+  }, 2);
+
+  writeFileSync(OUTPUT_PATH, sortedJson + '\n');
+  console.log(`Schema written to ${OUTPUT_PATH}`);
+} finally {
+  rmSync(TEMP_PATH, { force: true });
+}


### PR DESCRIPTION
…ides

Allow users to customize the underlying Vite config via `advanced.vite` in docs.json/docs.ts. The user config is merged with xyd's internal config using Vite's `mergeConfig` for both dev server and builds.

This addresses the need to persist Vite settings like `server.allowedHosts` for remote development environments (code-server, Gitpod) without manual edits on every restart.

- Add `vite?: ViteUserConfig` to Advanced interface in xyd-core
- Merge user vite config in documan dev.ts and build.ts
- Add ViteUserConfigInline for schema-safe JSON schema generation
- Switch schema generation to programmatic API (scripts/generate-schema.mjs)
- Add e2e tests verifying allowedHosts behavior
- Update docs and apps/docs settings guide