### PR TITLE
fix(e2e): don't override global registry in CI, use XYD_E2E_VERDACCIO…

### DIFF
--- a/.github/workflows/tests-e2e.yml
+++ b/.github/workflows/tests-e2e.yml
@@ -118,5 +118,4 @@ jobs:
     - name: 🧪 Run E2E tests
       run: pnpm run test:e2e
       env:
-        npm_config_registry: http://localhost:4873
-        BUN_CONFIG_REGISTRY: http://localhost:4873
+        XYD_E2E_VERDACCIO_URL: http://localhost:4873

--- a/__tests__/e2e/7.themes/2.custom-npm-theme/custom-npm-theme.test.ts
+++ b/__tests__/e2e/7.themes/2.custom-npm-theme/custom-npm-theme.test.ts
@@ -4,9 +4,8 @@ import path from 'path';
 
 import { createXydBuildServer, XydServer } from '../../utils/xyd-server';
 
-// Use the Verdaccio registry from the environment (Docker entrypoint sets this)
-// or fall back to localhost:4873 for local testing with Verdaccio running
-const REGISTRY = process.env.npm_config_registry || 'http://localhost:4873';
+// Verdaccio URL: Docker entrypoint sets npm_config_registry, CI sets XYD_E2E_VERDACCIO_URL
+const REGISTRY = process.env.XYD_E2E_VERDACCIO_URL || process.env.npm_config_registry || 'http://localhost:4873';
 
 test.describe('Custom npm Theme', () => {
     let server: XydServer;

--- a/__tests__/e2e/7.themes/3.custom-npm-theme-advanced/custom-npm-theme-advanced.test.ts
+++ b/__tests__/e2e/7.themes/3.custom-npm-theme-advanced/custom-npm-theme-advanced.test.ts
@@ -4,7 +4,7 @@ import path from 'path';
 
 import { createXydBuildServer, XydServer } from '../../utils/xyd-server';
 
-const REGISTRY = process.env.npm_config_registry || 'http://localhost:4873';
+const REGISTRY = process.env.XYD_E2E_VERDACCIO_URL || process.env.npm_config_registry || 'http://localhost:4873';
 
 test.describe('Custom npm Theme (Advanced)', () => {
     let server: XydServer;


### PR DESCRIPTION
…_URL

Setting npm_config_registry globally caused xyd build to resolve all @xyd-js/* packages from empty Verdaccio instead of npm. Only custom theme tests need Verdaccio - they now use XYD_E2E_VERDACCIO_URL env var.