### PR TITLE
fix(build): resolve typescript transform errors in ask-ai and themes

### DIFF
--- a/packages/xyd-ask-ai/rollup.config.js
+++ b/packages/xyd-ask-ai/rollup.config.js
@@ -2,7 +2,7 @@ import {createRequire} from 'module';
 
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
-import typescript from 'rollup-plugin-typescript2';
+import typescript from '@rollup/plugin-typescript';
 import dts from 'rollup-plugin-dts';
 import {terser} from 'rollup-plugin-terser';
 import babel from '@rollup/plugin-babel';
@@ -44,10 +44,7 @@ export default [
             }),
             commonjs(),
             typescript({
-                tsconfig: './tsconfig.json',
-                declaration: true,
-                declarationDir: 'dist',
-                useTsconfigDeclarationDir: true
+                tsconfig: './tsconfig.json'
             }),
             babel({
                 babelHelpers: 'bundled',

--- a/packages/xyd-ask-ai/tsconfig.json
+++ b/packages/xyd-ask-ai/tsconfig.json
@@ -24,5 +24,5 @@
     "noFallthroughCasesInSwitch": true,
     
   },
-  "include": ["src"]
+  "include": ["src", "packages"]
 }

--- a/packages/xyd-themes/tsconfig.json
+++ b/packages/xyd-themes/tsconfig.json
@@ -18,8 +18,7 @@
     "lib": [
       "dom",
       "dom.iterable",
-      "esnext",
-      "node"
+      "esnext"
     ],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
- xyd-ask-ai: switch to @rollup/plugin-typescript and include packages/* in tsconfig so files outside src/ are transformed before Rollup parses them
- xyd-themes: remove invalid "node" entry from tsconfig lib (TS6046)