### PR TITLE
fix(dev-server): revert dedupe/noExternal hacks that broke React Context

### DIFF
--- a/packages/xyd-documan/src/dev.ts
+++ b/packages/xyd-documan/src/dev.ts
@@ -157,9 +157,7 @@ export async function dev(options?: DevOptions) {
     {
         // TODO: !!! IN THE FUTURE BETTER SOLUTION !!!
         if (process.env.XYD_DEV_MODE) {
-            const themeName = respPluginDocs.settings?.theme?.name || "poetry";
             USE_CONTEXT_ISSUE_PACKAGES = [
-                `@xyd-js/theme-${themeName}`,
                 "react-github-btn",
                 "radix-ui",
                 "@code-hike/lighter",
@@ -197,20 +195,6 @@ export async function dev(options?: DevOptions) {
             'process.env': {}
         },
         resolve: {
-            dedupe: [
-                "react",
-                "react-dom",
-                "react-router",
-                "react/jsx-runtime",
-                "react/jsx-dev-runtime",
-                "@xyd-js/framework",
-                "@xyd-js/core",
-                "@xyd-js/ui",
-                "@xyd-js/components",
-                "@xyd-js/atlas",
-                "@xyd-js/themes",
-                "@xyd-js/analytics",
-            ],
             alias: {
                 process: 'process/browser',
                 // When rehype-mermaid is externalized, resolve it from CLI's node_modules
@@ -229,13 +213,6 @@ export async function dev(options?: DevOptions) {
         },
         ssr: {
             external: externalPackages,
-            // In dev mode, prevent @xyd-js/* from being externalized during SSR
-            // so that resolve.dedupe can unify them with the source code instances
-            ...(process.env.XYD_DEV_MODE ? {
-                noExternal: [
-                    /^@xyd-js\//,
-                ],
-            } : {}),
         },
         optimizeDeps: {
             include: [
@@ -244,29 +221,6 @@ export async function dev(options?: DevOptions) {
             ],
             exclude: optimizeDepsExclude,
             // exclude: ["react", "react-dom"]
-            ...(process.env.XYD_DEV_MODE ? {
-                esbuildOptions: {
-                    plugins: [
-                        {
-                            name: 'externalize-xyd-packages',
-                            setup(build: any) {
-                                // Externalize @xyd-js/* and react from pre-bundled deps
-                                // so they use the same module instances as source code
-                                build.onResolve({ filter: /^@xyd-js\// }, (args: any) => {
-                                    if (args.kind === 'import-statement' && args.importer?.includes('node_modules')) {
-                                        return { path: args.path, external: true }
-                                    }
-                                })
-                                build.onResolve({ filter: /^react(-dom|-router)?(\/.*)?$/ }, (args: any) => {
-                                    if (args.kind === 'import-statement' && args.importer?.includes('node_modules')) {
-                                        return { path: args.path, external: true }
-                                    }
-                                })
-                            }
-                        }
-                    ]
-                }
-            } : {}),
         },
         plugins: [
             ...(commonRunVitePlugins as PluginOption[]),

--- a/packages/xyd-documan/src/utils.ts
+++ b/packages/xyd-documan/src/utils.ts
@@ -314,6 +314,22 @@ function getThemeDependency(settings: Settings): Record<string, string> {
         return { [packageName]: "latest" };
     }
 
+    // In dev mode, prefer the live workspace package via `workspace:*` so
+    // changes to the theme source (and its compiled dist) propagate without
+    // bumping BUILT_IN_THEME_VERSIONS or republishing. This matches the
+    // pattern every other @xyd-js/* dep already uses in the host package.json
+    // template.
+    if (process.env.XYD_DEV_MODE) {
+        const workspacePath = path.resolve(
+            __dirname,
+            "../..",
+            `xyd-theme-${themeName}`
+        );
+        if (fs.existsSync(path.join(workspacePath, "package.json"))) {
+            return { [packageName]: "workspace:*" };
+        }
+    }
+
     if (!process.env.XYD_DEV_MODE) {
         const documanVersion = getDocumanRuntimeVersion();
         if (documanVersion && isLockstepSnapshotVersion(documanVersion)) {


### PR DESCRIPTION
The pile of dev.ts workarounds (resolve.dedupe, ssr.noExternal in dev mode, optimizeDeps.esbuildOptions externalize plugin, active theme in optimizeDeps.include) created dual module identities for @xyd-js/framework between the host and the workspace-symlinked active theme. That tore down React Context across SSR/CSR boundaries and produced hydration mismatches under FwSidebarTabsDropdown.

Reverting to the alpha.11 dev shape — Vite's default symlink-aware resolution handles workspace deps correctly on its own. Also pin the active theme to workspace:* in dev so theme source changes propagate.