### PR TITLE
chore(release): add canary2 release channel

### DIFF
--- a/.github/workflows/cli-canary2.yml
+++ b/.github/workflows/cli-canary2.yml
@@ -1,0 +1,119 @@
+name: 🐤 CLI Canary2 Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build canary2 from (default: current branch)'
+        required: false
+        type: string
+        default: ''
+
+jobs:
+  canary2-release:
+    name: 🐤 Canary2 Release
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [ 22.12.0 ]
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: 📥 Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
+          fetch-depth: 0
+
+      - name: 🟢 Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.10.0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 'latest'
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install the packages
+        run: pnpm i
+
+      - name: 🏗 Build packages
+        run: pnpm run build
+
+      - name: 🔐 Setup npm auth
+        run: |
+          echo "registry=https://registry.npmjs.org" >> ~/.npmrc
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> ~/.npmrc
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: 🕵️ Determine canary2 version
+        id: version
+        run: |
+          SHA=$(git rev-parse HEAD)
+          SHORT_SHA=${SHA::7}
+          BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          TIMESTAMP=$(date +%Y%m%d%H%M%S)
+          CANARY2_VERSION="canary2-${SHORT_SHA}"
+          echo "CANARY2_VERSION=${CANARY2_VERSION}" >> $GITHUB_OUTPUT
+          echo "📦 Canary2 version: ${CANARY2_VERSION}"
+          echo "🌿 Branch: ${BRANCH}"
+          echo "🔑 Commit: ${SHORT_SHA}"
+
+      - name: 🐤 Publish canary2 packages
+        run: node ./release.js --prod --tag canary2 --snapshot ${{ steps.version.outputs.CANARY2_VERSION }}
+
+      - name: 📦 Publish xyd-js canary2
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          # Read the canary2 version of @xyd-js/cli from its local package.json
+          # (already versioned by changeset in the previous step)
+          CANARY2_CLI_VERSION=$(node -p "require('./packages/xyd-cli/package.json').version")
+          echo "📦 @xyd-js/cli version: ${CANARY2_CLI_VERSION}"
+
+          cd packages/xyd-js
+
+          # Write dependency directly into package.json (avoids npm install resolving full dep tree)
+          node -e "
+            const fs = require('fs');
+            const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+            pkg.dependencies['@xyd-js/cli'] = '${CANARY2_CLI_VERSION}';
+            fs.writeFileSync('package.json', JSON.stringify(pkg, null, 4) + '\n');
+          "
+
+          # Set canary2 version on xyd-js package
+          npm version 0.0.0-${{ steps.version.outputs.CANARY2_VERSION }} --no-git-tag-version
+
+          echo "📦 Publishing xyd-js@0.0.0-${{ steps.version.outputs.CANARY2_VERSION }} with canary2 tag"
+          npm publish --tag canary2
+
+      - name: ✅ Success
+        run: |
+          echo "✅ Canary2 release published!"
+          echo ""
+          echo "Install with:"
+          echo "  bun add -g xyd-js@canary2"
+          echo "  npm i -g xyd-js@canary2"
+          echo ""
+          echo "Version: 0.0.0-${{ steps.version.outputs.CANARY2_VERSION }}"

--- a/.github/workflows/tests-opencli-pipeline.yml
+++ b/.github/workflows/tests-opencli-pipeline.yml
@@ -17,7 +17,7 @@ name: tests:opencli-pipeline
 
 on:
   push:
-    branches: [ master, canary ]
+    branches: [ master, canary, canary2 ]
     paths:
       - 'packages/xyd-opencli/**'
       - 'packages/xyd-openapi2opencli/**'
@@ -25,7 +25,7 @@ on:
       - 'packages/xyd-opencli2rust/**'
       - '.github/workflows/tests-opencli-pipeline.yml'
   pull_request:
-    branches: [ master, canary ]
+    branches: [ master, canary, canary2 ]
     paths:
       - 'packages/xyd-opencli/**'
       - 'packages/xyd-openapi2opencli/**'

--- a/.github/workflows/tests-opensdk-pipeline.yml
+++ b/.github/workflows/tests-opensdk-pipeline.yml
@@ -23,7 +23,7 @@ name: tests:opensdk-pipeline
 
 on:
   push:
-    branches: [ master, canary ]
+    branches: [ master, canary, canary2 ]
     paths:
       - 'packages/xyd-opensdk-core/**'
       - 'packages/xyd-opensdk-framework/**'
@@ -40,7 +40,7 @@ on:
       - 'packages/xyd-opensdk-cli/**'
       - '.github/workflows/tests-opensdk-pipeline.yml'
   pull_request:
-    branches: [ master, canary ]
+    branches: [ master, canary, canary2 ]
     paths:
       - 'packages/xyd-opensdk-core/**'
       - 'packages/xyd-opensdk-framework/**'

--- a/.github/workflows/tests-unit.yml
+++ b/.github/workflows/tests-unit.yml
@@ -2,9 +2,9 @@ name: tests:unit
 
 on:
   push:
-    branches: [ master, canary ]
+    branches: [ master, canary, canary2 ]
   pull_request:
-    branches: [ master, canary ]
+    branches: [ master, canary, canary2 ]
 
 jobs:
   test:

--- a/packages/xyd-documan/src/utils.ts
+++ b/packages/xyd-documan/src/utils.ts
@@ -270,11 +270,11 @@ const BUILT_IN_THEME_VERSIONS: Record<string, string> = {
 const NPM_THEME_PREFIX = "npm:";
 
 // release.js republishes every @xyd-js/* package together with the same
-// snapshot version (e.g. 0.0.0-canary-{sha}-{ts} or 0.0.0-build-{sha}-{ts}),
-// so the theme published alongside this documan is at the exact same
-// version. Reading documan's own package.json at runtime returns the
-// published snapshot — pinning to that exact version keeps builds
-// reproducible (no drift from later canary republishes) and avoids stale
+// snapshot version (e.g. 0.0.0-canary-{sha}, 0.0.0-canary2-{sha} or
+// 0.0.0-build-{sha}-{ts}), so the theme published alongside this documan is
+// at the exact same version. Reading documan's own package.json at runtime
+// returns the published snapshot — pinning to that exact version keeps builds
+// reproducible (no drift from later canary/canary2 republishes) and avoids stale
 // values inlined from workspace package.json imports at tsup build time
 // (release.js bumps versions AFTER documan is built).
 function getDocumanRuntimeVersion(): string | null {
@@ -290,7 +290,7 @@ function getDocumanRuntimeVersion(): string | null {
 function isLockstepSnapshotVersion(version: string): boolean {
     // Snapshot versions produced by `pnpm changeset version --snapshot {tag}`
     // — same value across every @xyd-js/* package on a given release.
-    return version.startsWith("0.0.0-canary-") || version.startsWith("0.0.0-build-");
+    return version.startsWith("0.0.0-canary-") || version.startsWith("0.0.0-canary2-") || version.startsWith("0.0.0-build-");
 }
 
 function getThemeDependency(settings: Settings): Record<string, string> {

--- a/scripts/canary2.sh
+++ b/scripts/canary2.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -e
+
+# Publish a canary2 release of xyd-js from local machine
+# Usage: ./scripts/canary2.sh
+#
+# Prerequisites:
+#   - npm auth configured (npm login or NPM_TOKEN env var)
+#   - packages built (pnpm run build)
+#
+# Install the canary2 release with:
+#   bun add -g xyd-js@canary2
+
+SHA=$(git rev-parse HEAD)
+SHORT_SHA=${SHA::7}
+CANARY2_VERSION="canary2-${SHORT_SHA}"
+
+echo "🐤 Publishing canary2 release..."
+echo "   Commit: ${SHORT_SHA}"
+echo "   Version: 0.0.0-${CANARY2_VERSION}"
+echo ""
+
+# Step 1: Build packages
+echo "🏗  Building packages..."
+pnpm run build
+
+# Step 2: Publish all @xyd-js/* packages with canary2 snapshot
+echo "📦 Publishing @xyd-js/* packages..."
+node ./release.js --prod --snapshot "${CANARY2_VERSION}"
+
+# Step 3: Read the canary2 version of @xyd-js/cli from local package.json
+# (already versioned by changeset in the previous step)
+CANARY2_CLI_VERSION=$(node -p "require('./packages/xyd-cli/package.json').version")
+echo "   @xyd-js/cli version: ${CANARY2_CLI_VERSION}"
+
+# Step 4: Update xyd-js package and publish with canary2 tag
+echo "📦 Publishing xyd-js canary2..."
+cd packages/xyd-js
+
+# Write dependency directly (avoids npm install resolving full dep tree)
+node -e "
+  const fs = require('fs');
+  const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+  pkg.dependencies['@xyd-js/cli'] = '${CANARY2_CLI_VERSION}';
+  fs.writeFileSync('package.json', JSON.stringify(pkg, null, 4) + '\n');
+"
+
+npm version "0.0.0-${CANARY2_VERSION}" --no-git-tag-version
+npm publish --tag canary2
+cd ../..
+
+# Step 5: Restore xyd-js package.json
+echo "🔄 Restoring packages/xyd-js/package.json..."
+git checkout packages/xyd-js/package.json packages/xyd-js/package-lock.json 2>/dev/null || true
+
+echo ""
+echo "✅ Canary2 release published!"
+echo ""
+echo "Install with:"
+echo "  bun add -g xyd-js@canary2"
+echo "  npm i -g xyd-js@canary2"
+echo "  pnpm add -g xyd-js@canary2"


### PR DESCRIPTION
Mirror the existing canary channel as a parallel canary2 side-channel:

- scripts/canary2.sh: local publish (0.0.0-canary2-{sha}, npm tag canary2)
- .github/workflows/cli-canary2.yml: workflow_dispatch CI release (tag canary2)
- packages/xyd-documan/src/utils.ts: recognize the 0.0.0-canary2- prefix in isLockstepSnapshotVersion so canary2 builds still pin the theme to the published snapshot (0.0.0-canary2-{sha} does not match the 0.0.0-canary- prefix, which would otherwise silently disable theme-version pinning)
- tests-unit / tests-opencli-pipeline / tests-opensdk-pipeline: add canary2 to the push/pull_request branch triggers, matching the canary branch parity