### PR TITLE
test(opencli): scope the sidebar assertion to the visible desktop sid…

### DIFF
--- a/__tests__/e2e/8.opencli/1.basic/opencli.test.ts
+++ b/__tests__/e2e/8.opencli/1.basic/opencli.test.ts
@@ -37,9 +37,12 @@ test.describe('api.cli virtual CLI pages [build]', () => {
     await page.goto(server.getUrl('/docs/cli/overview'));
     await page.waitForLoadState('networkidle');
 
-    // sidebar links to each generated command page
+    // sidebar links to each generated command page. Scope to the desktop sidebar:
+    // the responsive layout also renders a mobile sidebar (`part="mobile-sidebar"`,
+    // hidden on desktop) FIRST in the DOM, so an unscoped `.first()` would grab that
+    // hidden copy.
     for (const cmd of ['install', 'remove', 'list']) {
-      await expect(page.locator(`a[href$="/docs/cli/${cmd}"]`).first()).toBeVisible();
+      await expect(page.locator(`aside[part="sidebar"] a[href$="/docs/cli/${cmd}"]`).first()).toBeVisible();
     }
   });
 


### PR DESCRIPTION
…ebar

The responsive layout renders TWO sidebars in the DOM — a mobile one (`aside[part="mobile-sidebar"]`, hidden on desktop) that comes FIRST, and the desktop `aside[part="sidebar"]`. The "every command is present in the sidebar" assertion used an unscoped `a[href$="…"]`.first(), so it grabbed the hidden mobile copy and failed `toBeVisible()`. Scope the locator to the desktop sidebar so it targets the link the user actually sees. The generated command pages themselves are unchanged — this is purely the test locator.