### PR TITLE
ci(opensdk): quote step names containing a colon (invalid workflow YAML)

### DIFF
--- a/.github/workflows/tests-opensdk-pipeline.yml
+++ b/.github/workflows/tests-opensdk-pipeline.yml
@@ -260,12 +260,12 @@ jobs:
     # Prove `opensdk run` + chain.json: one chain (a merge source + an overlay +
     # a target per language) generates every SDK and each COMPILES. All 6
     # toolchains are set up above; no registries needed (generate + compile only).
-    - name: Chain e2e (opensdk run: merge + overlay → all-language SDKs, each compiles)
+    - name: "Chain e2e (opensdk run: merge + overlay → all-language SDKs, each compiles)"
       run: pnpm --filter @xyd-js/opensdk-chain exec vitest run __tests__/e2e/chain.test.ts
       env:
         E2E_SDK_CHAIN: '1'
 
-    - name: Chain e2e — CLI output targets (opensdk run: go-cli + rust-cli, each compiles)
+    - name: "Chain e2e — CLI output targets (opensdk run: go-cli + rust-cli, each compiles)"
       run: pnpm --filter @xyd-js/opensdk-cli exec vitest run __tests__/e2e/cli-chain.test.ts
       env:
         E2E_SDK_CHAIN: '1'


### PR DESCRIPTION
Two "Chain e2e" step names embed `opensdk run: …`; the unquoted `: ` reads as a YAML mapping value ("mapping values are not allowed here", line 263), so GitHub rejected the whole tests-opensdk-pipeline workflow. Wrap both names in quotes so the colon is literal. No behavior change — same steps, same runs.