### PR TITLE
test(opensdk-go): populate required params in e2e driver so multipart…

### DIFF
--- a/packages/xyd-opensdk-go/__tests__/e2e/harness.ts
+++ b/packages/xyd-opensdk-go/__tests__/e2e/harness.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 
 import { describe, it } from 'vitest';
 
-import type { Method, OpensdkSpecJson, Resource } from '@xyd-js/opensdk-core';
+import type { Method, NamedType, OpensdkSpecJson, Resource } from '@xyd-js/opensdk-core';
 import {
   type ApiConfig,
   type BuiltDriver,
@@ -18,8 +18,9 @@ import {
 } from '@xyd-js/opensdk-ci';
 
 import { opensdkGo, writeProject } from '../../index';
+import { type GoExampleCtx, renderDriverParams } from '../../src/example-go';
+import { Imports, goFile } from '../../src/gowriter';
 import { goMethodName, pascalCase } from '../../src/naming';
-import { resourceQualifier } from '../../src/service';
 
 // The GO-SPECIFIC half of the e2e — a thin DriverAdapter over the shared,
 // language-agnostic harness in @xyd-js/opensdk-ci (IR merge, expected request,
@@ -38,6 +39,17 @@ const callKey = (segments: string[], method: Method): string =>
 // ---- generated driver: call each method against the recording server -----
 
 function generateDriver(spec: OpensdkSpecJson, pkg: string, modulePath: string): string {
+  const types = new Map<string, NamedType>((spec.types || []).map((t) => [t.name, t]));
+  const imports = new Imports();
+  imports.add('context');
+  imports.add('os');
+  const pkgQ = imports.add(modulePath, pkg);
+  const optionQ = imports.add(`${modulePath}/option`);
+  // Reuse the SDK's own example param assembly so REQUIRED fields — including a
+  // multipart file (io.Reader) — are populated. A bare `Params{}` drops the
+  // nil-reader file part, so the real request would be missing its upload field.
+  const ctx: GoExampleCtx = { types, modulePath, pkgQ, optionQ, imports };
+
   const cases: string[] = [];
   const walk = (resources: Resource[] | undefined, segments: string[]) => {
     for (const r of resources || []) {
@@ -46,35 +58,25 @@ function generateDriver(spec: OpensdkSpecJson, pkg: string, modulePath: string):
         const recv = seg.map(pascalCase).join('.');
         const mname = goMethodName(m.action);
         const args = ['ctx', ...(m.pathParams || []).map(() => JSON.stringify(EXAMPLE))];
-        if (m.requestBody || (m.queryParams || []).length > 0) {
-          args.push(`${pkg}.${resourceQualifier(seg)}${mname}Params{}`);
-        }
+        const params = renderDriverParams(seg, m, ctx);
+        if (params) args.push(params);
         cases.push(`\tcase ${JSON.stringify(`${recv}.${mname}`)}:\n\t\tclient.${recv}.${mname}(${args.join(', ')})`);
       }
       walk(r.resources, seg);
     }
   };
   walk(spec.resources, []);
-  return `package main
 
-import (
-	"context"
-	"os"
-
-	${pkg} ${JSON.stringify(modulePath)}
-	"${modulePath}/option"
-)
-
-func main() {
-	client := ${pkg}.NewClient(option.WithBaseURL(os.Getenv("E2E_BASE_URL")))
+  const mainFn = `func main() {
+	client := ${pkgQ}.NewClient(${optionQ}.WithBaseURL(os.Getenv("E2E_BASE_URL")))
 	ctx := context.Background()
 	_ = ctx
 	_ = client
 	switch os.Args[1] {
 ${cases.join('\n')}
 	}
-}
-`;
+}`;
+  return goFile('main', imports, [mainFn]);
 }
 
 const MODULE = (pkg: string) => `github.com/example/${pkg}`;

--- a/packages/xyd-opensdk-go/src/example-go.ts
+++ b/packages/xyd-opensdk-go/src/example-go.ts
@@ -342,6 +342,21 @@ function paramsStructExpr(
   return { text: `${typeQ}{\n${body}\n}`, multiline: true };
 }
 
+/**
+ * The required-only, POPULATED params-struct literal for the e2e driver — reuses
+ * the exact test/usage param assembly so a multipart FILE field is set to a
+ * non-nil io.Reader. An empty `Params{}` drops the nil-reader file part (the
+ * apiform encoder skips a nil io.Reader field), so the real request would be
+ * missing its required upload field and diverge from the recorded binding.
+ * Imports are tracked on `ctx.imports`; returns the struct-literal text, or null
+ * when the method takes no params struct.
+ */
+export function renderDriverParams(segments: string[], method: Method, ctx: GoExampleCtx): string | null {
+  const op = planOperation(method, ctx.types);
+  const expr = paramsStructExpr(segments, method, op, false, goMethodName(method.action), ctx, false);
+  return expr ? expr.text : null;
+}
+
 // ---- test-function assembly ----------------------------------------------
 
 /** Prefix every line of a (possibly multi-line) block with `tabs` tab stops. */


### PR DESCRIPTION
… uploads bind

The Go e2e driver invoked each method with an empty `Params{}`, leaving a required multipart file field (io.Reader) nil — the apiform encoder drops a nil-reader part, so the actual request was missing its upload field and failed the recorded-binding diff (files / images / uploads / videos / audio: "body missing file/image/data/video").

This only surfaced on Linux CI. On macOS the generated Go binary can't exec (dyld LC_UUID), so the real-SDK diff tests skip (sdkRuns=false) and the bug was masked — "green" locally meant "skipped", not "passed".

The driver now reuses the SDK's own example param assembly (renderDriverParams) to populate required fields — including a non-nil io.Reader for multipart file fields — matching the python/java/dotnet drivers. Verified in a linux/arm64 container: the exact CI command (O2S_GO_SMOKE=1 E2E_SDK=1 E2E_SDK_TESTS=1) passes 759/759.