### PR TITLE
fix(opensdk-java): import java.util.List/Map for collection return types

### DIFF
--- a/crates/xyd_opensdk_java/src/service.rs
+++ b/crates/xyd_opensdk_java/src/service.rs
@@ -253,6 +253,15 @@ fn method_def(
     }
 
     let ret = return_plan(method, &plan, ctx);
+    // A generic-collection return type (e.g. `List<Thing>` from an array
+    // response) carries element imports that aren't added anywhere else — add
+    // them so the service compiles (mirrors the params-file import handling).
+    if ret.0.contains("List<") {
+        imports.insert("java.util.List".to_string());
+    }
+    if ret.0.contains("Map<") {
+        imports.insert("java.util.Map".to_string());
+    }
     lines.push(ret.1);
 
     let doc = java_doc(str_field(method, "description"), "  ");

--- a/packages/xyd-opensdk-java/__fixtures__/9.x-open-sdk/output/src/main/java/com/example/extensionsdemo/CatalogService.java
+++ b/packages/xyd-opensdk-java/__fixtures__/9.x-open-sdk/output/src/main/java/com/example/extensionsdemo/CatalogService.java
@@ -2,6 +2,8 @@
 
 package com.example.extensionsdemo;
 
+import java.util.List;
+
 public final class CatalogService {
   private final Transport transport;
 

--- a/packages/xyd-opensdk-java/src/service.ts
+++ b/packages/xyd-opensdk-java/src/service.ts
@@ -155,6 +155,11 @@ function methodDef(
   }
 
   const ret = returnPlan(method, plan, ctx);
+  // A generic-collection return type (e.g. `List<Thing>` from an array response)
+  // carries element imports that aren't added anywhere else — add them so the
+  // service compiles (mirrors the params-file import handling below).
+  if (ret.type.includes('List<')) imports.add('java.util.List');
+  if (ret.type.includes('Map<')) imports.add('java.util.Map');
   lines.push(ret.statement);
 
   const doc = javaDoc(method.description, '  ');


### PR DESCRIPTION
A service method returning a generic collection — e.g. `CatalogService.browse()` returning `List<Thing>` from an array response — emitted `public List<Thing> browse()` without importing java.util.List, so `javac` failed ("cannot find symbol: class List"). `returnPlan` computes the return type but never contributed its imports; only query-param and params-file collection types were covered.

Add java.util.List / java.util.Map to a service's imports when a method's return type is a generic collection. Fixed in both the Rust emitter (crates/xyd_opensdk_java/src/service.rs) and its JS twin (packages/xyd-opensdk-java/src/service.ts), kept in parity, and the 9.x-open-sdk golden regenerated — byte-identical from the native and JS paths.

Verified: javac (JDK 17) clean across all goldens, the assertion suite is green against the mock, cargo parity test (4 passed), native==JS.