### PR TITLE
fix(xyd_mdx): fall back when a directive body re-parses to raw MDX

### DIFF
--- a/crates/xyd_mdx/src/directives.rs
+++ b/crates/xyd_mdx/src/directives.rs
@@ -233,12 +233,30 @@ pub fn has_raw_mdx(node: &Node) -> bool {
 /// Re-parse a container directive's raw content string as nested flow (the fork
 /// captures content raw; the JS `micromark-directive` subtokenizes it). Returns
 /// the child nodes.
+///
+/// A directive body may contain only prose and *nested directives* (still
+/// `ContainerDirective`/`LeafDirective` at this point — converted afterwards). If
+/// the re-parse surfaces a raw MDX expression / JSX / ESM node, either the author
+/// wrote real MDX or a nested directive failed to parse — e.g. `:::name{attrs}`
+/// inside a `:::tabs`/`:::steps` list item, where the list indentation stops the
+/// fork from recognizing the directive and `{attrs}` then reads as an MDX
+/// expression. Both cases need the JS pipeline, so we return `Err` → the page
+/// falls back. The top-level capability gate can't catch this: the container body
+/// was captured raw, so the leaked node only appears on this re-parse. Without
+/// this guard the leak is emitted as `capability: "full"` — a wrong render (the
+/// bug this fixes), instead of the "honest fallback, never a wrong render" the
+/// crate promises. Prose/simple-directive bodies have no raw MDX, so they still
+/// take the fast path unchanged.
 fn reparse_content(raw: &str, opts: &Options) -> Result<Vec<Node>, String> {
     let root = mdast_util_from_mdx(raw, opts).map_err(|e| format!("directive content: {e}"))?;
-    match root {
-        Node::Root(r) => Ok(r.children),
-        other => Ok(vec![other]),
+    let children = match root {
+        Node::Root(r) => r.children,
+        other => vec![other],
+    };
+    if children.iter().any(has_raw_mdx) {
+        return Err("directive body contains raw mdx".to_string());
     }
+    Ok(children)
 }
 
 /// Extract the raw content string a container directive captured (single `Text`

--- a/crates/xyd_mdx/src/lib.rs
+++ b/crates/xyd_mdx/src/lib.rs
@@ -171,6 +171,36 @@ mod tests {
     }
 
     #[test]
+    fn directive_nested_in_tabs_list_item_falls_back() {
+        // Regression: a directive nested inside a `:::tabs` list item is not
+        // recognized by the fork (the list indentation defeats directive
+        // parsing), so its `{attrs}` re-parse as an MDX expression. `build_nav`
+        // re-parses the tab body WITHOUT the top-level capability gate, so before
+        // the `reparse_content` guard the leaked expression shipped as
+        // `capability: "full"` — a wrong render (`title = "…"` as an
+        // undefined-variable reference that 500s at runtime). Now it falls back
+        // and the JS pipeline renders the page.
+        let src = r#":::::tabs{kind="secondary"}
+1. [SDK](platform=sdk)
+
+    :::code-group{title="Init LiveSession Browser"}
+    ```ts sdk
+    a
+    ```
+    :::
+:::::
+"#;
+        let out = compile_mdx(src, "{}", "");
+        assert_eq!(out.capability, CAP_FALLBACK, "reason={:?}", out.reason);
+        // Belt-and-suspenders: never emit the leaked assignment expression.
+        assert!(
+            !out.compiled.contains("title ="),
+            "leaked expression:\n{}",
+            out.compiled
+        );
+    }
+
+    #[test]
     fn math_inline_and_block_compile_full() {
         // Rust-native math: inline `$…$` and block `$$…$$` now compile `full` to
         // MathML (no more `fallback` for math).


### PR DESCRIPTION
A `:::code-group{title="…"}` (or any directive) nested inside a `:::tabs` list item was mis-compiled as `capability: "full"` with the `{title="…"}` leaked as an MDX expression (`title = "…"`) — an undefined-variable reference that 500s at render time (`ReferenceError: title is not defined`).

Cause: the list indentation defeats the fork's directive recognition, so the directive's `{attrs}` re-parse as an MDX expression. The top-level capability gate (`has_raw_mdx`) can't see it because the `:::tabs` body is captured raw and only re-parsed later inside `build_nav`/`build_steps`/… via `reparse_content`, which did not re-apply the gate.

Fix: `reparse_content` now returns `Err` (→ honest fallback to the JS pipeline) when a re-parsed directive body contains a raw MDX expression/JSX/ESM node — matching the crate's "never a wrong render" contract. Prose and simple-directive bodies have no raw MDX, so they keep the Rust fast path unchanged.

Verified: the real docs page (`:::tabs` → list → `:::code-group`) now returns `fallback` and renders via the JS pipeline (HTTP 200) instead of the 500; the fast path is preserved for callout/steps/table/top-level code-group. Adds a regression test.