### PR TITLE
feat(navigation): dropdownMenu nested menus on anchors & tabs

### DIFF
--- a/__tests__/e2e/1.navigation/2.dropdown-menu/changelog.md
+++ b/__tests__/e2e/1.navigation/2.dropdown-menu/changelog.md
@@ -1,0 +1,5 @@
+---
+title: Changelog
+---
+
+# Changelog

--- a/__tests__/e2e/1.navigation/2.dropdown-menu/docs.json
+++ b/__tests__/e2e/1.navigation/2.dropdown-menu/docs.json
@@ -1,0 +1,45 @@
+{
+    "theme": {
+        "name": "opener",
+        "appearance": {
+            "navigationDropdown": {
+                "chevron": "static",
+                "items": "flush"
+            }
+        }
+    },
+    "navigation": {
+        "anchors": {
+            "header": [
+                {
+                    "title": "Products",
+                    "trigger": "hover",
+                    "dropdownMenu": [
+                        { "title": "Browser SDK", "page": "docs/browser" },
+                        { "title": "REST API", "page": "docs/rest" },
+                        {
+                            "title": "Guides",
+                            "dropdownMenu": [
+                                { "title": "Authentication", "page": "docs/auth" }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "title": "Company",
+                    "trigger": "click",
+                    "dropdownMenu": [
+                        { "title": "Changelog", "page": "changelog" }
+                    ]
+                }
+            ]
+        },
+        "sidebar": [
+            "overview",
+            "docs/browser",
+            "docs/rest",
+            "docs/auth",
+            "changelog"
+        ]
+    }
+}

--- a/__tests__/e2e/1.navigation/2.dropdown-menu/docs/auth.md
+++ b/__tests__/e2e/1.navigation/2.dropdown-menu/docs/auth.md
@@ -1,0 +1,5 @@
+---
+title: Authentication
+---
+
+# Authentication

--- a/__tests__/e2e/1.navigation/2.dropdown-menu/docs/browser.md
+++ b/__tests__/e2e/1.navigation/2.dropdown-menu/docs/browser.md
@@ -1,0 +1,5 @@
+---
+title: Browser SDK
+---
+
+# Browser SDK

--- a/__tests__/e2e/1.navigation/2.dropdown-menu/docs/rest.md
+++ b/__tests__/e2e/1.navigation/2.dropdown-menu/docs/rest.md
@@ -1,0 +1,5 @@
+---
+title: REST API
+---
+
+# REST API

--- a/__tests__/e2e/1.navigation/2.dropdown-menu/dropdown-menu.test.ts
+++ b/__tests__/e2e/1.navigation/2.dropdown-menu/dropdown-menu.test.ts
@@ -1,0 +1,132 @@
+import { test, expect, Page } from '@playwright/test';
+
+import { createXydBunServer, XydServer } from '../../utils/xyd-server';
+
+// The `dropdownMenu` nav feature ships on the Rust+bun engine — run against it.
+test.describe('navigation — dropdownMenu (bun engine)', () => {
+    let server: XydServer;
+
+    test.beforeAll(async () => {
+        server = await createXydBunServer(__dirname);
+    });
+
+    test.afterAll(async () => {
+        await server.stop();
+    });
+
+    const trigger = (page: Page, label: string) =>
+        page.locator('[part="dropdown-trigger"]', { hasText: label });
+    const item = (page: Page, label: string) =>
+        page.locator('[part="dropdown-item"]', { hasText: label });
+
+    async function open(page: Page) {
+        await page.goto(server.getUrl('/overview'));
+        await page.waitForLoadState('networkidle');
+    }
+
+    test('renders both dropdown triggers (SSR + hydrate)', async ({ page }) => {
+        await open(page);
+        await expect(page.locator('[data-fw-nav-dropdown]')).toHaveCount(2);
+        await expect(trigger(page, 'Products')).toBeVisible();
+        await expect(trigger(page, 'Company')).toBeVisible();
+    });
+
+    test('trigger:"hover" opens the menu on hover', async ({ page }) => {
+        await open(page);
+        await trigger(page, 'Products').hover();
+        await expect(item(page, 'Browser SDK')).toBeVisible();
+        await expect(item(page, 'REST API')).toBeVisible();
+    });
+
+    test('appearance.navigationDropdown.chevron:"static" does not rotate the open chevron', async ({ page }) => {
+        await open(page);
+        await trigger(page, 'Products').hover();
+        await expect(item(page, 'Browser SDK')).toBeVisible(); // menu open → trigger data-state="open"
+        const chevron = trigger(page, 'Products').locator('[part="dropdown-chevron"]');
+        // static → rotate(0deg) → identity matrix. A rotating chevron would be matrix(-1, …).
+        const transform = await chevron.evaluate((el) => getComputedStyle(el).transform);
+        expect(['none', 'matrix(1, 0, 0, 1, 0, 0)']).toContain(transform);
+    });
+
+    test('appearance.navigationDropdown.items:"flush" gives edge-to-edge rows with bigger padding', async ({ page }) => {
+        await open(page);
+        await trigger(page, 'Products').hover();
+        const rest = item(page, 'REST API');
+        await expect(rest).toBeVisible();
+        await expect(rest).toHaveCSS('padding-left', '16px');
+        await expect(rest).toHaveCSS('padding-top', '10px');
+    });
+
+    test('trigger and menu items use a pointer cursor', async ({ page }) => {
+        await open(page);
+        const t = trigger(page, 'Products');
+        await expect(t).toHaveCSS('cursor', 'pointer');
+        await t.hover();
+        const sdk = item(page, 'Browser SDK');
+        await expect(sdk).toBeVisible();
+        await expect(sdk).toHaveCSS('cursor', 'pointer');
+    });
+
+    test('opened menu is within the viewport (not clipped)', async ({ page }) => {
+        await open(page);
+        await trigger(page, 'Products').hover();
+        const list = page.locator('[part="dropdown-list"]').first();
+        await expect(list).toBeVisible();
+        const box = await list.boundingBox();
+        const vw = page.viewportSize()!;
+        expect(box).not.toBeNull();
+        // The menu must sit inside the viewport (a clipped/off-screen menu fails here).
+        expect(box!.x).toBeGreaterThanOrEqual(-1);
+        expect(box!.y).toBeGreaterThanOrEqual(-1);
+        expect(box!.x + box!.width).toBeLessThanOrEqual(vw.width + 1);
+        expect(box!.height).toBeGreaterThan(0);
+    });
+
+    test('menu stays open moving pointer from trigger into it', async ({ page }) => {
+        await open(page);
+        await trigger(page, 'Products').hover();
+        const sdk = item(page, 'Browser SDK');
+        await expect(sdk).toBeVisible();
+        // Move the pointer down into the menu with a human-like pause; the menu
+        // must NOT flicker closed (the bug this fixes).
+        await page.waitForTimeout(250);
+        await sdk.hover();
+        await page.waitForTimeout(250);
+        await expect(sdk).toBeVisible();
+    });
+
+    test('trigger:"click" opens on click, not on hover', async ({ page }) => {
+        await open(page);
+        // hover must NOT open a click-triggered menu
+        await trigger(page, 'Company').hover();
+        await expect(item(page, 'Changelog')).toHaveCount(0);
+        // click opens it
+        await trigger(page, 'Company').click();
+        await expect(item(page, 'Changelog')).toBeVisible();
+    });
+
+    test('multi-level submenu opens', async ({ page }) => {
+        await open(page);
+        await trigger(page, 'Products').hover();
+        const guides = page.locator('[part="dropdown-item"][data-has-submenu]', { hasText: 'Guides' });
+        await expect(guides).toBeVisible();
+        await guides.hover();
+        await expect(item(page, 'Authentication')).toBeVisible();
+    });
+
+    test('selecting a leaf item navigates', async ({ page }) => {
+        await open(page);
+        await trigger(page, 'Products').hover();
+        await item(page, 'Browser SDK').click();
+        await page.waitForURL(/\/docs\/browser$/);
+        await expect(page.locator('h1')).toContainText('Browser SDK');
+    });
+
+    test('Escape closes the menu', async ({ page }) => {
+        await open(page);
+        await trigger(page, 'Company').click();
+        await expect(item(page, 'Changelog')).toBeVisible();
+        await page.keyboard.press('Escape');
+        await expect(item(page, 'Changelog')).toHaveCount(0);
+    });
+});

--- a/__tests__/e2e/1.navigation/2.dropdown-menu/overview.md
+++ b/__tests__/e2e/1.navigation/2.dropdown-menu/overview.md
@@ -1,0 +1,7 @@
+---
+title: Overview
+---
+
+# Overview
+
+Nav dropdown menu demo.

--- a/__tests__/e2e/utils/xyd-server.ts
+++ b/__tests__/e2e/utils/xyd-server.ts
@@ -287,4 +287,16 @@ export async function createXydBuildServer(templateDir: string, options: Omit<Xy
     });
     await server.start();
     return server;
-} 
+}
+
+// Helper: dev server on the NEW Rust+bun engine (XYD_BUN=1). Use for features
+// that only ship on the bun engine (the Vite/React-Router path is deprecating).
+export async function createXydBunServer(testDirPath: string, options: Omit<XydServerOptions, 'testDir'> = {}): Promise<XydServer> {
+    const server = new XydServer({
+        ...options,
+        testDir: path.resolve(testDirPath),
+        env: { XYD_BUN: '1', ...(options.env || {}) },
+    });
+    await server.start();
+    return server;
+}

--- a/apps/docs/guides/appearance.md
+++ b/apps/docs/guides/appearance.md
@@ -236,7 +236,7 @@ Customize content appearance and navigation elements:
 ```
 ::atlas{apiRefItemKind="secondary" references="@uniform('@core/types/settings.ts', {mini: 'AppearanceContent'})"}
 
-## Navigation Dropdown
+## Navigation Dropdown {label="Coming Soon"}
 Style the [dropdown menus](/guides/navigation) on header anchors and tabs (the
 `dropdownMenu` feature).
 
@@ -258,46 +258,3 @@ Style the [dropdown menus](/guides/navigation) on header anchors and tabs (the
 - **`items`** — `"flush"` makes the hovered item background touch all four edges of
   the popover (no surrounding padding); `"padded"` (default) keeps a small inset with
   rounded item corners.
-
-### Advanced: CSS variables
-For finer control, set the underlying variables via [`cssTokens`](#css-tokens) — e.g.
-rotate the chevron a quarter turn:
-```json
-{
-    "theme": {
-        "appearance": {
-            "cssTokens": {
-                "--xyd-nav-dropdown-chevron-rotate": "90deg"
-            }
-        }
-    }
-}
-```
-
-| Variable | Default | What it controls |
-|---|---|---|
-| `--xyd-nav-dropdown-chevron-rotate` | `180deg` | Trigger chevron rotation when open (`0deg` disables) |
-| `--xyd-nav-dropdown-padding` | `6px` | Padding around the menu panel |
-| `--xyd-nav-dropdown-gap` | `2px` | Gap between items |
-| `--xyd-nav-dropdown-item-radius` | small | Item corner radius |
-| `--xyd-nav-dropdown-item-padding` | `6px 8px` | Per-item padding (bumped to `10px 16px` when `items: "flush"`) |
-| `--xyd-nav-dropdown-bgcolor` | content bg | Menu panel background |
-| `--xyd-nav-dropdown-border-color` | header border | Menu panel border |
-| `--xyd-nav-dropdown-shadow` | soft shadow | Menu panel shadow |
-| `--xyd-nav-dropdown-item-bgcolor--hover` | subtle | Hovered/active item background |
-
-For anything beyond tokens, target the custom elements directly (in a custom
-stylesheet or theme):
-
-| Element / part | What it is |
-|---|---|
-| `xyd-nav-dropdown` | the dropdown host (trigger + menu) |
-| `[part="dropdown-trigger"]` | the trigger (anchor/tab label) |
-| `xyd-nav-dropdown-menu` | the menu panel (popover content + each submenu) |
-| `xyd-nav-dropdown-item` | a menu item / submenu trigger |
-| `[part="dropdown-icon"]` · `[part="dropdown-label"]` · `[part="dropdown-description"]` · `[part="dropdown-submenu-indicator"]` | item internals |
-
-```css
-xyd-nav-dropdown-menu { border-radius: 12px; }
-xyd-nav-dropdown-item { font-size: 14px; }
-```

--- a/apps/docs/guides/appearance.md
+++ b/apps/docs/guides/appearance.md
@@ -235,3 +235,69 @@ Customize content appearance and navigation elements:
 }
 ```
 ::atlas{apiRefItemKind="secondary" references="@uniform('@core/types/settings.ts', {mini: 'AppearanceContent'})"}
+
+## Navigation Dropdown
+Style the [dropdown menus](/guides/navigation) on header anchors and tabs (the
+`dropdownMenu` feature).
+
+```json
+{
+    "theme": {
+        "appearance": {
+            "navigationDropdown": {
+                "chevron": "'rotate' | 'static'",
+                "items": "'padded' | 'flush'"
+            }
+        }
+    }
+}
+```
+::atlas{apiRefItemKind="secondary" references="@uniform('@core/types/settings.ts', {mini: 'AppearanceNavigationDropdown'})"}
+
+- **`chevron`** — trigger chevron behavior when open: `"rotate"` (default) flips it, `"static"` leaves it unchanged.
+- **`items`** — `"flush"` makes the hovered item background touch all four edges of
+  the popover (no surrounding padding); `"padded"` (default) keeps a small inset with
+  rounded item corners.
+
+### Advanced: CSS variables
+For finer control, set the underlying variables via [`cssTokens`](#css-tokens) — e.g.
+rotate the chevron a quarter turn:
+```json
+{
+    "theme": {
+        "appearance": {
+            "cssTokens": {
+                "--xyd-nav-dropdown-chevron-rotate": "90deg"
+            }
+        }
+    }
+}
+```
+
+| Variable | Default | What it controls |
+|---|---|---|
+| `--xyd-nav-dropdown-chevron-rotate` | `180deg` | Trigger chevron rotation when open (`0deg` disables) |
+| `--xyd-nav-dropdown-padding` | `6px` | Padding around the menu panel |
+| `--xyd-nav-dropdown-gap` | `2px` | Gap between items |
+| `--xyd-nav-dropdown-item-radius` | small | Item corner radius |
+| `--xyd-nav-dropdown-item-padding` | `6px 8px` | Per-item padding (bumped to `10px 16px` when `items: "flush"`) |
+| `--xyd-nav-dropdown-bgcolor` | content bg | Menu panel background |
+| `--xyd-nav-dropdown-border-color` | header border | Menu panel border |
+| `--xyd-nav-dropdown-shadow` | soft shadow | Menu panel shadow |
+| `--xyd-nav-dropdown-item-bgcolor--hover` | subtle | Hovered/active item background |
+
+For anything beyond tokens, target the custom elements directly (in a custom
+stylesheet or theme):
+
+| Element / part | What it is |
+|---|---|
+| `xyd-nav-dropdown` | the dropdown host (trigger + menu) |
+| `[part="dropdown-trigger"]` | the trigger (anchor/tab label) |
+| `xyd-nav-dropdown-menu` | the menu panel (popover content + each submenu) |
+| `xyd-nav-dropdown-item` | a menu item / submenu trigger |
+| `[part="dropdown-icon"]` · `[part="dropdown-label"]` · `[part="dropdown-description"]` · `[part="dropdown-submenu-indicator"]` | item internals |
+
+```css
+xyd-nav-dropdown-menu { border-radius: 12px; }
+xyd-nav-dropdown-item { font-size: 14px; }
+```

--- a/apps/docs/guides/navigation.md
+++ b/apps/docs/guides/navigation.md
@@ -423,6 +423,71 @@ Anchors provide a way to add fixed navigation elements. They're useful for displ
   ::atlas{apiRefItemKind="secondary" references="@uniform('@core/types/settings.ts', {mini: 'Anchors'})"}
 ::::
 
+## Dropdown Menu {label="Coming Soon"}
+
+Turn a **header anchor** or a **tab** into a nested menu with `dropdownMenu`. Each entry is a [Navigation Item](/reference/core/navigationitem); an entry that itself declares `dropdownMenu` becomes a **submenu**, so menus can nest to multiple levels.
+
+Use `trigger` to control how the menu opens — `"hover"` (default) or `"click"`.
+
+:::tabs
+1. [Anchor](dropdownmenu=anchor)
+    ```json [!scroll]
+    {
+      "navigation": {
+        "anchors": {
+          "header": [
+            {
+              // !diff +
+              "title": "Products",
+              // !diff +
+              "trigger": "hover",
+              // !diff +
+              "dropdownMenu": [
+                {
+                  "title": "Browser SDK",
+                  "dropdownMenu": [
+                    { "title": "Install", "page": "docs/browser/install" },
+                    { "title": "Methods", "page": "docs/browser/methods" }
+                  ]
+                },
+                { "title": "REST API", "page": "docs/rest" },
+                { "title": "GraphQL", "page": "docs/graphql" }
+              ]
+            }
+          ]
+        }
+      }
+    }
+    ```
+
+2. [Tab](dropdownmenu=tab)
+    ```json [!scroll]
+    {
+      "navigation": {
+        "tabs": [
+          { "title": "Overview", "page": "overview" },
+          {
+            // !diff +
+            "title": "API Reference",
+            // !diff +
+            "trigger": "hover",
+            // !diff +
+            "dropdownMenu": [
+              { "title": "Browser SDK", "page": "docs/browser" },
+              { "title": "REST API", "page": "docs/rest" },
+              { "title": "GraphQL", "page": "docs/graphql" }
+            ]
+          }
+        ]
+      }
+    }
+    ```
+:::
+
+:::callout{kind="tip"}
+Style the dropdown — chevron rotation, edge-to-edge items, colors — via [`appearance.navigationDropdown`](/guides/appearance#navigation-dropdown).
+:::
+
 ## Segments {label="Experimental"}
 
 ![asset](/public/assets/Segments.png)

--- a/apps/docs/public/docs.json
+++ b/apps/docs/public/docs.json
@@ -98,6 +98,10 @@
           "$ref": "#/definitions/APIInfo",
           "description": "API information configuration"
         },
+        "options": {
+          "$ref": "#/definitions/APIFileOptions",
+          "description": "Preset-specific rendering options (e.g. CLI)."
+        },
         "route": {
           "description": "Route configuration",
           "type": "string"
@@ -124,6 +128,17 @@
         ]
       },
       "description": "API file map type",
+      "type": "object"
+    },
+    "APIFileOptions": {
+      "additionalProperties": false,
+      "description": "Preset-specific rendering options for an API source.",
+      "properties": {
+        "globalOptionsPerCommand": {
+          "description": "(CLI) Render the CLI's global options on every command page. When `false` (the default), the global options are rendered once as a dedicated \"Global options\" page in the sidebar instead of repeated on each command.",
+          "type": "boolean"
+        }
+      },
       "type": "object"
     },
     "APIInfo": {
@@ -809,6 +824,10 @@
           "$ref": "#/definitions/AppearanceLogo",
           "description": "Logo appearance for the theme."
         },
+        "navigationDropdown": {
+          "$ref": "#/definitions/AppearanceNavigationDropdown",
+          "description": "Navigation dropdown appearance (header anchors & tabs `dropdownMenu`)."
+        },
         "presets": {
           "description": "Presets for the theme.",
           "items": {
@@ -967,6 +986,28 @@
             }
           ],
           "description": "If `true` then the logo will be displayed on the sidebar."
+        }
+      },
+      "type": "object"
+    },
+    "AppearanceNavigationDropdown": {
+      "additionalProperties": false,
+      "properties": {
+        "chevron": {
+          "description": "Trigger chevron behavior when the menu is open. `\"rotate\"` (default) flips the chevron; `\"static\"` leaves it unchanged.",
+          "enum": [
+            "rotate",
+            "static"
+          ],
+          "type": "string"
+        },
+        "items": {
+          "description": "Menu item layout. `\"flush\"` makes the hovered item background touch all four edges of the popover (no surrounding padding); `\"padded\"` (default) keeps a small inset with rounded item corners.",
+          "enum": [
+            "padded",
+            "flush"
+          ],
+          "type": "string"
         }
       },
       "type": "object"
@@ -2119,6 +2160,13 @@
           "description": "The navigation item description",
           "type": "string"
         },
+        "dropdownMenu": {
+          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs.",
+          "items": {
+            "$ref": "#/definitions/NavigationItem"
+          },
+          "type": "array"
+        },
         "href": {
           "description": "The navigation href, if set it redirects but does not match based on routing",
           "type": "string"
@@ -2140,6 +2188,14 @@
         },
         "title": {
           "description": "The navigation item title",
+          "type": "string"
+        },
+        "trigger": {
+          "description": "How the `dropdownMenu` opens. Defaults to `\"hover\"`.",
+          "enum": [
+            "hover",
+            "click"
+          ],
           "type": "string"
         }
       },
@@ -2159,6 +2215,13 @@
           "description": "The navigation item description",
           "type": "string"
         },
+        "dropdownMenu": {
+          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs.",
+          "items": {
+            "$ref": "#/definitions/NavigationItem"
+          },
+          "type": "array"
+        },
         "href": {
           "description": "The navigation href, if set it redirects but does not match based on routing",
           "type": "string"
@@ -2181,6 +2244,14 @@
         "title": {
           "description": "The navigation item title",
           "type": "string"
+        },
+        "trigger": {
+          "description": "How the `dropdownMenu` opens. Defaults to `\"hover\"`.",
+          "enum": [
+            "hover",
+            "click"
+          ],
+          "type": "string"
         }
       },
       "required": [
@@ -2194,6 +2265,13 @@
         "description": {
           "description": "The navigation item description",
           "type": "string"
+        },
+        "dropdownMenu": {
+          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs.",
+          "items": {
+            "$ref": "#/definitions/NavigationItem"
+          },
+          "type": "array"
         },
         "href": {
           "description": "The navigation href, if set it redirects but does not match based on routing",
@@ -2219,6 +2297,14 @@
         },
         "title": {
           "description": "The navigation item title",
+          "type": "string"
+        },
+        "trigger": {
+          "description": "How the `dropdownMenu` opens. Defaults to `\"hover\"`.",
+          "enum": [
+            "hover",
+            "click"
+          ],
           "type": "string"
         }
       },
@@ -3067,6 +3153,13 @@
           "description": "If `true` then the item will be displayed on desktop.",
           "type": "boolean"
         },
+        "dropdownMenu": {
+          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs.",
+          "items": {
+            "$ref": "#/definitions/NavigationItem"
+          },
+          "type": "array"
+        },
         "float": {
           "description": "Float the header to the right",
           "enum": [
@@ -3105,6 +3198,14 @@
         "title": {
           "description": "The navigation item title",
           "type": "string"
+        },
+        "trigger": {
+          "description": "How the `dropdownMenu` opens. Defaults to `\"hover\"`.",
+          "enum": [
+            "hover",
+            "click"
+          ],
+          "type": "string"
         }
       },
       "type": "object"
@@ -3124,6 +3225,13 @@
         "desktop": {
           "description": "If `true` then the item will be displayed on desktop.",
           "type": "boolean"
+        },
+        "dropdownMenu": {
+          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs.",
+          "items": {
+            "$ref": "#/definitions/NavigationItem"
+          },
+          "type": "array"
         },
         "href": {
           "description": "The navigation href, if set it redirects but does not match based on routing",
@@ -3154,6 +3262,14 @@
         },
         "title": {
           "description": "The navigation item title",
+          "type": "string"
+        },
+        "trigger": {
+          "description": "How the `dropdownMenu` opens. Defaults to `\"hover\"`.",
+          "enum": [
+            "hover",
+            "click"
+          ],
           "type": "string"
         }
       },

--- a/packages/xyd-core/src/types/settings.ts
+++ b/packages/xyd-core/src/types/settings.ts
@@ -315,6 +315,11 @@ export interface Appearance {
    * Footer appearance for the theme.
    */
   footer?: AppearanceFooter;
+
+  /**
+   * Navigation dropdown appearance (header anchors & tabs `dropdownMenu`).
+   */
+  navigationDropdown?: AppearanceNavigationDropdown;
 }
 
 export interface Colors {
@@ -453,6 +458,21 @@ export interface AppearanceSidebar {
 
 export interface AppearanceButtons {
   rounded?: boolean | "lg" | "md" | "sm";
+}
+
+export interface AppearanceNavigationDropdown {
+  /**
+   * Trigger chevron behavior when the menu is open. `"rotate"` (default) flips the
+   * chevron; `"static"` leaves it unchanged.
+   */
+  chevron?: "rotate" | "static";
+
+  /**
+   * Menu item layout. `"flush"` makes the hovered item background touch all four
+   * edges of the popover (no surrounding padding); `"padded"` (default) keeps a
+   * small inset with rounded item corners.
+   */
+  items?: "padded" | "flush";
 }
 
 export interface AppearanceTables {
@@ -763,6 +783,20 @@ export interface NavigationItem {
    * The navigation item icon
    */
   icon?: string | React.ReactNode;
+
+  /**
+   * Nested navigation rendered as a dropdown menu under this item.
+   *
+   * Recursive — a child may itself declare `dropdownMenu` to create submenus
+   * (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors
+   * and tabs.
+   */
+  dropdownMenu?: NavigationItem[];
+
+  /**
+   * How the `dropdownMenu` opens. Defaults to `"hover"`.
+   */
+  trigger?: "hover" | "click";
 }
 
 export type NavigationItemButton = NavigationItem & {

--- a/packages/xyd-documan/src/bun/renderPage.tsx
+++ b/packages/xyd-documan/src/bun/renderPage.tsx
@@ -13,6 +13,7 @@ import { seedGlobals, ShellProviders, getSettings, getSettingsClone, matchRoute,
 import { metaTagsHtml, robotsTxt, sitemapXml, sitemapRoutes } from "./seo";
 import { themePackage, themeShortName } from "./themePkg";
 import { stripReactElements, settingsBundleJs } from "./serialize";
+import { userAppearanceStyle } from "./userCss";
 import { resolveShellOnly, authFromCookie, accessAllowed, pageAccess } from "./accessControl";
 import { matchPluginPage, pluginPageMeta } from "./pluginPages";
 export { stripReactElements }; // re-exported for existing consumers
@@ -73,6 +74,8 @@ function renderShell({ settings, bodyHtml, data }: any): string {
     `<link rel="stylesheet" href="/_xyd/components.css">` +
     `<link rel="stylesheet" href="/_xyd/atlas.css">` +
     `<link rel="stylesheet" href="/_xyd/ui.css">` +
+    // theme.appearance overrides (colors + cssTokens) — parity with the Vite path.
+    userAppearanceStyle(settings) +
     themeHeadHtml(settings) +
     `</head><body>` +
     `<div id="root">${bodyHtml}</div>` +
@@ -393,6 +396,8 @@ function renderStaticShell({ settings, bodyHtml, data }: any): string {
     (favicon ? `<link rel="icon" href="${esc(favicon)}">` : "") +
     `<style>${layer}</style>` + // @layer declaration before the layer-using stylesheets
     (a?.cssLinks || []).map((h: string) => `<link rel="stylesheet" href="${h}">`).join("") +
+    // theme.appearance overrides (colors + cssTokens) — parity with the Vite path.
+    userAppearanceStyle(settings) +
     themeHeadHtml(settings) +
     `</head><body>` +
     `<div id="root">${bodyHtml}</div>` +

--- a/packages/xyd-documan/src/bun/userCss.ts
+++ b/packages/xyd-documan/src/bun/userCss.ts
@@ -1,0 +1,94 @@
+// User appearance CSS for the bun engine — parity with the Vite path
+// (`packages/xyd-host/app/root.tsx` `generateUserCss`). Turns
+// `theme.appearance.colors` + `theme.appearance.cssTokens` into a `:root` (+ dark)
+// custom-property block that is injected as `<style data-appearance>` in the SSR
+// head. Kept as a standalone copy so the Vite path stays untouched; the two
+// should be kept in sync.
+
+import type { Appearance } from "@xyd-js/core";
+
+function tokensToCss(
+    tokens: Record<string, string | boolean | undefined>,
+    wrapInRoot = true,
+): string {
+    const entries = Object.entries(tokens).filter(([, value]) => value !== undefined);
+    if (!entries.length) return "";
+    const props = entries.map(([key, value]) => `${key}: ${value};`).join("\n");
+    return wrapInRoot ? `:root {\n${props}\n}` : props;
+}
+
+function generateColorTokens(primary: string): Record<string, string> {
+    return {
+        "--color-primary": primary,
+        "--xyd-sidebar-item-bgcolor--active": "color-mix(in srgb, var(--color-primary) 10%, transparent)",
+        "--xyd-sidebar-item-color--active": "var(--color-primary)",
+        "--xyd-sidebar-item-bgcolor--active-hover": "var(--xyd-sidebar-item-bgcolor--active)",
+        "--xyd-toc-item-color--active": "var(--color-primary)",
+        "--theme-color-primary": "var(--color-primary)",
+        "--theme-color-primary-active": "var(--color-primary)",
+        "--color-primary--active": "color-mix(in srgb, var(--color-primary) 75%, transparent)",
+        "--xyd-breadcrumbs-color": "var(--color-primary)",
+    };
+}
+
+function generateDarkCss(tokens: Record<string, string>): string {
+    if (!Object.keys(tokens).length) return "";
+    const raw = tokensToCss(tokens, false);
+    return [
+        `[data-color-scheme="dark"] {\n${raw}\n}`,
+        `@media (prefers-color-scheme: dark) {`,
+        `    :root:not([data-color-scheme="light"]):not([data-color-scheme="dark"]) {\n        ${raw.replace(/\n/g, "\n        ")}\n    }`,
+        `}`,
+    ].join("\n");
+}
+
+/**
+ * Map the typed `appearance.dropdown` flags to the technical `--xyd-nav-dropdown-*`
+ * variables — so consumers set one informative flag instead of raw tokens.
+ * (`cssTokens` still wins, since it is merged after this.)
+ */
+function dropdownTokens(appearance: any): Record<string, string> {
+    const d = appearance?.navigationDropdown;
+    if (!d) return {};
+    const t: Record<string, string> = {};
+    if (d.items === "flush") {
+        // Hovered item background touches all four edges of the popover. Bump the
+        // per-item padding so full-bleed rows don't look cramped against the edges.
+        t["--xyd-nav-dropdown-padding"] = "0";
+        t["--xyd-nav-dropdown-gap"] = "0";
+        t["--xyd-nav-dropdown-item-radius"] = "0";
+        t["--xyd-nav-dropdown-item-padding"] = "10px 16px";
+    }
+    if (d.chevron === "static") {
+        t["--xyd-nav-dropdown-chevron-rotate"] = "0deg";
+    }
+    return t;
+}
+
+/** `theme.appearance` → CSS (colors + dropdown flags + cssTokens, light + dark), or `""`. */
+export function generateUserCss(appearance?: Appearance): string {
+    if (!appearance) return "";
+    const { colors, cssTokens } = appearance as any;
+    const dropdown = dropdownTokens(appearance);
+
+    const lightTokens = {
+        ...(colors?.primary ? generateColorTokens(colors.primary) : {}),
+        ...dropdown,
+        ...(cssTokens || {}),
+    };
+    const darkTokens = {
+        ...(colors?.light ? generateColorTokens(colors.light) : {}),
+        ...dropdown,
+        ...(cssTokens || {}),
+    };
+
+    const lightCss = tokensToCss(lightTokens);
+    const darkCss = generateDarkCss(darkTokens);
+    return [lightCss, darkCss].filter(Boolean).join("\n\n");
+}
+
+/** `<style data-appearance>` for the SSR head, or `""` when there is nothing to add. */
+export function userAppearanceStyle(settings: any): string {
+    const css = generateUserCss(settings?.theme?.appearance);
+    return css ? `<style data-appearance>${css}</style>` : "";
+}

--- a/packages/xyd-framework/__tests__/navDropdown.test.ts
+++ b/packages/xyd-framework/__tests__/navDropdown.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+
+import type { NavigationItem } from "@xyd-js/core";
+
+import {
+    resolveDropdownItems,
+    resolveDropdownHref,
+} from "../packages/react/utils/navDropdown";
+
+describe("resolveDropdownHref", () => {
+    it("resolves a page to a routed link", () => {
+        expect(resolveDropdownHref({ page: "docs/api/browser" })).toBe("/docs/api/browser");
+    });
+
+    it("keeps an href verbatim (external)", () => {
+        expect(resolveDropdownHref({ href: "https://x.dev" })).toBe("https://x.dev");
+    });
+
+    it("prefers href over page", () => {
+        expect(resolveDropdownHref({ href: "/a", page: "b" })).toBe("/a");
+    });
+
+    it("returns null for a menu-only (group) item", () => {
+        expect(resolveDropdownHref({ title: "API" })).toBeNull();
+    });
+});
+
+describe("resolveDropdownItems", () => {
+    it("resolves a flat menu (api → Browser SDK / REST / GraphQL)", () => {
+        const items: NavigationItem[] = [
+            { title: "Browser SDK", page: "docs/api/browser" },
+            { title: "REST API", page: "docs/api/rest" },
+            { title: "GraphQL", href: "https://graphql.example.com" },
+        ];
+
+        expect(resolveDropdownItems(items)).toEqual([
+            { title: "Browser SDK", description: undefined, href: "/docs/api/browser", value: "docs/api/browser", icon: undefined, items: undefined },
+            { title: "REST API", description: undefined, href: "/docs/api/rest", value: "docs/api/rest", icon: undefined, items: undefined },
+            { title: "GraphQL", description: undefined, href: "https://graphql.example.com", value: "https://graphql.example.com", icon: undefined, items: undefined },
+        ]);
+    });
+
+    it("resolves multi-level submenus recursively", () => {
+        const items: NavigationItem[] = [
+            {
+                title: "Browser SDK",
+                dropdownMenu: [
+                    { title: "Install", page: "docs/api/browser/install" },
+                    {
+                        title: "Methods",
+                        dropdownMenu: [{ title: "identify", page: "docs/api/browser/identify" }],
+                    },
+                ],
+            },
+        ];
+
+        const resolved = resolveDropdownItems(items);
+
+        // Top level: a menu-only group with children, no own href.
+        expect(resolved[0].title).toBe("Browser SDK");
+        expect(resolved[0].href).toBeNull();
+        expect(resolved[0].items).toHaveLength(2);
+
+        // 2nd level.
+        expect(resolved[0].items![0]).toMatchObject({
+            title: "Install",
+            href: "/docs/api/browser/install",
+        });
+        expect(resolved[0].items![0].items).toBeUndefined();
+
+        // 3rd level (recursion).
+        expect(resolved[0].items![1].title).toBe("Methods");
+        expect(resolved[0].items![1].items).toHaveLength(1);
+        expect(resolved[0].items![1].items![0]).toMatchObject({
+            title: "identify",
+            href: "/docs/api/browser/identify",
+        });
+    });
+
+    it("handles an empty / undefined menu", () => {
+        expect(resolveDropdownItems([])).toEqual([]);
+        expect(resolveDropdownItems(undefined as any)).toEqual([]);
+    });
+});

--- a/packages/xyd-framework/packages/react/components/FwHeaderItems.tsx
+++ b/packages/xyd-framework/packages/react/components/FwHeaderItems.tsx
@@ -9,6 +9,7 @@ import { useAppearance } from "../contexts";
 import { FwLink } from "../components";
 import { useHeaderItems } from "../hooks";
 import { WebEditorComponent } from "./WebEditorComponent";
+import { FwNavDropdown } from "./FwNavDropdown";
 
 export function FwHeaderItems() {
     const headerItems = useHeaderItems()
@@ -29,6 +30,12 @@ export function FwHeaderItems() {
 
 export function FwHeaderItem(props: WebEditorHeader) {
     const appearance = useAppearance()
+
+    // Header anchors / center-surface tabs that declare a nested menu render as a
+    // multi-level dropdown (hover default | click) instead of a plain Nav.Item.
+    if (props.dropdownMenu?.length) {
+        return <FwNavDropdown key={keyId(props)} item={props} />
+    }
 
     let href: string | null = null
 

--- a/packages/xyd-framework/packages/react/components/FwNavDropdown.tsx
+++ b/packages/xyd-framework/packages/react/components/FwNavDropdown.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+import type { NavigationItem } from "@xyd-js/core";
+import { Nav } from "@xyd-js/ui";
+
+import { resolveDropdownItems } from "../utils";
+import { FwLink } from "./FwLink";
+
+/**
+ * Renders a nav item that carries `dropdownMenu` as a {@link Nav.Dropdown} — the
+ * shared render path for header anchors (`FwHeaderItem`) and tabs (`FwSubNav`).
+ * Passes `FwLink` so leaf links route through the framework's router-agnostic link
+ * (works under both the bun and Vite engines). Hrefs (incl. nested submenus) are
+ * resolved by the pure `resolveDropdownItems`.
+ */
+export function FwNavDropdown({ item }: { item: NavigationItem }) {
+    return (
+        <Nav.Dropdown
+            title={item.title}
+            icon={item.icon}
+            trigger={item.trigger}
+            items={resolveDropdownItems(item.dropdownMenu || [])}
+            as={FwLink}
+        />
+    );
+}

--- a/packages/xyd-framework/packages/react/components/FwSubNav.tsx
+++ b/packages/xyd-framework/packages/react/components/FwSubNav.tsx
@@ -5,6 +5,7 @@ import { SubNav } from "@xyd-js/ui";
 import { pageLink } from "../utils";
 import { useActiveMatchedSubNav, useMatchedSubNav } from "../hooks";
 import { FwLink } from "./FwLink";
+import { FwNavDropdown } from "./FwNavDropdown";
 
 export function FwSubNav() {
     const matchedSubnav = useMatchedSubNav()
@@ -21,6 +22,14 @@ export function FwSubNav() {
         }}
     >
         {matchedSubnav?.pages?.map((item, index) => {
+            // A tab that declares a nested menu renders as a multi-level dropdown.
+            if (item.dropdownMenu?.length) {
+                return <FwNavDropdown
+                    key={item.title || item.page || item.href || index}
+                    item={item}
+                />
+            }
+
             let href: string | null = null
 
             if (typeof item.href === "string") {

--- a/packages/xyd-framework/packages/react/utils/index.ts
+++ b/packages/xyd-framework/packages/react/utils/index.ts
@@ -9,3 +9,9 @@ export {
 export {
     trailingSlash,
 } from "./trailingSlash"
+
+export {
+    resolveDropdownItems,
+    resolveDropdownHref,
+} from "./navDropdown"
+export type { ResolvedDropdownItem } from "./navDropdown"

--- a/packages/xyd-framework/packages/react/utils/navDropdown.ts
+++ b/packages/xyd-framework/packages/react/utils/navDropdown.ts
@@ -1,0 +1,37 @@
+import type { NavigationItem } from "@xyd-js/core";
+
+import { pageLink } from "./pageLink";
+
+/**
+ * A nav item resolved for rendering in a dropdown menu — its link target is
+ * resolved and its children (`dropdownMenu`) are resolved recursively into
+ * `items` (multi-level submenus). Pure (only depends on {@link pageLink}), so the
+ * multi-level resolution is unit-testable without the UI layer.
+ */
+export interface ResolvedDropdownItem {
+    title?: string;
+    description?: string;
+    href: string | null;
+    value?: string;
+    icon?: NavigationItem["icon"];
+    items?: ResolvedDropdownItem[];
+}
+
+/** Resolve a nav item's link target: `page` → routed link, `href` → verbatim. */
+export function resolveDropdownHref(item: NavigationItem): string | null {
+    if (typeof item.href === "string") return pageLink(item.href);
+    if (typeof item.page === "string") return pageLink(item.page);
+    return null;
+}
+
+/** Map config `NavigationItem[]` → resolved dropdown items, recursing into `dropdownMenu`. */
+export function resolveDropdownItems(items: NavigationItem[]): ResolvedDropdownItem[] {
+    return (items || []).map((item) => ({
+        title: item.title,
+        description: item.description,
+        href: resolveDropdownHref(item),
+        value: item.page || item.href || item.title,
+        icon: item.icon,
+        items: item.dropdownMenu?.length ? resolveDropdownItems(item.dropdownMenu) : undefined,
+    }));
+}

--- a/packages/xyd-themes/src/Theme.tsx
+++ b/packages/xyd-themes/src/Theme.tsx
@@ -210,6 +210,19 @@ export abstract class Theme {
                     desktop: true,
                 }
 
+                // A header anchor with a nested menu renders as a multi-level
+                // dropdown (FwHeaderItem → Nav.Dropdown). Keep it a plain header
+                // item (no Button component) so `dropdownMenu`/`trigger` survive.
+                if ("dropdownMenu" in item && item.dropdownMenu?.length) {
+                    this.webeditor.header = this.headerAppend({
+                        ...item,
+                        float: "right" as const,
+                        desktop: true,
+                    })
+
+                    return
+                }
+
                 if ("button" in item) {
                     this.webeditor.header = this.headerAppend({
                         ...button,

--- a/packages/xyd-ui/src/components/Nav/Nav.tsx
+++ b/packages/xyd-ui/src/components/Nav/Nav.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import { Tabs as RadixTabs } from "radix-ui"; // TODO: remove and use separation
 
 import * as cn from "./Nav.styles";
+import { NavDropdown } from "./NavDropdown";
+export type { NavDropdownProps, NavDropdownItem } from "./NavDropdown";
 
 export interface NavProps {
     children: React.ReactNode
@@ -86,6 +88,9 @@ Nav.Item = function NavItem(props: NavItemProps) {
         <Nav.ItemRaw {...props} />
     </RadixTabs.Trigger>
 };
+
+/** Multi-level dropdown nav item (header anchors + tabs). See {@link NavDropdown}. */
+Nav.Dropdown = NavDropdown;
 
 Nav.ItemRaw = function NavItemRaw({ children, href, as, ...rest }: Omit<NavItemProps, "value">) {
     const Link = as || $Link;

--- a/packages/xyd-ui/src/components/Nav/NavDropdown.styles.tsx
+++ b/packages/xyd-ui/src/components/Nav/NavDropdown.styles.tsx
@@ -1,0 +1,146 @@
+import { css } from "@linaria/core";
+
+/** The inline `<xyd-nav-dropdown>` host + its trigger (styled like a nav item). */
+export const DropdownHost = css`
+    @layer defaults {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+
+        [part="dropdown-trigger"] {
+            /* targeted button reset (not \`all: unset\`, which resets the inherited
+               \`cursor\` and can clobber the \`cursor: pointer\` below) */
+            appearance: none;
+            background: none;
+            border: none;
+            outline: none;
+            margin: 0;
+            font: inherit;
+            box-sizing: border-box;
+            cursor: pointer;
+            position: relative;
+            white-space: nowrap;
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            color: var(--xyd-nav-item-color);
+            padding: var(--xyd-nav-item-padding-y) var(--xyd-nav-item-padding);
+            border-radius: var(--xyd-border-radius-medium, 8px);
+
+            &:hover,
+            &[data-state="open"] {
+                color: var(--xyd-nav-item-color--active);
+            }
+
+            &[data-active] {
+                font-weight: var(--xyd-font-weight-semibold, 600);
+                color: var(--xyd-nav-item-color--active);
+            }
+        }
+
+        [part="dropdown-chevron"] {
+            flex: none;
+            transition: transform 0.15s ease;
+        }
+
+        /* Chevron rotation on open. Override the angle (e.g. \`90deg\`, or \`0deg\`
+           to disable) via \`--xyd-nav-dropdown-chevron-rotate\`. */
+        [part="dropdown-trigger"][data-state="open"] [part="dropdown-chevron"] {
+            transform: rotate(var(--xyd-nav-dropdown-chevron-rotate, 180deg));
+        }
+    }
+`;
+
+/** The portaled menu panel (`DropdownMenu.Content` / `SubContent`) + its items. */
+export const DropdownList = css`
+    @layer defaults {
+        z-index: 50;
+        min-width: 180px;
+        max-height: min(70vh, 480px);
+        /* \`overflow: hidden\` (not just -y) so full-bleed item backgrounds are
+           clipped to the panel's rounded corners when padding/gap are set to 0. */
+        overflow: hidden auto;
+        display: flex;
+        flex-direction: column;
+        /* Set \`--xyd-nav-dropdown-padding\` + \`--xyd-nav-dropdown-gap\` to \`0\` for
+           edge-to-edge hovered-item backgrounds (touching all four sides). */
+        gap: var(--xyd-nav-dropdown-gap, 2px);
+        padding: var(--xyd-nav-dropdown-padding, 6px);
+        background: var(--xyd-nav-dropdown-bgcolor, var(--xyd-content-bgcolor, var(--white, #fff)));
+        color: var(--xyd-nav-item-color);
+        border: 1px solid var(--xyd-nav-dropdown-border-color, var(--color-header-border, var(--dark12, rgba(0, 0, 0, 0.08))));
+        border-radius: var(--xyd-border-radius-medium, 8px);
+        box-shadow: var(--xyd-nav-dropdown-shadow, 0 8px 24px rgba(0, 0, 0, 0.12));
+
+        /* Leaf links wrap the item element (link = navigation, custom element =
+           the styled row). \`display: contents\` lets the item behave as a direct
+           full-width child of the menu. */
+        & > a {
+            display: contents;
+            text-decoration: none;
+            color: inherit;
+        }
+
+        [part="dropdown-item"] {
+            /* targeted reset (avoid \`all: unset\` — it wipes the inherited cursor) */
+            appearance: none;
+            background: none;
+            border: none;
+            outline: none;
+            font: inherit;
+            box-sizing: border-box;
+            cursor: pointer;
+            width: 100%;
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: var(--xyd-nav-dropdown-item-padding, 6px 8px);
+            /* Set \`--xyd-nav-dropdown-item-radius: 0\` for square, edge-to-edge rows. */
+            border-radius: var(--xyd-nav-dropdown-item-radius, var(--xyd-border-radius-small, 4px));
+            color: var(--xyd-nav-item-color);
+            text-decoration: none;
+            white-space: nowrap;
+
+            &:hover,
+            &[data-highlighted],
+            &[data-state="open"] {
+                background: var(--xyd-nav-dropdown-item-bgcolor--hover, var(--xyd-sidebar-item-bgcolor--active, rgba(0, 0, 0, 0.05)));
+                color: var(--xyd-nav-item-color--active);
+            }
+
+            &[data-active] {
+                font-weight: var(--xyd-font-weight-semibold, 600);
+                color: var(--xyd-nav-item-color--active);
+            }
+        }
+
+        [part="dropdown-icon"] {
+            flex: none;
+            display: inline-flex;
+            align-items: center;
+        }
+
+        [part="dropdown-label-group"] {
+            display: flex;
+            flex-direction: column;
+            flex: 1;
+            min-width: 0;
+        }
+
+        [part="dropdown-label"] {
+            font-size: var(--xyd-font-size-small, 14px);
+        }
+
+        [part="dropdown-description"] {
+            font-size: var(--xyd-font-size-xsmall, 12px);
+            opacity: 0.7;
+        }
+
+        [part="dropdown-submenu-indicator"] {
+            margin-inline-start: auto;
+            display: inline-flex;
+            align-items: center;
+            opacity: 0.7;
+        }
+    }
+`;

--- a/packages/xyd-ui/src/components/Nav/NavDropdown.tsx
+++ b/packages/xyd-ui/src/components/Nav/NavDropdown.tsx
@@ -1,0 +1,238 @@
+import React, { useRef, useState } from "react";
+import { DropdownMenu } from "radix-ui";
+
+import { Icon } from "@xyd-js/components/writer";
+
+import * as cn from "./NavDropdown.styles";
+
+/**
+ * One entry inside a nav dropdown. Recursive: an entry that carries its own
+ * `items` renders a submenu (multi-level). Leaf entries render as links via the
+ * router-agnostic `as` component supplied by {@link NavDropdownProps}.
+ */
+export interface NavDropdownItem {
+    title?: string;
+    description?: string;
+    /** Resolved link target (the framework resolves `page`/`href` via `pageLink`). */
+    href?: string | null;
+    value?: string;
+    icon?: React.ReactNode | string;
+    active?: boolean;
+    /** Nested entries → a submenu. */
+    items?: NavDropdownItem[];
+}
+
+export interface NavDropdownProps {
+    /** Trigger label. */
+    title?: string;
+    icon?: React.ReactNode | string;
+    /** How the menu opens. Defaults to `"hover"`. */
+    trigger?: "hover" | "click";
+    /** Menu entries (recursive). */
+    items: NavDropdownItem[];
+    /**
+     * Router-agnostic link component used for leaf entries — receives `{ href }`.
+     * The framework passes `FwLink`; falls back to a plain anchor.
+     */
+    as?: React.ElementType;
+    /** Whether the trigger's section is active (a descendant matches the route). */
+    active?: boolean;
+    className?: string;
+}
+
+/** Open after a short hover so a quick sweep across the nav doesn't flash it open. */
+const OPEN_DELAY = 140;
+/** Small close grace so a brief slip off the edge doesn't snap it shut. */
+const CLOSE_DELAY = 120;
+
+function $Link({ children, ...props }: any) {
+    return <a {...props}>{children}</a>;
+}
+
+function IconSlot({ icon }: { icon?: React.ReactNode | string }) {
+    if (!icon) return null;
+    if (typeof icon === "string") {
+        return (
+            <span part="dropdown-icon">
+                <Icon name={icon} size={16} />
+            </span>
+        );
+    }
+    return <span part="dropdown-icon">{icon}</span>;
+}
+
+function Chevron() {
+    return (
+        <svg part="dropdown-chevron" width={10} height={10} viewBox="0 0 10 10" aria-hidden="true">
+            <path
+                d="M2 3.5L5 6.5L8 3.5"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={1.5}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </svg>
+    );
+}
+
+function ChevronRight() {
+    return (
+        <svg part="dropdown-chevron" width={10} height={10} viewBox="0 0 10 10" aria-hidden="true">
+            <path
+                d="M3.5 2L6.5 5L3.5 8"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={1.5}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+            />
+        </svg>
+    );
+}
+
+function ItemBody({ item }: { item: NavDropdownItem }) {
+    return (
+        <>
+            <IconSlot icon={item.icon} />
+            <span part="dropdown-label-group">
+                {item.title && <span part="dropdown-label">{item.title}</span>}
+                {item.description && (
+                    <span part="dropdown-description">{item.description}</span>
+                )}
+            </span>
+        </>
+    );
+}
+
+/**
+ * Render menu entries recursively — submenus for entries that carry `items`.
+ * Content is rendered INLINE (no `DropdownMenu.Portal`) so the whole menu tree is
+ * a DOM descendant of the dropdown host; that is what makes the hover zone one
+ * contiguous element (see {@link NavDropdown}).
+ */
+function renderItems(items: NavDropdownItem[], as?: React.ElementType) {
+    const Link = as || $Link;
+    return items.map((item, i) => {
+        const key = `${item.value || item.href || item.title || "."}-${i}`;
+
+        if (item.items && item.items.length) {
+            return (
+                <DropdownMenu.Sub key={key}>
+                    {/* `asChild` → the styleable custom element IS the submenu trigger. */}
+                    <DropdownMenu.SubTrigger asChild>
+                        <xyd-nav-dropdown-item
+                            part="dropdown-item"
+                            data-has-submenu=""
+                            data-active={item.active || undefined}
+                        >
+                            <ItemBody item={item} />
+                            <span part="dropdown-submenu-indicator">
+                                <ChevronRight />
+                            </span>
+                        </xyd-nav-dropdown-item>
+                    </DropdownMenu.SubTrigger>
+                    <DropdownMenu.SubContent asChild sideOffset={0} alignOffset={-4}>
+                        <xyd-nav-dropdown-menu className={cn.DropdownList} part="dropdown-list">
+                            {renderItems(item.items, as)}
+                        </xyd-nav-dropdown-menu>
+                    </DropdownMenu.SubContent>
+                </DropdownMenu.Sub>
+            );
+        }
+
+        // Leaf: the router link wraps the styleable item element (mirrors
+        // `Nav.ItemRaw` — link = navigation, custom element = the styled box).
+        return (
+            <DropdownMenu.Item key={key} asChild>
+                <Link href={item.href || item.value}>
+                    <xyd-nav-dropdown-item
+                        part="dropdown-item"
+                        data-active={item.active || undefined}
+                    >
+                        <ItemBody item={item} />
+                    </xyd-nav-dropdown-item>
+                </Link>
+            </DropdownMenu.Item>
+        );
+    });
+}
+
+/**
+ * A nav dropdown (header anchor or tab) with a nested, multi-level menu. Built on
+ * Radix `DropdownMenu` for native submenus + keyboard/focus/dismiss a11y.
+ *
+ * `trigger` selects hover (default) vs click. For hover, the menu is rendered
+ * INLINE (not portaled) so it is a DOM descendant of the `<xyd-nav-dropdown>`
+ * host: moving the pointer from the trigger into the menu (or a submenu) never
+ * leaves the host, so a single `onPointerLeave` on the host reliably decides when
+ * to close — no dead-gap flicker across a portal boundary. Opens after a short
+ * delay so a quick sweep across the nav doesn't flash it open.
+ *
+ * Router-agnostic: leaf entries use the `as` link component (the framework passes
+ * `FwLink`) so it works under the bun engine's router.
+ */
+export function NavDropdown(props: NavDropdownProps) {
+    const { title, icon, trigger = "hover", items, as, active, className } = props;
+    const [open, setOpen] = useState(false);
+    const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const isHover = trigger !== "click";
+
+    const clearTimers = () => {
+        if (openTimer.current) clearTimeout(openTimer.current);
+        if (closeTimer.current) clearTimeout(closeTimer.current);
+        openTimer.current = null;
+        closeTimer.current = null;
+    };
+    const scheduleOpen = () => {
+        clearTimers();
+        openTimer.current = setTimeout(() => setOpen(true), OPEN_DELAY);
+    };
+    const scheduleClose = () => {
+        clearTimers();
+        closeTimer.current = setTimeout(() => setOpen(false), CLOSE_DELAY);
+    };
+    const onOpenChange = (next: boolean) => {
+        // Radix drives this on click / Escape / outside-pointer / select.
+        clearTimers();
+        setOpen(next);
+    };
+
+    const hoverHandlers = isHover
+        ? { onPointerEnter: scheduleOpen, onPointerLeave: scheduleClose }
+        : {};
+
+    return (
+        <xyd-nav-dropdown
+            className={`${cn.DropdownHost} ${className || ""}`}
+            data-fw-nav-dropdown=""
+            data-trigger={trigger}
+            {...hoverHandlers}
+        >
+            {/* `modal={false}` keeps the page interactive (nav dropdowns are non-modal). */}
+            <DropdownMenu.Root open={open} onOpenChange={onOpenChange} modal={false}>
+                {/* Radix sets `data-state` (open/closed) on the trigger itself. */}
+                <DropdownMenu.Trigger
+                    part="dropdown-trigger"
+                    data-active={active || undefined}
+                >
+                    <IconSlot icon={icon} />
+                    {title && <span part="dropdown-trigger-label">{title}</span>}
+                    <Chevron />
+                </DropdownMenu.Trigger>
+
+                {/* INLINE (no Portal): the menu is a DOM child of the host, so the
+                    host's onPointerLeave governs the whole tree. `sideOffset={0}`
+                    keeps it flush so there is no non-host pixel gap to cross.
+                    `asChild` → the panel is the styleable `<xyd-nav-dropdown-menu>`
+                    custom element (theme/user CSS targets it directly). */}
+                <DropdownMenu.Content asChild align="start" sideOffset={0}>
+                    <xyd-nav-dropdown-menu className={cn.DropdownList} part="dropdown-list">
+                        {renderItems(items, as)}
+                    </xyd-nav-dropdown-menu>
+                </DropdownMenu.Content>
+            </DropdownMenu.Root>
+        </xyd-nav-dropdown>
+    );
+}


### PR DESCRIPTION
Add nested navigation to header anchors and tabs via a recursive `dropdownMenu` on NavigationItem, opening on `trigger: "hover"` (default) or `"click"`. Submenus nest to multiple levels.

- core: `dropdownMenu?` + `trigger?` on NavigationItem; typed `appearance.navigationDropdown` ({ chevron: rotate|static, items: padded|flush })
- ui: router-agnostic `Nav.Dropdown` (Radix DropdownMenu, inline render so hover works via DOM containment) + styleable <xyd-nav-dropdown*> elements
- framework: FwNavDropdown wiring in header items & subnav; resolveDropdownItems
- themes: preserve dropdownMenu/trigger through the anchors -> webeditor.header transform
- documan(bun): map appearance.navigationDropdown flags to CSS vars in the SSR head

Rendered by the shared React components (the bun engine consumes it); the Vite path is untouched. Docs marked "Coming Soon". Adds unit + e2e (bun) tests and regenerates docs.json schema.