### PR TITLE
fix(content): replace O(n²) fromMarkdown in componentLike with an O(n…

### DIFF
--- a/packages/xyd-content/packages/md/plugins/utils/componentLike.equivalence-helpers.ts
+++ b/packages/xyd-content/packages/md/plugins/utils/componentLike.equivalence-helpers.ts
@@ -1,0 +1,72 @@
+// Shared test helpers for the componentLike equivalence suites. NOT a test file
+// (no `.test.ts`) and NOT reachable from any tsup entry (only `*.test.ts` import
+// it), so it never ships in dist — it just gives both equivalence suites a single
+// source of truth for "the old engine".
+//
+// `legacyComponentLike` is the exact pre-change O(n²) `fromMarkdown` implementation,
+// copied verbatim. It is the FROZEN baseline: the whole point of the equivalence
+// tests is to prove the new acorn path in ./componentLike compiles byte-identically
+// to this, so this copy must never be "improved".
+import * as React from 'react';
+import { mdxJsxFromMarkdown } from 'mdast-util-mdx-jsx';
+import acornJsx from 'acorn-jsx';
+import { fromMarkdown } from 'mdast-util-from-markdown';
+import { mdxJsx } from 'micromark-extension-mdx-jsx';
+import * as acorn from 'acorn';
+import reactElementToJSXString from 'react-element-to-jsx-string';
+import { compile } from '@mdx-js/mdx';
+
+const acornWithJsx = acorn.Parser.extend(acornJsx());
+
+/** Verbatim copy of componentLike.ts's ensureProperEscaping (see that file). */
+export function ensureProperEscaping(obj: any): any {
+    if (React.isValidElement(obj)) return obj;
+    if (typeof obj === 'string') return obj.replace(/(?<!\\)\\(?!\\)/g, '\\\\');
+    if (Array.isArray(obj)) return obj.map((item) => ensureProperEscaping(item));
+    if (obj && typeof obj === 'object') {
+        const result = { ...obj };
+        for (const key in result) result[key] = ensureProperEscaping(result[key]);
+        return result;
+    }
+    return obj;
+}
+
+/** The legacy (baseline) componentLike: React element → JSX string → the O(n²)
+ *  micromark `fromMarkdown(mdxJsx)` reparse. This is exactly what the new acorn
+ *  path replaces; equivalence tests assert new(...) ≡ this(...) after compile. */
+export function legacyComponentLike(componentName: string, props: Record<string, any>, children: any[]) {
+    const escapedProps = ensureProperEscaping(props);
+    const escapedChildren = ensureProperEscaping(children);
+    const reactElement = React.createElement(componentName, escapedProps, ...escapedChildren);
+    const toJsxString: any = (reactElementToJSXString as any).default || reactElementToJSXString;
+    const mdxString = toJsxString(reactElement);
+    return fromMarkdown(mdxString, {
+        extensions: [mdxJsx({ acorn: acornWithJsx, addResult: true })],
+        mdastExtensions: [mdxJsxFromMarkdown()],
+    });
+}
+
+export type ComponentLikeFn = (name: string, props: Record<string, any>, children: any[]) => any;
+
+/** Compile a componentLike node exactly as production does (fs.ts:63-77):
+ *  development:false, outputFormat:'function-body', jsx:false. A remark plugin
+ *  splices the node into the tree (mirrors mdMeta.ts:172). Old and new run the
+ *  identical compile, so any diff is purely componentLike's. */
+export async function compileVia(
+    cl: ComponentLikeFn,
+    name: string,
+    props: Record<string, any>,
+    children: any[],
+): Promise<string> {
+    const inject = () => (tree: any) => {
+        const root = cl(name, props, children);
+        tree.children = root.children;
+    };
+    const out = await compile('', {
+        remarkPlugins: [inject],
+        development: false,
+        outputFormat: 'function-body',
+        jsx: false,
+    });
+    return String(out);
+}

--- a/packages/xyd-content/packages/md/plugins/utils/componentLike.equivalence.test.ts
+++ b/packages/xyd-content/packages/md/plugins/utils/componentLike.equivalence.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import * as React from 'react';
+
+// the frozen legacy baseline + the shared compile helper (single source of truth
+// for "the old engine", reused by the real-uniform/composer suite too).
+import { legacyComponentLike, compileVia, type ComponentLikeFn } from './componentLike.equivalence-helpers';
+
+// the new implementation under test
+import { componentLike as newComponentLike } from './componentLike';
+
+// A live React description tree, exactly the kind @xyd-js/composer injects into
+// resolved Atlas references (Composer.ts) — the reason the props can't be plain JSON.
+const desc = React.createElement('p', null, 'A ', React.createElement('strong', null, 'user'), ' object.');
+const propDesc = React.createElement('span', null, 'the identifier');
+
+// --- the compose matrix: every shape that flows through componentLike ---------
+const MATRIX: { name: string; component: string; props: Record<string, any>; children?: any[] }[] = [
+    {
+        name: 'atlas — resolved references with React-element descriptions',
+        component: 'Atlas',
+        props: {
+            references: [
+                {
+                    title: 'List users',
+                    canonical: 'list-users',
+                    description: desc,
+                    type: 'rest_get',
+                    context: { method: 'GET', path: '/users' },
+                    definitions: [
+                        {
+                            title: 'Response',
+                            properties: [
+                                { name: 'id', type: 'string', description: propDesc, meta: [{ name: 'required', value: 'true' }] },
+                                { name: 'count', type: 'number' },
+                            ],
+                        },
+                    ],
+                    examples: { groups: [] },
+                },
+            ],
+        },
+    },
+    { name: 'atlas — empty references', component: 'Atlas', props: { references: [] } },
+    { name: 'home — passthrough props', component: 'PageHome', props: { layout: 'page', title: 'Home', subtitle: 'Welcome' } },
+    { name: 'bloghome — passthrough props', component: 'PageBlogHome', props: { layout: 'page' } },
+    { name: 'firstslide — passthrough props', component: 'PageFirstSlide', props: { layout: 'page', title: 'Hi' } },
+    // edge cases not covered by the mdx-parity fixtures:
+    { name: 'edge — backslash-bearing string prop (ensureProperEscaping)', component: 'Atlas', props: { references: [{ title: 'X', canonical: 'x', examples: { groups: [{ examples: [{ codeblock: { tabs: [{ title: 'shell', language: 'shell', code: 'curl -X POST \\\n  https://api' }] } }] }] } }] } },
+    { name: 'edge — raw React element prop (isValidElement short-circuit)', component: 'Atlas', props: { references: [], icon: React.createElement('svg', { width: 16 }) } },
+    // NOTE: componentLike's sole caller (mdMeta.ts:172) always passes children=[],
+    // so the top element is always self-closing and the composed React trees live
+    // in the *attribute* estree (never as JSX children). Non-empty formatted
+    // children is a dead path — byte-parity there would require re-implementing
+    // micromark's flow-markdown whitespace handling — so it is intentionally not
+    // asserted here.
+];
+
+describe('componentLike equivalence (new acorn path === legacy fromMarkdown path)', () => {
+    for (const c of MATRIX) {
+        it(`compiles identically: ${c.name}`, async () => {
+            const legacy = await compileVia(legacyComponentLike, c.component, c.props, c.children ?? []);
+            const next = await compileVia(newComponentLike as ComponentLikeFn, c.component, c.props, c.children ?? []);
+            expect(next).toBe(legacy);
+        });
+    }
+
+    it('the sole caller contract: componentLike returns { children: [node] }', () => {
+        const out = newComponentLike('Atlas', { references: [] }, []);
+        expect(out.type).toBe('root');
+        expect(Array.isArray(out.children)).toBe(true);
+        expect(out.children).toHaveLength(1);
+        expect(out.children[0].type).toBe('mdxJsxFlowElement');
+        expect(out.children[0].name).toBe('Atlas');
+    });
+});

--- a/packages/xyd-content/packages/md/plugins/utils/componentLike.ts
+++ b/packages/xyd-content/packages/md/plugins/utils/componentLike.ts
@@ -1,52 +1,166 @@
-import * as fs from 'fs';
-import { mdxJsxFromMarkdown } from 'mdast-util-mdx-jsx';
 import * as React from 'react';
 import acornJsx from 'acorn-jsx';
-import { fromMarkdown } from 'mdast-util-from-markdown'
-import { mdxJsx } from 'micromark-extension-mdx-jsx'
 import * as acorn from 'acorn';
 import reactElementToJSXString from 'react-element-to-jsx-string';
 
 const acornWithJsx = acorn.Parser.extend(acornJsx());
 
+/**
+ * Turn a composed meta-component (Atlas, PageHome, …) + its props into the mdast
+ * `mdxJsxFlowElement` node the `@mdx-js/mdx` compile consumes.
+ *
+ * Historically this did `React.createElement → reactElementToJSXString →
+ * fromMarkdown(micromark, mdxJsx)`. The `fromMarkdown` step is O(n²) in the
+ * serialized prop size — micromark tokenises the single huge JSX string as
+ * markdown — so a large Atlas page (e.g. a 2861-property OpenAPI schema) took
+ * minutes to compile. A plain `acorn` parse of the same string is O(n).
+ *
+ * We keep the (linear) React-element serialisation and instead parse the JSX
+ * with `acorn` once, then build the equivalent `mdxJsxFlowElement` node by hand,
+ * attaching each `{…}` expression's estree in the exact shape the downstream
+ * reader (`hast-util-to-estree`) uses: `value.data.estree` = a
+ * `Program{ body:[ ExpressionStatement ] }`. Only the element/attribute `name`s
+ * and `value.data.estree` are read by the compile (the raw expression string and
+ * all unist/estree positions are inert under `development:false, jsx:false` with
+ * no SourceMapGenerator — see packages/.../fs.ts), so the compiled function-body
+ * is identical to the old `fromMarkdown` path. Verified by the mdx-parity golden
+ * harness + the componentLike equivalence test.
+ */
 export function componentLike(
     componentName: string,
     props: Record<string, any>,
     children: any[]
 ) {
-    console.time('componentLike:total');
-
-    console.time('componentLike:createElement');
-    // Ensure proper escaping in props and children before creating the React element
+    // Ensure proper escaping in props and children before creating the React
+    // element (preserves live React elements — see ensureProperEscaping).
     const escapedProps = ensureProperEscaping(props);
     const escapedChildren = ensureProperEscaping(children);
     const reactElement = React.createElement(componentName, escapedProps, ...escapedChildren);
-    console.timeEnd('componentLike:createElement');
 
-    // Convert the React element to a JSX string. The CJS module's default-import
-    // interop differs by bundler (tsup/Vite → `{default: fn}`; Bun.build → `fn`),
-    // so accept both shapes.
-    console.time('componentLike:toJSXString');
+    // Serialize the element (incl. any nested React description/example trees) to
+    // a JSX string. Linear. The CJS default-import interop differs by bundler
+    // (tsup/Vite → `{default: fn}`; Bun.build → `fn`), so accept both shapes.
     const toJsxString: any = (reactElementToJSXString as any).default || reactElementToJSXString;
-    const mdxString = toJsxString(reactElement);
-    console.timeEnd('componentLike:toJSXString');
+    const mdxString: string = toJsxString(reactElement);
 
-    // Parse the JSX string to get proper MDX attributes
-    console.time('componentLike:fromMarkdown');
-
-    const ast = fromMarkdown(mdxString, {
-        extensions: [mdxJsx({
-            acorn: acornWithJsx,
-            addResult: true
-        })],
-        mdastExtensions: [mdxJsxFromMarkdown()]
+    // Parse the JSX with acorn (O(n)) — replaces the O(n²) micromark `fromMarkdown`
+    // reparse. The same parser (acorn + acorn-jsx) that the old mdxJsx extension
+    // used internally, so the sub-expression estrees are equivalent.
+    const jsxRoot: any = acornWithJsx.parseExpressionAt(mdxString, 0, {
+        ecmaVersion: 'latest' as any,
     });
-    console.timeEnd('componentLike:fromMarkdown');
+    const node = jsxEstreeToMdast(jsxRoot, mdxString);
 
-    console.timeEnd('componentLike:total');
-    return ast
+    // The sole caller (mdMeta) consumes `.children`, so return a Root-shaped node.
+    return { type: 'root', children: [node] };
 }
 
+/** The estree shape `micromark-util-events-to-acorn` produces for an mdx
+ *  expression (and the shape `hast-util-to-estree` reads): a module `Program`
+ *  whose single `ExpressionStatement` wraps the expression. */
+function wrapProgram(expression: any) {
+    return {
+        type: 'Program',
+        sourceType: 'module',
+        comments: [],
+        body: [{ type: 'ExpressionStatement', expression }],
+    };
+}
+
+/** Flatten a JSX element name to the mdast `name` string. */
+function jsxNameToString(n: any): string | null {
+    if (!n) return null;
+    if (n.type === 'JSXIdentifier') return n.name;
+    if (n.type === 'JSXMemberExpression') return `${jsxNameToString(n.object)}.${n.property.name}`;
+    if (n.type === 'JSXNamespacedName') return `${n.namespace.name}:${n.name.name}`;
+    return null;
+}
+
+/** JSX attribute estree → mdast attribute. */
+function jsxAttrToMdast(attr: any, src: string): any {
+    if (attr.type === 'JSXSpreadAttribute') {
+        // `{...expr}` → mdxJsxExpressionAttribute; downstream reads
+        // estree.body[0].expression.properties[0] as a SpreadElement.
+        return {
+            type: 'mdxJsxExpressionAttribute',
+            value: src.slice(attr.start, attr.end),
+            data: {
+                estree: wrapProgram({
+                    type: 'ObjectExpression',
+                    properties: [{ type: 'SpreadElement', argument: attr.argument }],
+                }),
+            },
+        };
+    }
+    const name = jsxNameToString(attr.name);
+    if (attr.value == null) {
+        // boolean attribute (`<X foo />`)
+        return { type: 'mdxJsxAttribute', name, value: null };
+    }
+    if (attr.value.type === 'Literal') {
+        // string attribute (`foo="bar"`) — kept as a plain decoded string
+        return { type: 'mdxJsxAttribute', name, value: attr.value.value == null ? null : String(attr.value.value) };
+    }
+    if (attr.value.type === 'JSXExpressionContainer') {
+        const expr = attr.value.expression;
+        return {
+            type: 'mdxJsxAttribute',
+            name,
+            value: {
+                type: 'mdxJsxAttributeValueExpression',
+                value: src.slice(expr.start, expr.end),
+                data: { estree: wrapProgram(expr) },
+            },
+        };
+    }
+    // A JSXElement/JSXFragment used directly as an attribute value (rare) —
+    // treat it as an expression value.
+    return {
+        type: 'mdxJsxAttribute',
+        name,
+        value: {
+            type: 'mdxJsxAttributeValueExpression',
+            value: src.slice(attr.value.start, attr.value.end),
+            data: { estree: wrapProgram(attr.value) },
+        },
+    };
+}
+
+/** JSX child estree → mdast child. */
+function jsxChildToMdast(child: any, src: string): any {
+    if (child.type === 'JSXText') {
+        return { type: 'text', value: child.value };
+    }
+    if (child.type === 'JSXElement' || child.type === 'JSXFragment') {
+        return jsxEstreeToMdast(child, src);
+    }
+    if (child.type === 'JSXExpressionContainer') {
+        if (child.expression.type === 'JSXEmptyExpression') return null;
+        return {
+            type: 'mdxFlowExpression',
+            value: src.slice(child.expression.start, child.expression.end),
+            data: { estree: wrapProgram(child.expression) },
+        };
+    }
+    return null;
+}
+
+/** JSX element/fragment estree → mdast mdxJsxFlowElement. */
+function jsxEstreeToMdast(node: any, src: string): any {
+    if (node.type === 'JSXFragment') {
+        return {
+            type: 'mdxJsxFlowElement',
+            name: null,
+            attributes: [],
+            children: node.children.map((c: any) => jsxChildToMdast(c, src)).filter(Boolean),
+        };
+    }
+    // JSXElement
+    const name = jsxNameToString(node.openingElement.name);
+    const attributes = node.openingElement.attributes.map((a: any) => jsxAttrToMdast(a, src));
+    const children = node.children.map((c: any) => jsxChildToMdast(c, src)).filter(Boolean);
+    return { type: 'mdxJsxFlowElement', name, attributes, children };
+}
 
 /**
  * Recursively ensures proper backslash escaping in string values.

--- a/packages/xyd-content/packages/md/plugins/utils/componentLike.uniform-composer.equivalence.test.ts
+++ b/packages/xyd-content/packages/md/plugins/utils/componentLike.uniform-composer.equivalence.test.ts
@@ -1,0 +1,148 @@
+// Regression proof for the componentLike O(n²)→O(n) change, driven by REAL
+// uniform output through the REAL composer — not synthetic props.
+//
+// The sibling suite (componentLike.equivalence.test.ts) hand-builds Atlas props.
+// This one instead does what production does end-to-end for an API page:
+//
+//   OpenAPI/GraphQL spec
+//     → @xyd-js/openapi | @xyd-js/gql          (REAL uniform References)
+//     → new Composer() @metaComponent("atlas")  (REAL compose transform:
+//         markdown-in-descriptions → React trees, code-example highlighting,
+//         processDefinitionProperties over every nested property, …)
+//     → componentLike(name, composedProps, [])  (the code under test)
+//     → @mdx-js/mdx compile (fs.ts options)
+//
+// then asserts the compiled function-body is byte-identical between the frozen
+// legacy `fromMarkdown` path and the new acorn path. Because the props here carry
+// the composer's live React element trees (descriptions/examples), this is the
+// exact "xyd composes many things" shape the user asked us to protect.
+import { describe, it, expect, beforeAll } from 'vitest';
+import * as React from 'react';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { deferencedOpenAPI, oapSchemaToReferences } from '@xyd-js/openapi';
+import { gqlSchemaToReferences } from '@xyd-js/gql';
+import { Composer } from '@xyd-js/composer';
+import { getMetaComponent } from '@xyd-js/context';
+
+import { legacyComponentLike, compileVia, type ComponentLikeFn } from './componentLike.equivalence-helpers';
+import { componentLike as newComponentLike } from './componentLike';
+
+// .../xyd-content/packages/md/plugins/utils → up 5 → repo `packages/`
+const PKGS = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../..');
+const oapFx = (n: string) => path.join(PKGS, 'xyd-openapi/__fixtures__', n, 'input.yaml');
+const gqlFx = (n: string) => path.join(PKGS, 'xyd-gql/__fixtures__', n, 'input.graphql');
+
+const theme = { name: 'poetry' } as any;
+const settings = { theme } as any;
+
+/** Resolve real uniform → run the real atlas compose transform → return the
+ *  composed props exactly as mdMeta.ts feeds them to componentLike. */
+async function composeAtlas(references: any[]) {
+    const atlas = getMetaComponent('atlas');
+    if (!atlas) throw new Error('atlas meta component not registered');
+    // signature mirrors mdMeta.ts:160-166 (theme, props, outputVars, treeChilds, meta, settings)
+    return atlas.transform(theme, { references }, {}, [], { component: 'atlas' } as any, settings);
+}
+
+/** Count references whose composed description/property descriptions became React
+ *  elements — the coverage guard that proves the transform really produced the
+ *  "live React trees" shape (not trivial strings that would under-test the diff). */
+function reactTreeCount(props: any): number {
+    let n = 0;
+    const walk = (v: any) => {
+        if (!v) return;
+        if (React.isValidElement(v)) { n++; return; }
+        if (Array.isArray(v)) { v.forEach(walk); return; }
+        if (typeof v === 'object') for (const k in v) walk(v[k]);
+    };
+    walk(props.references);
+    return n;
+}
+
+beforeAll(() => {
+    // registers the @metaComponent("atlas") transform into the global registry
+    new Composer();
+});
+
+// Small/medium real specs — the legacy path is O(n²) so keep pages modest here;
+// the huge openai corpus is exercised new-only in the perf/smoke check below.
+const OPENAPI_FIXTURES = [
+    '1.basic',
+    '2.more',
+    '3.multiple-responses',
+    '7.examples',
+    '8.enums',
+    '6.codeSamples',
+    '5.xdocs.codeLanguages',
+];
+
+const GRAPHQL_FIXTURES = [
+    '-1.opendocs.docs-nested',
+    '4.union',
+    '-1.opendocs.flat',
+];
+
+describe('componentLike equivalence — REAL uniform through the REAL composer (atlas)', () => {
+    describe('OpenAPI', () => {
+        for (const fx of OPENAPI_FIXTURES) {
+            it(`atlas compose compiles identically (new ≡ legacy): ${fx}`, async () => {
+                const references = oapSchemaToReferences(await deferencedOpenAPI(oapFx(fx)));
+                expect(references.length).toBeGreaterThan(0);
+
+                const composed = await composeAtlas(references);
+
+                // the composer must have produced live React trees for this to be a
+                // meaningful test of the "composed content" path
+                expect(reactTreeCount(composed)).toBeGreaterThan(0);
+
+                const legacy = await compileVia(legacyComponentLike, 'Atlas', composed, []);
+                const next = await compileVia(newComponentLike as ComponentLikeFn, 'Atlas', composed, []);
+                expect(next).toBe(legacy);
+            });
+        }
+    });
+
+    describe('GraphQL', () => {
+        for (const fx of GRAPHQL_FIXTURES) {
+            it(`atlas compose compiles identically (new ≡ legacy): ${fx}`, async () => {
+                const references = await gqlSchemaToReferences(gqlFx(fx));
+                expect(references.length).toBeGreaterThan(0);
+
+                const composed = await composeAtlas(references);
+
+                const legacy = await compileVia(legacyComponentLike, 'Atlas', composed, []);
+                const next = await compileVia(newComponentLike as ComponentLikeFn, 'Atlas', composed, []);
+                expect(next).toBe(legacy);
+            });
+        }
+    });
+
+    // Scale guard: the A/B tests above prove *equivalence*, not *speed*. This is
+    // what actually broke the openai-clone deploy — a schema page with ~2861
+    // properties (ResponseStreamEvent). The old `fromMarkdown` path is O(n²) in the
+    // serialized prop size and took minutes on a page this size; the new acorn path
+    // is O(n) (~ms). We deliberately run the NEW path only (legacy would blow past
+    // vitest's 5s default by minutes) — so if the O(n²) ever comes back, this test
+    // times out. No flaky wall-clock threshold: the O(n)/O(n²) gap here is ~1000×.
+    it('new path compiles a ~3000-property reference well under the default timeout (O(n) guard)', async () => {
+        const properties = Array.from({ length: 3000 }, (_, i) => ({
+            name: `field_${i}`,
+            type: 'string',
+            description: `Field number ${i} in a very large generated schema.`,
+            meta: i % 3 === 0 ? [{ name: 'required', value: 'true' }] : [],
+        }));
+        const bigReference = {
+            title: 'ResponseStreamEvent (scale guard)',
+            canonical: 'response-stream-event-scale-guard',
+            type: 'rest_post',
+            context: { method: 'POST', path: '/scale' },
+            definitions: [{ title: 'Response', properties }],
+            examples: { groups: [] },
+        };
+        const composed = await composeAtlas([bigReference]);
+        const out = await compileVia(newComponentLike as ComponentLikeFn, 'Atlas', composed, []);
+        expect(out.length).toBeGreaterThan(0);
+    });
+});


### PR DESCRIPTION
…) acorn parse

componentLike turns a composed meta-component (Atlas, PageHome, …) + its resolved props into the mdast MDX node the @mdx-js/mdx compile consumes. It did React.createElement → reactElementToJSXString → fromMarkdown(micromark, mdxJsx). The fromMarkdown step is O(n²) in the serialized prop size — micromark tokenizes one giant JSX string as markdown — so a schema-heavy Atlas page (e.g. an OpenAPI schema with ~2861 properties) took minutes to compile a single page and blew past the deploy budget.

Replace only that step with a direct acorn (+ acorn-jsx) parse of the same JSX string (O(n)) plus a small recursive mdast-node builder. The downstream reader (hast-util-to-estree) consumes only attribute.value.data.estree, and under development:false, jsx:false with no SourceMapGenerator the raw value string and all positions are inert — so the compiled function-body is byte-identical to the old path. Both paths run the same acorn-jsx on the same string.

Equivalence is proven three ways:
- componentLike.equivalence.test.ts — synthetic A/B (legacy fromMarkdown vs new) across every compose shape (atlas/home/bloghome/firstslide + escaping edges).
- componentLike.uniform-composer.equivalence.test.ts — REAL uniform (OpenAPI + GraphQL fixtures) run through the REAL composer atlas transform, then A/B compiled; a coverage guard asserts the composer produced live React trees, and a scale guard runs the new path on a ~3000-property reference (O(n²) would time out).
- the mdx-parity golden harness still verifies with zero drift.

legacyComponentLike + compileVia are factored into componentLike.equivalence-helpers.ts (shared frozen baseline; not shipped in dist).