### PR TITLE
fix(website): advertise the native curl installer only on canary builds

### DIFF
--- a/apps/website/app/pages/index/Hero.tsx
+++ b/apps/website/app/pages/index/Hero.tsx
@@ -5,10 +5,16 @@ import { IconWindows } from "~/icons/Windows";
 import { IconLinux } from "~/icons/Linux";
 
 // Injected by vite `define` at build time (see vite.config.ts): the current
-// site's origin. Baked into the prerendered HTML so canary.xyd.dev ships the
-// canary install command and prod ships xyd.dev's — no client-side host sniffing.
+// site's origin + whether this is the canary build. Baked into the prerendered
+// HTML — no client-side host sniffing.
 declare const __XYD_INSTALL_ORIGIN__: string;
-const INSTALL_CMD = `curl -fsSL ${__XYD_INSTALL_ORIGIN__}/install | bash`;
+declare const __XYD_IS_CANARY__: boolean;
+// The native one-line installer is canary-only for now; stable/prod ships the
+// published npm CLI. (`__XYD_IS_CANARY__` is a compile-time constant, so the
+// unused branch is dead-code-eliminated from each build.)
+const INSTALL_CMD = __XYD_IS_CANARY__
+  ? `curl -fsSL ${__XYD_INSTALL_ORIGIN__}/install | bash`
+  : "bun add -g xyd-js";
 
 export function Hero() {
   const [activeTab, setActiveTab] = useState(0);

--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -4,6 +4,13 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 import PluginCritical from "rollup-plugin-critical";
 
+// Resolved once at build time (Netlify `URL`, else deploy-preview prime URL, else
+// local → xyd.dev). Both the install origin and the canary flag derive from it.
+const INSTALL_ORIGIN =
+  process.env.URL || process.env.DEPLOY_PRIME_URL || "https://xyd.dev";
+// Canary site is canary.<domain>; only it advertises the native installer.
+const IS_CANARY = /^https?:\/\/canary\./i.test(INSTALL_ORIGIN);
+
 export default defineConfig({
   // The homepage is prerendered (ssr: true, prerender: true), so the install
   // command's host has to be known at BUILD time — there is no request to read
@@ -11,10 +18,14 @@ export default defineConfig({
   // the canary site (canary.xyd.dev) bakes in its own /install, prod bakes in
   // xyd.dev, and deploy previews fall back to their prime URL. Local builds have
   // neither → xyd.dev.
+  //
+  // The native one-line installer (`curl … /install | bash`) is currently
+  // canary-only, so the hero advertises it ONLY on the canary build; stable/prod
+  // advertises the npm CLI (`bun add -g xyd-js`). Canary-ness is derived from the
+  // same resolved origin (a `canary.` host) so there is one source of truth.
   define: {
-    __XYD_INSTALL_ORIGIN__: JSON.stringify(
-      process.env.URL || process.env.DEPLOY_PRIME_URL || "https://xyd.dev",
-    ),
+    __XYD_INSTALL_ORIGIN__: JSON.stringify(INSTALL_ORIGIN),
+    __XYD_IS_CANARY__: JSON.stringify(IS_CANARY),
   },
   plugins: [
     tailwindcss(), 


### PR DESCRIPTION
The homepage hero baked `curl -fsSL <origin>/install | bash` on every build. The one-line native installer is currently canary-only, so on the stable/prod site (xyd.dev) it pointed users at an installer for a channel that isn't GA yet.

Gate it on the build channel: derive a compile-time `__XYD_IS_CANARY__` from the same resolved origin already used for the install command (a `canary.` host → canary), and only then show the curl installer. Stable/prod falls back to the previous published-CLI command, `bun add -g xyd-js`.

`__XYD_IS_CANARY__` is a vite `define` constant, so the unused branch is dead-code-eliminated per build. Verified end to end: a stable build (no `URL`, or a non-canary host) bakes `bun add -g xyd-js` with the curl branch gone; a `URL=https://canary.xyd.dev` build bakes `curl -fsSL https://canary.xyd.dev/install | bash` with the bun branch gone.