### PR TITLE
feat(navigation): segment appearance "logoTrailing" — global product …

### DIFF
--- a/__tests__/e2e/1.navigation/3.segments-logo-trailing/docs.json
+++ b/__tests__/e2e/1.navigation/3.segments-logo-trailing/docs.json
@@ -1,0 +1,60 @@
+{
+    "theme": {
+        "name": "cosmo",
+        "logo": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2NCIgaGVpZ2h0PSIxOCI+PHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjE4IiByeD0iMyIgZmlsbD0iIzExMSIvPjx0ZXh0IHg9IjgiIHk9IjEzIiBmb250LWZhbWlseT0ic2Fucy1zZXJpZiIgZm9udC1zaXplPSIxMSIgZm9udC13ZWlnaHQ9IjcwMCIgZmlsbD0iI2ZmZiI+ZG9jczwvdGV4dD48L3N2Zz4="
+    },
+    "components": {
+        "footer": {
+            "logo": true
+        }
+    },
+    "navigation": {
+        "segments": [
+            {
+                "route": "products",
+                "title": "Products",
+                "appearance": "logoTrailing",
+                "trigger": "hover",
+                "pages": [
+                    {
+                        "title": "Session Replay",
+                        "page": "products/session-replay",
+                        "icon": "eye"
+                    },
+                    {
+                        "title": "Web Analytics",
+                        "page": "products/web-analytics",
+                        "icon": "chart-line"
+                    }
+                ]
+            }
+        ],
+        "sidebar": [
+            "overview",
+            {
+                "route": "products/session-replay",
+                "pages": [
+                    {
+                        "group": "Session Replay",
+                        "pages": [
+                            "products/session-replay/overview",
+                            "products/session-replay/methods"
+                        ]
+                    }
+                ]
+            },
+            {
+                "route": "products/web-analytics",
+                "pages": [
+                    {
+                        "group": "Web Analytics",
+                        "pages": [
+                            "products/web-analytics/overview",
+                            "products/web-analytics/events"
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/__tests__/e2e/1.navigation/3.segments-logo-trailing/overview.md
+++ b/__tests__/e2e/1.navigation/3.segments-logo-trailing/overview.md
@@ -1,0 +1,7 @@
+---
+title: Overview
+---
+
+# Overview
+
+Welcome. Pick a product from the switcher next to the logo.

--- a/__tests__/e2e/1.navigation/3.segments-logo-trailing/products/session-replay/methods.md
+++ b/__tests__/e2e/1.navigation/3.segments-logo-trailing/products/session-replay/methods.md
@@ -1,0 +1,7 @@
+---
+title: Methods
+---
+
+# Session Replay Methods
+
+Methods for Session Replay.

--- a/__tests__/e2e/1.navigation/3.segments-logo-trailing/products/session-replay/overview.md
+++ b/__tests__/e2e/1.navigation/3.segments-logo-trailing/products/session-replay/overview.md
@@ -1,0 +1,7 @@
+---
+title: Session Replay
+---
+
+# Session Replay
+
+Session Replay product overview.

--- a/__tests__/e2e/1.navigation/3.segments-logo-trailing/products/web-analytics/events.md
+++ b/__tests__/e2e/1.navigation/3.segments-logo-trailing/products/web-analytics/events.md
@@ -1,0 +1,7 @@
+---
+title: Events
+---
+
+# Web Analytics Events
+
+Events for Web Analytics.

--- a/__tests__/e2e/1.navigation/3.segments-logo-trailing/products/web-analytics/overview.md
+++ b/__tests__/e2e/1.navigation/3.segments-logo-trailing/products/web-analytics/overview.md
@@ -1,0 +1,7 @@
+---
+title: Web Analytics
+---
+
+# Web Analytics
+
+Web Analytics product overview.

--- a/__tests__/e2e/1.navigation/3.segments-logo-trailing/segments-logo-trailing.test.ts
+++ b/__tests__/e2e/1.navigation/3.segments-logo-trailing/segments-logo-trailing.test.ts
@@ -1,0 +1,101 @@
+import { test, expect, Page } from '@playwright/test';
+
+import { createXydServer, createXydBunServer, XydServer } from '../../utils/xyd-server';
+
+// A `logoTrailing` segment renders as a hover product-switcher right after the
+// logo, via the `logo.trailing` surface (hosted by FwLogo). The render path is
+// shared, so we assert the same behavior on BOTH engines: the bun engine and the
+// Vite engine that examples-build ships with.
+const ENGINES: { name: string; make: (dir: string) => Promise<XydServer> }[] = [
+    { name: 'bun', make: (dir) => createXydBunServer(dir) },
+    { name: 'vite', make: (dir) => createXydServer(dir) },
+];
+
+for (const engine of ENGINES) {
+    test.describe(`navigation — segments logoTrailing (${engine.name} engine)`, () => {
+        let server: XydServer;
+
+        test.beforeAll(async () => {
+            server = await engine.make(__dirname);
+        });
+
+        test.afterAll(async () => {
+            await server?.stop();
+        });
+
+        const trigger = (page: Page) => page.locator('[part="dropdown-trigger"]');
+        const triggerLabel = (page: Page) => page.locator('[part="dropdown-trigger-label"]');
+        const item = (page: Page, label: string) =>
+            page.locator('[part="dropdown-item"]', { hasText: label });
+
+        async function goto(page: Page, path: string) {
+            await page.goto(server.getUrl(path));
+            await page.waitForLoadState('networkidle');
+        }
+
+        test('renders the switcher after the logo, labeled with the active product', async ({ page }) => {
+            await goto(page, '/products/session-replay/overview');
+            // hosted inside the logo element → "right after the logo"
+            const switcher = page.locator('[part="logo"] [data-fw-nav-dropdown]');
+            await expect(switcher).toBeVisible();
+            await expect(triggerLabel(page)).toHaveText('Session Replay');
+        });
+
+        test('is global — visible on the landing page, labeled with the segment title', async ({ page }) => {
+            await goto(page, '/overview');
+            // logoTrailing is a top-level switcher: it renders on every page, not
+            // only under a product route. No product is active on the landing, so
+            // the trigger falls back to the segment `title`.
+            await expect(page.locator('[part="logo"] [data-fw-nav-dropdown]')).toBeVisible();
+            await expect(triggerLabel(page)).toHaveText('Products');
+        });
+
+        test('can pick a product from the landing page', async ({ page }) => {
+            await goto(page, '/overview');
+            await trigger(page).hover();
+            await item(page, 'Web Analytics').click();
+            await page.waitForURL(/\/products\/web-analytics\/overview$/);
+            await expect(triggerLabel(page)).toHaveText('Web Analytics');
+        });
+
+        test('hover opens the menu with both products; the active one is checked', async ({ page }) => {
+            await goto(page, '/products/session-replay/overview');
+            await trigger(page).hover();
+            await expect(item(page, 'Session Replay')).toBeVisible();
+            await expect(item(page, 'Web Analytics')).toBeVisible();
+            // active item carries the switcher check; the inactive one does not
+            await expect(item(page, 'Session Replay').locator('[part="dropdown-check"]')).toHaveCount(1);
+            await expect(item(page, 'Web Analytics').locator('[part="dropdown-check"]')).toHaveCount(0);
+        });
+
+        test('selecting another product navigates and the trigger updates', async ({ page }) => {
+            await goto(page, '/products/session-replay/overview');
+            await trigger(page).hover();
+            await item(page, 'Web Analytics').click();
+            await page.waitForURL(/\/products\/web-analytics\/overview$/);
+            await expect(page.locator('h1')).toContainText('Web Analytics');
+            await expect(triggerLabel(page)).toHaveText('Web Analytics');
+        });
+
+        test('the switcher persists on a sub-page of the product section', async ({ page }) => {
+            await goto(page, '/products/session-replay/methods');
+            await expect(page.locator('[part="logo"] [data-fw-nav-dropdown]')).toBeVisible();
+            await expect(triggerLabel(page)).toHaveText('Session Replay');
+        });
+
+        test('the switcher does not leak into the footer logo (only the nav logo hosts it)', async ({ page }) => {
+            await goto(page, '/products/session-replay/overview');
+            // the footer also renders a logo (components.footer.logo), but only the
+            // nav logo opts into `trailing`, so exactly one switcher exists.
+            await expect(page.locator('[data-fw-nav-dropdown]')).toHaveCount(1);
+        });
+
+        test('the segment renders ONLY after the logo — never as a subnav below the nav', async ({ page }) => {
+            await goto(page, '/products/session-replay/overview');
+            // a `logoTrailing` segment must not also drive the default subnav/subheader
+            // (regression: useMatchedSubNav used to render any non-sidebarDropdown segment)
+            await expect(page.locator('xyd-subnav')).toHaveCount(0);
+            await expect(page.locator('xyd-subnav-item')).toHaveCount(0);
+        });
+    });
+}

--- a/apps/docs/guides/navigation.md
+++ b/apps/docs/guides/navigation.md
@@ -539,6 +539,43 @@ Thanks to that you can create for example a subheader that will shown only on sp
   ::atlas{apiRefItemKind="secondary" references="@uniform('@core/types/settings.ts', {mini: 'Segment'})"}
 ::::
 
+### Logo Trailing {label="Coming Soon"}
+
+Set a segment's `appearance` to `"logoTrailing"` to render it as a product-switcher
+right after the logo — wherever your theme places the logo (header, or the sidebar
+like `picasso`). Unlike `sidebarDropdown`, it is **global**: it appears on every page
+(a top-level switcher), so you can switch products from anywhere — including the
+landing page. The trigger shows the active product (whichever `page` prefixes the
+current route), falling back to the segment `title` when none is active; the menu
+switches between the segment `pages` (the active one is checked).
+
+This suits docs that span multiple products — e.g. a **Products** switcher over
+_Session Replay_ and _Web Analytics_:
+
+```json
+{
+  "navigation": {
+    "segments": [
+      {
+        "route": "products",
+        "title": "Products",
+        // !diff +
+        "appearance": "logoTrailing",
+        // !diff +
+        "trigger": "hover",
+        "pages": [
+          { "title": "Session Replay", "page": "products/session-replay" },
+          { "title": "Web Analytics", "page": "products/web-analytics" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+The dropdown opens on `trigger: "hover"` (default) or `"click"`. A page may itself
+declare a nested [`dropdownMenu`](/guides/navigation#dropdown-menu) to add submenus.
+
 ##  File-Convention Routing {label="Coming Soon"}
 :::callout
 File-convention routing is powerful because you don't need any configuration but also has some limitations. 

--- a/apps/docs/public/docs.json
+++ b/apps/docs/public/docs.json
@@ -2624,9 +2624,8 @@
       "description": "Segment configuration",
       "properties": {
         "appearance": {
-          "const": "sidebarDropdown",
-          "description": "Appearance of this segment. If 'sidebarDropdown' then show this segment as a dropdown in the sidebar if match.",
-          "type": "string"
+          "$ref": "#/definitions/SegmentAppearance",
+          "description": "Appearance of this segment. See  {@link  SegmentAppearance } ."
         },
         "pages": {
           "description": "Items within this segment",
@@ -2642,6 +2641,14 @@
         "title": {
           "description": "Title of this segment",
           "type": "string"
+        },
+        "trigger": {
+          "description": "How a `logoTrailing` segment's dropdown opens. Defaults to `\"hover\"`.",
+          "enum": [
+            "hover",
+            "click"
+          ],
+          "type": "string"
         }
       },
       "required": [
@@ -2649,6 +2656,14 @@
         "pages"
       ],
       "type": "object"
+    },
+    "SegmentAppearance": {
+      "description": "How a matched  {@link  Segment }  is presented.\n\n- `\"sidebarDropdown\"` — a click dropdown at the top of the sidebar.\n- `\"logoTrailing\"` — a hover product-switcher rendered right after the logo   (wherever the active theme places its logo — header or sidebar). The trigger   shows the active page's title (falling back to the segment `title`), and the   menu is the segment `pages` with a check on the active one.",
+      "enum": [
+        "sidebarDropdown",
+        "logoTrailing"
+      ],
+      "type": "string"
     },
     "Sidebar": {
       "additionalProperties": false,

--- a/packages/xyd-core/src/types/settings.ts
+++ b/packages/xyd-core/src/types/settings.ts
@@ -739,6 +739,17 @@ export type VirtualPage =
     };
 
 /**
+ * How a matched {@link Segment} is presented.
+ *
+ * - `"sidebarDropdown"` — a click dropdown at the top of the sidebar.
+ * - `"logoTrailing"` — a hover product-switcher rendered right after the logo
+ *   (wherever the active theme places its logo — header or sidebar). The trigger
+ *   shows the active page's title (falling back to the segment `title`), and the
+ *   menu is the segment `pages` with a check on the active one.
+ */
+export type SegmentAppearance = "sidebarDropdown" | "logoTrailing";
+
+/**
  * Segment configuration
  */
 export interface Segment {
@@ -748,8 +759,11 @@ export interface Segment {
   /** Title of this segment */
   title?: string;
 
-  /** Appearance of this segment. If 'sidebarDropdown' then show this segment as a dropdown in the sidebar if match. */
-  appearance?: "sidebarDropdown";
+  /** Appearance of this segment. See {@link SegmentAppearance}. */
+  appearance?: SegmentAppearance;
+
+  /** How a `logoTrailing` segment's dropdown opens. Defaults to `"hover"`. */
+  trigger?: "hover" | "click";
 
   /** Items within this segment */
   pages: NavigationItem[];

--- a/packages/xyd-documan/src/bun/render-tree.tsx
+++ b/packages/xyd-documan/src/bun/render-tree.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 
-import { Surfaces } from "@xyd-js/framework";
-import { Framework, FrameworkPage, FwLink, FwLogo, FwLocaleSwitcher, type IFrameworkI18n } from "@xyd-js/framework/react";
+import { Surfaces, SurfaceTarget } from "@xyd-js/framework";
+import { Framework, FrameworkPage, FwLink, FwLogo, FwLocaleSwitcher, FwSegmentLogoTrailing, type IFrameworkI18n } from "@xyd-js/framework/react";
 import { resolveLocaleSettings } from "@xyd-js/framework/hydration/locale";
 import { ReactContent } from "@xyd-js/components/content";
 import { IconProvider } from "@xyd-js/components/writer";
@@ -61,6 +61,9 @@ export function seedGlobals(ThemeCtor: any) {
   if (settings?.navigation?.languages?.length) {
     surfaces.define("nav.right", FwLocaleSwitcher as any, { append: true } as any);
   }
+  // `logoTrailing` segments render after the logo via this surface (hosted by
+  // FwLogo). Self-gating component, so registering unconditionally is safe.
+  surfaces.define(SurfaceTarget.LogoTrailing, <FwSegmentLogoTrailing />);
   state.surfaces = surfaces;
 
   globalThis.__xydReactContent = new ReactContent(settings, {

--- a/packages/xyd-framework/__tests__/segmentLogoTrailing.test.ts
+++ b/packages/xyd-framework/__tests__/segmentLogoTrailing.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+
+import type { Segment } from "@xyd-js/core";
+
+import { resolveLogoTrailingSwitcher } from "../packages/react/utils/segmentLogoTrailing";
+
+const productsSegment: Segment = {
+    route: "/",
+    title: "Products",
+    appearance: "logoTrailing",
+    trigger: "hover",
+    pages: [
+        { title: "Session Replay", page: "session-replay/intro", icon: "replay" },
+        { title: "Web Analytics", page: "web-analytics/intro", icon: "chart" },
+    ],
+};
+
+describe("resolveLogoTrailingSwitcher", () => {
+    it("labels the trigger with the active page's title and checks only it", () => {
+        const { triggerLabel, items } = resolveLogoTrailingSwitcher(
+            productsSegment,
+            "web-analytics/intro",
+        );
+
+        expect(triggerLabel).toBe("Web Analytics");
+        expect(items.map((i) => i.active)).toEqual([false, true]);
+        // hrefs resolved via pageLink
+        expect(items.map((i) => i.href)).toEqual([
+            "/session-replay/intro",
+            "/web-analytics/intro",
+        ]);
+        expect(items.map((i) => i.title)).toEqual(["Session Replay", "Web Analytics"]);
+    });
+
+    it("falls back to the segment title when nothing is active", () => {
+        const { triggerLabel, items } = resolveLogoTrailingSwitcher(productsSegment, "");
+        expect(triggerLabel).toBe("Products");
+        expect(items.every((i) => !i.active)).toBe(true);
+    });
+
+    it("falls back to the segment title when the active page is not one of its pages", () => {
+        const { triggerLabel, items } = resolveLogoTrailingSwitcher(
+            productsSegment,
+            "some/other/page",
+        );
+        expect(triggerLabel).toBe("Products");
+        expect(items.every((i) => !i.active)).toBe(true);
+    });
+
+    it("resolves a page's nested dropdownMenu into a submenu", () => {
+        const segment: Segment = {
+            route: "/",
+            title: "Products",
+            appearance: "logoTrailing",
+            pages: [
+                {
+                    title: "Session Replay",
+                    page: "session-replay/intro",
+                    dropdownMenu: [
+                        { title: "Overview", page: "session-replay/overview" },
+                        { title: "API", href: "https://api.example.com" },
+                    ],
+                },
+            ],
+        };
+
+        const { items } = resolveLogoTrailingSwitcher(segment, "session-replay/intro");
+
+        expect(items).toHaveLength(1);
+        expect(items[0].active).toBe(true);
+        expect(items[0].items).toHaveLength(2);
+        expect(items[0].items?.map((i) => i.href)).toEqual([
+            "/session-replay/overview",
+            "https://api.example.com",
+        ]);
+    });
+
+    it("handles an empty segment gracefully", () => {
+        const { triggerLabel, items } = resolveLogoTrailingSwitcher(
+            { route: "/", title: "Products", appearance: "logoTrailing", pages: [] },
+            "anything",
+        );
+        expect(triggerLabel).toBe("Products");
+        expect(items).toEqual([]);
+    });
+});

--- a/packages/xyd-framework/packages/react/components/FwLogo.tsx
+++ b/packages/xyd-framework/packages/react/components/FwLogo.tsx
@@ -5,39 +5,50 @@ import {
     useColorScheme
 } from "@xyd-js/components/writer";
 
+import { SurfaceTarget } from "../../../src";
 import { useSettings } from "../contexts";
 import { useLogoLink } from "../hooks";
+import { Surface } from "./Surfaces";
 
-export function FwLogo() {
+/**
+ * The logo. Rendered by every theme (navbar directly, the sidebar via the
+ * webeditor "Logo" item, gusto's `sidebar.top` surface) AND the footer.
+ *
+ * `trailing` opts this instance into hosting the `logo.trailing` surface right
+ * after the logo (e.g. a `logoTrailing` segment product-switcher). It is set only
+ * at the nav/sidebar logo sites — the footer logo omits it, so nothing leaks there.
+ */
+export function FwLogo({ trailing }: { trailing?: boolean } = {}) {
     const settings = useSettings()
     const [clientColorScheme] = useColorScheme()
-    
+
     const colorScheme = clientColorScheme || settings?.theme?.appearance?.colorScheme || "light"
     const logo = settings?.theme?.logo
 
     if (typeof logo === "string") {
-        return <$Logo src={logo} />
+        return <$Logo src={logo} trailing={trailing} />
     }
 
     if (isValidElement(logo)) {
-        return <$Logo>
+        return <$Logo trailing={trailing}>
             {logo}
         </$Logo>
     }
 
     if (typeof logo === "object") {
-        return <$Logo src={logo[colorScheme]} />
+        return <$Logo src={logo[colorScheme]} trailing={trailing} />
     }
 
     return null
 }
 
-function $Logo({ src, children }: { src?: string, children?: React.ReactNode }) {
+function $Logo({ src, children, trailing }: { src?: string, children?: React.ReactNode, trailing?: boolean }) {
     const logoLink = useLogoLink()
 
     return <span part="logo">
         <Link to={logoLink}>
             { src ? <img src={src} /> : children }
         </Link>
+        {trailing && <Surface target={SurfaceTarget.LogoTrailing} />}
     </span>
 }

--- a/packages/xyd-framework/packages/react/components/FwNav.tsx
+++ b/packages/xyd-framework/packages/react/components/FwNav.tsx
@@ -24,7 +24,7 @@ export function FwNav() {
     const logo = appearance?.logo?.header ? <WebEditorComponent.NavItemRaw
         device={appearance?.logo?.header}
     >
-        <FwLogo />
+        <FwLogo trailing />
     </WebEditorComponent.NavItemRaw> : null
 
     // TODO: in the future better floating system - just pure css?

--- a/packages/xyd-framework/packages/react/components/FwSegmentLogoTrailing.tsx
+++ b/packages/xyd-framework/packages/react/components/FwSegmentLogoTrailing.tsx
@@ -1,0 +1,44 @@
+import React from "react";
+import { useLocation } from "react-router";
+
+import { Nav } from "@xyd-js/ui";
+
+import { useLogoTrailingSegment } from "../hooks";
+import { pageLink, trailingSlash, resolveLogoTrailingSwitcher } from "../utils";
+import { FwLink } from "./FwLink";
+
+/**
+ * Renders a `logoTrailing` segment as a GLOBAL hover product-switcher, hosted on
+ * the `logo.trailing` surface (see FwLogo). It appears after the logo on every
+ * page. The trigger shows the active product — whichever page's route prefixes
+ * the current path — falling back to the segment `title` when none is active
+ * (e.g. the landing page). The menu is the segment `pages` with a check on the
+ * active one; a page's nested `dropdownMenu` becomes a submenu.
+ *
+ * Self-gating: returns null unless a `logoTrailing` segment is configured, so it
+ * is safe to register on the surface unconditionally in both app entries.
+ */
+export function FwSegmentLogoTrailing() {
+    const segment = useLogoTrailingSegment()
+    const location = useLocation()
+
+    if (!segment) {
+        return null
+    }
+
+    const pathname = trailingSlash(location.pathname)
+    const activePage = segment.pages?.findLast(
+        page => !!page.page && pathname.startsWith(pageLink(page.page))
+    )?.page || ""
+
+    const { triggerLabel, items } = resolveLogoTrailingSwitcher(segment, activePage)
+
+    return (
+        <Nav.Dropdown
+            title={triggerLabel}
+            trigger={segment.trigger}
+            items={items}
+            as={FwLink}
+        />
+    )
+}

--- a/packages/xyd-framework/packages/react/components/index.ts
+++ b/packages/xyd-framework/packages/react/components/index.ts
@@ -19,6 +19,8 @@ export {FwNavLinks} from "./FwNavLinks";
 
 export {FwSidebar} from "./FwSidebar";
 
+export {FwSegmentLogoTrailing} from "./FwSegmentLogoTrailing";
+
 export {FwSubNav} from "./FwSubNav";
 
 export {FwToc} from "./FwToc";

--- a/packages/xyd-framework/packages/react/hooks/index.ts
+++ b/packages/xyd-framework/packages/react/hooks/index.ts
@@ -39,6 +39,10 @@ export {
 } from "./useMatchedSegmentSidebarDropdown";
 
 export {
+    useLogoTrailingSegment
+} from "./useLogoTrailingSegment";
+
+export {
     useMatchedSubNav,
 } from "./useMatchedSubNav";
 

--- a/packages/xyd-framework/packages/react/hooks/useLogoTrailingSegment.ts
+++ b/packages/xyd-framework/packages/react/hooks/useLogoTrailingSegment.ts
@@ -1,0 +1,20 @@
+import { Segment } from "@xyd-js/core";
+
+import { useSettings } from "../contexts";
+
+/**
+ * The (first) segment declaring `appearance: "logoTrailing"`.
+ *
+ * Unlike `sidebarDropdown` (which is route-scoped), a logoTrailing switcher is
+ * GLOBAL — a top-level product switcher rendered after the logo on EVERY page,
+ * so it is found straight from settings, NOT gated by the current route. The
+ * active product is derived from the current path in `FwSegmentLogoTrailing`
+ * (no product active → the trigger falls back to the segment `title`).
+ */
+export function useLogoTrailingSegment(): Segment | null {
+    const settings = useSettings()
+
+    return settings.navigation?.segments?.find(
+        segment => segment.appearance === "logoTrailing"
+    ) || null
+}

--- a/packages/xyd-framework/packages/react/hooks/useMatchedSubNav.ts
+++ b/packages/xyd-framework/packages/react/hooks/useMatchedSubNav.ts
@@ -19,7 +19,9 @@ export function useMatchedSubNav(): Segment | null {
         return null
     }
 
-    if (!matchedSegment || matchedSegment.appearance === "sidebarDropdown") {
+    // A segment with an explicit appearance (sidebarDropdown, logoTrailing, …)
+    // renders in its own dedicated place — never as the default subnav/subheader.
+    if (!matchedSegment || matchedSegment.appearance) {
         return tabSegments
     }
 

--- a/packages/xyd-framework/packages/react/utils/index.ts
+++ b/packages/xyd-framework/packages/react/utils/index.ts
@@ -15,3 +15,8 @@ export {
     resolveDropdownHref,
 } from "./navDropdown"
 export type { ResolvedDropdownItem } from "./navDropdown"
+
+export {
+    resolveLogoTrailingSwitcher,
+} from "./segmentLogoTrailing"
+export type { LogoTrailingItem, LogoTrailingSwitcher } from "./segmentLogoTrailing"

--- a/packages/xyd-framework/packages/react/utils/segmentLogoTrailing.ts
+++ b/packages/xyd-framework/packages/react/utils/segmentLogoTrailing.ts
@@ -1,0 +1,42 @@
+import type { Segment } from "@xyd-js/core";
+
+import { resolveDropdownHref, resolveDropdownItems, type ResolvedDropdownItem } from "./navDropdown";
+
+/** A logoTrailing switch target — a resolved dropdown item plus whether it is the
+ *  currently-active page (→ rendered with a check by the switcher). */
+export interface LogoTrailingItem extends ResolvedDropdownItem {
+    active?: boolean;
+}
+
+export interface LogoTrailingSwitcher {
+    /** Trigger label: the active page's title, else the segment title, else "". */
+    triggerLabel: string;
+    /** The segment pages resolved to dropdown items, the active one marked. */
+    items: LogoTrailingItem[];
+}
+
+/**
+ * Pure: resolve a `logoTrailing` segment + the active page string (from
+ * `useActiveSegment`) into the product-switcher's trigger label + menu items.
+ * Kept out of the component (like {@link resolveDropdownItems}) so it is
+ * unit-testable without the router/UI layer.
+ */
+export function resolveLogoTrailingSwitcher(segment: Segment, activePage: string): LogoTrailingSwitcher {
+    const pages = segment.pages || [];
+    const isActive = (page?: string) => !!activePage && (page || "") === activePage;
+
+    const items: LogoTrailingItem[] = pages.map((page) => ({
+        title: page.title,
+        description: page.description,
+        href: resolveDropdownHref(page),
+        value: page.page || page.href || page.title,
+        icon: page.icon,
+        active: isActive(page.page),
+        items: page.dropdownMenu?.length ? resolveDropdownItems(page.dropdownMenu) : undefined,
+    }));
+
+    const activeItem = pages.find((page) => isActive(page.page));
+    const triggerLabel = activeItem?.title || segment.title || "";
+
+    return { triggerLabel, items };
+}

--- a/packages/xyd-framework/src/surfaces.ts
+++ b/packages/xyd-framework/src/surfaces.ts
@@ -9,6 +9,11 @@ export enum SurfaceTarget {
 
     SidebarItemLeft = "sidebar.item.left",
     SidebarItemRight = "sidebar.item.right",
+
+    // Rendered immediately after the logo, wherever the active theme places it
+    // (header or sidebar). Hosted by FwLogo (gated by its `trailing` prop so the
+    // footer logo never fills it). Used by the `logoTrailing` segment appearance.
+    LogoTrailing = "logo.trailing",
 }
 
 // Type that allows both enum and string values

--- a/packages/xyd-plugin-docs/src/pages/layout.tsx
+++ b/packages/xyd-plugin-docs/src/pages/layout.tsx
@@ -18,12 +18,12 @@ import { resolveLocaleSettings } from "@xyd-js/framework/hydration/locale";
 
 import type { Metadata, MetadataMap, Settings, Theme as ThemeSettings } from "@xyd-js/core";
 import type { INavLinks, IBreadcrumb } from "@xyd-js/ui";
-import { Framework, FwLink, FwLogo, FwLocaleSwitcher, useSettings, type FwSidebarItemProps, type IFrameworkI18n } from "@xyd-js/framework/react";
+import { Framework, FwLink, FwLogo, FwLocaleSwitcher, FwSegmentLogoTrailing, useSettings, type FwSidebarItemProps, type IFrameworkI18n } from "@xyd-js/framework/react";
 import { ReactContent } from "@xyd-js/components/content";
 import { Atlas, AtlasContext, type VariantToggleConfig } from "@xyd-js/atlas";
 import AtlasXydPlugin from "@xyd-js/atlas/xydPlugin";
 
-import { Surfaces, pageMetaLayout } from "@xyd-js/framework";
+import { Surfaces, SurfaceTarget, pageMetaLayout } from "@xyd-js/framework";
 import { Composer } from "@xyd-js/composer";
 import { Analytics, useAnalytics } from "@xyd-js/analytics";
 // @ts-ignore
@@ -110,6 +110,11 @@ if (settings?.navigation?.languages?.length) {
         { append: true }
     )
 }
+
+// `logoTrailing` segments render after the logo via this surface (hosted by
+// FwLogo). The component self-gates (null unless a logoTrailing segment matches),
+// so registering unconditionally is safe.
+surfaces.define(SurfaceTarget.LogoTrailing, <FwSegmentLogoTrailing />)
 
 const reactContent = new ReactContent(settings, {
     Link: FwLink,

--- a/packages/xyd-theme-gusto/src/theme.tsx
+++ b/packages/xyd-theme-gusto/src/theme.tsx
@@ -57,7 +57,7 @@ function _SidebarTop() {
     return <>
         <UISidebar.Item ghost>
             <div className={styles.SidebarTop}>
-                <FwLogo/>
+                <FwLogo trailing/>
                 <div>
                     {showColorSchemeButton && <ColorSchemeButton/>}
                 </div>

--- a/packages/xyd-themes/src/Theme.tsx
+++ b/packages/xyd-themes/src/Theme.tsx
@@ -165,6 +165,9 @@ export abstract class Theme {
         if (this.theme.appearance?.logo?.sidebar) {
             const logo: WebEditorNavigationItem = {
                 component: "Logo",
+                // opt this sidebar logo into hosting the `logo.trailing` surface
+                // (FwLogo reads `trailing` — see FwJsonComponent props pass-through)
+                props: { trailing: true },
                 mobile: this.theme.appearance?.logo?.sidebar === "mobile" || undefined,
                 desktop: this.theme.appearance?.logo?.sidebar === "desktop" || undefined
             }
@@ -193,7 +196,9 @@ export abstract class Theme {
             this.theme.appearance?.tabs?.surface !== "center") {
 
             this.navigation.segments = this.navigation.segments.map(segment => {
-                if (segment.appearance !== "sidebarDropdown") {
+                // only default when unset — a segment that opts into another
+                // appearance (e.g. "logoTrailing") must survive.
+                if (!segment.appearance) {
                     segment.appearance = "sidebarDropdown"
                 }
                 return segment

--- a/packages/xyd-ui/src/components/Nav/NavDropdown.tsx
+++ b/packages/xyd-ui/src/components/Nav/NavDropdown.tsx
@@ -91,6 +91,16 @@ function ChevronRight() {
     );
 }
 
+function Check() {
+    return (
+        <svg part="dropdown-check" width={14} height={14} viewBox="0 0 24 24" fill="none"
+            stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"
+            aria-hidden="true">
+            <path d="M20 6 9 17l-5-5" />
+        </svg>
+    );
+}
+
 function ItemBody({ item }: { item: NavDropdownItem }) {
     return (
         <>
@@ -101,6 +111,9 @@ function ItemBody({ item }: { item: NavDropdownItem }) {
                     <span part="dropdown-description">{item.description}</span>
                 )}
             </span>
+            {/* Switcher check — only the logoTrailing renderer marks items active; the
+                header/tab dropdowns never set `active`, so no check appears there. */}
+            {item.active && <Check />}
         </>
     );
 }


### PR DESCRIPTION
…switcher after the logo

Adds a second `Segment` appearance, `"logoTrailing"`, that renders a segment as a hover product-switcher right after the logo — wherever the active theme places its logo (header for cosmo/opener/solar, sidebar for picasso/poetry, gusto's sidebar.top surface). Unlike `sidebarDropdown`, it is GLOBAL: it appears on every page (a top-level switcher), so users can switch products from anywhere including the landing. The trigger shows the active product (whichever page's route prefixes the current path) falling back to the segment `title`; the active item is checked. Opens on `trigger: "hover"` (default) or `"click"`; a page's nested `dropdownMenu` → submenu.

Placement goes through a new `logo.trailing` surface so one edit covers every theme: FwLogo hosts the surface (gated by a `trailing` prop set at the nav/sidebar logo sites only, so the footer logo never fills it). The renderer reuses the dropdownMenu machinery (Nav.Dropdown + resolveDropdownItems), extended with an active check.

- core: `SegmentAppearance` union + `Segment.trigger`; regenerated docs.json schema.
- framework: `SurfaceTarget.LogoTrailing`; FwLogo `trailing` host; `FwSegmentLogoTrailing` (global — finds the segment from settings, derives the active product from the path)
  + `useLogoTrailingSegment` + pure `resolveLogoTrailingSwitcher`. `useMatchedSubNav` now diverts ANY explicit-appearance segment away from the subnav (a logoTrailing segment must not also render as the subheader below the nav).
- ui: NavDropdown renders a check on `item.active` (switcher only).
- themes: FwNav/gusto/webeditor logo opt into `trailing`; the segments-with-tabs coercion only defaults `appearance` when unset (was clobbering non-default).
- registered on the surface in both app entries (Vite layout.tsx + bun render-tree.tsx).

Tests: unit (`resolveLogoTrailingSwitcher`) + e2e (`3.segments-logo-trailing`, 8 tests: global on the landing, pick-from-landing, renders after the logo, hover opens + active checked, switching navigates + relabels, persists on sub-pages, no footer leak, never a subnav). Docs: navigation.md "Logo Trailing" (Coming Soon).