### PR TITLE
feat(navigation): breadcrumbs — full path + route-based clickable lin…

### DIFF
--- a/__tests__/e2e/1.navigation/4.breadcrumbs/breadcrumbs.test.ts
+++ b/__tests__/e2e/1.navigation/4.breadcrumbs/breadcrumbs.test.ts
@@ -1,0 +1,58 @@
+import { test, expect, Page } from '@playwright/test';
+
+import { createXydServer, createXydBunServer, XydServer } from '../../utils/xyd-server';
+
+// Breadcrumbs: full path (incl. the top-level tab "Guides"), and each crumb is a
+// link ONLY when it resolves to a real route (tab/route, page, or a group with a
+// `page`); a plain group and the current page are plain text. Shared render path,
+// so assert on both engines.
+const ENGINES: { name: string; make: (dir: string) => Promise<XydServer> }[] = [
+    { name: 'bun', make: (dir) => createXydBunServer(dir) },
+    { name: 'vite', make: (dir) => createXydServer(dir) },
+];
+
+for (const engine of ENGINES) {
+    test.describe(`navigation — breadcrumbs (${engine.name} engine)`, () => {
+        let server: XydServer;
+
+        test.beforeAll(async () => { server = await engine.make(__dirname); });
+        test.afterAll(async () => { await server?.stop(); });
+
+        const items = (page: Page) => page.locator('xyd-breadcrumbs [part="item"]');
+        const crumb = (page: Page, text: string) =>
+            page.locator('xyd-breadcrumbs [part="item"]', { hasText: text });
+
+        async function goto(page: Page, path: string) {
+            await page.goto(server.getUrl(path));
+            await page.waitForLoadState('networkidle');
+        }
+
+        test('shows the full path including the root tab (Guides / Customization / Appearance)', async ({ page }) => {
+            await goto(page, '/guides/customization/appearance');
+            await expect(items(page)).toHaveText(['Guides', 'Customization', 'Appearance']);
+        });
+
+        test('links only crumbs with a real route: root tab yes, plain group no, current no', async ({ page }) => {
+            await goto(page, '/guides/customization/appearance');
+            await expect(crumb(page, 'Guides').locator('a')).toHaveCount(1);        // tab route → link
+            await expect(crumb(page, 'Customization').locator('a')).toHaveCount(0); // plain group → text
+            await expect(crumb(page, 'Appearance').locator('a')).toHaveCount(0);    // current page → text
+            await expect(page.locator('xyd-breadcrumbs [part="item"][data-active="true"]')).toHaveText('Appearance');
+        });
+
+        test('the root crumb links to its route', async ({ page }) => {
+            await goto(page, '/guides/customization/appearance');
+            await expect(crumb(page, 'Guides').locator('a')).toHaveAttribute('href', /\/guides$/);
+        });
+
+        test('a group-with-`page` is a clickable breadcrumb and navigates', async ({ page }) => {
+            await goto(page, '/guides/integrations/analytics');
+            await expect(items(page)).toHaveText(['Guides', 'Integrations', 'Analytics']);
+            const link = crumb(page, 'Integrations').locator('a');
+            await expect(link).toHaveCount(1); // group has a `page` → real route → link
+            await link.click();
+            await page.waitForURL(/\/guides\/integrations\/overview$/);
+            await expect(page.locator('h1')).toContainText('Integrations');
+        });
+    });
+}

--- a/__tests__/e2e/1.navigation/4.breadcrumbs/docs.json
+++ b/__tests__/e2e/1.navigation/4.breadcrumbs/docs.json
@@ -1,0 +1,32 @@
+{
+    "theme": {
+        "name": "cosmo",
+        "logo": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2NCIgaGVpZ2h0PSIxOCI+PHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjE4IiByeD0iMyIgZmlsbD0iIzExMSIvPjwvc3ZnPg==",
+        "appearance": { "content": { "breadcrumbs": true } }
+    },
+    "navigation": {
+        "tabs": [ { "title": "Guides", "page": "guides" } ],
+        "sidebar": [
+            {
+                "route": "guides",
+                "pages": [
+                    {
+                        "group": "Customization",
+                        "pages": [
+                            "guides/customization/overview",
+                            "guides/customization/appearance"
+                        ]
+                    },
+                    {
+                        "group": "Integrations",
+                        "page": "guides/integrations/overview",
+                        "pages": [
+                            "guides/integrations/overview",
+                            "guides/integrations/analytics"
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/__tests__/e2e/1.navigation/4.breadcrumbs/guides/customization/appearance.md
+++ b/__tests__/e2e/1.navigation/4.breadcrumbs/guides/customization/appearance.md
@@ -1,0 +1,7 @@
+---
+title: Appearance
+---
+
+# Appearance
+
+Appearance page.

--- a/__tests__/e2e/1.navigation/4.breadcrumbs/guides/customization/overview.md
+++ b/__tests__/e2e/1.navigation/4.breadcrumbs/guides/customization/overview.md
@@ -1,0 +1,7 @@
+---
+title: Customization
+---
+
+# Customization
+
+Customization overview.

--- a/__tests__/e2e/1.navigation/4.breadcrumbs/guides/integrations/analytics.md
+++ b/__tests__/e2e/1.navigation/4.breadcrumbs/guides/integrations/analytics.md
@@ -1,0 +1,7 @@
+---
+title: Analytics
+---
+
+# Analytics
+
+Analytics page.

--- a/__tests__/e2e/1.navigation/4.breadcrumbs/guides/integrations/overview.md
+++ b/__tests__/e2e/1.navigation/4.breadcrumbs/guides/integrations/overview.md
@@ -1,0 +1,7 @@
+---
+title: Integrations
+---
+
+# Integrations
+
+Integrations overview.

--- a/__tests__/e2e/1.navigation/4.breadcrumbs/overview.md
+++ b/__tests__/e2e/1.navigation/4.breadcrumbs/overview.md
@@ -1,0 +1,7 @@
+---
+title: Overview
+---
+
+# Overview
+
+Welcome.

--- a/apps/docs/guides/appearance.md
+++ b/apps/docs/guides/appearance.md
@@ -234,7 +234,38 @@ Customize content appearance and navigation elements:
     }
 }
 ```
+
 ::atlas{apiRefItemKind="secondary" references="@uniform('@core/types/settings.ts', {mini: 'AppearanceContent'})"}
+
+### Breadcrumbs {label="Coming Soon"}
+Breadcrumbs show the full path from the top-level tab/route down to the current page —
+each crumb is a clickable link only when it resolves to a real route (the parent
+tab/route, a page, or a group that declares a `page`); a plain group (no route) and the
+current page are plain text.
+
+`content.breadcrumbs` accepts a boolean, or an object for finer control (both flags
+default to `true`):
+```json
+{
+    "theme": {
+        "appearance": {
+            "content": {
+                "breadcrumbs": {
+                    // !diff +
+                    "links": true,
+                    // !diff +
+                    "rootLevel": true
+                }
+            }
+        }
+    }
+}
+```
+
+- **`links`** — when `true`, breadcrumb items that resolve to a real route render as
+  clickable links; when `false`, every crumb is plain text.
+- **`rootLevel`** — when `true`, the top-level segment (e.g. `Guides`) is shown; when
+  `false`, it is omitted.
 
 ## Navigation Dropdown {label="Coming Soon"}
 Style the [dropdown menus](/guides/navigation) on header anchors and tabs (the

--- a/apps/docs/guides/navigation.md
+++ b/apps/docs/guides/navigation.md
@@ -126,6 +126,11 @@ If you want to have a clickable group as a page, define `page` instead of `group
 }
 ```
 
+Even while the clickable group **header** in the sidebar is still Coming Soon, a
+group that declares a `page` (either a Group Page, or a named group with a `page`)
+already becomes a **clickable breadcrumb** automatically — breadcrumbs link any
+crumb that resolves to a real route. See [breadcrumb `links`](/guides/appearance#content).
+
 ### Routing
 You can also do more advanced routing in the sidebar, like matching based on the specific route:
 

--- a/apps/docs/public/docs.json
+++ b/apps/docs/public/docs.json
@@ -864,6 +864,21 @@
       },
       "type": "object"
     },
+    "AppearanceBreadcrumbs": {
+      "additionalProperties": false,
+      "description": "Fine-grained breadcrumbs options (the object form of  {@link  AppearanceContent.breadcrumbs } ).",
+      "properties": {
+        "links": {
+          "description": "If `true` (default) breadcrumb items that resolve to a real route render as clickable links; if `false` every crumb is plain text.",
+          "type": "boolean"
+        },
+        "rootLevel": {
+          "description": "If `true` (default) the top-level segment (the tab/route the page belongs to, e.g. \"Guides\") is included; if `false` it is omitted.",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "AppearanceButtons": {
       "additionalProperties": false,
       "properties": {
@@ -893,8 +908,15 @@
       "additionalProperties": false,
       "properties": {
         "breadcrumbs": {
-          "description": "If `true` then the breadcrumbs will be displayed.",
-          "type": "boolean"
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/AppearanceBreadcrumbs"
+            }
+          ],
+          "description": "Controls the breadcrumbs. `true`/`false` toggles them; an object ( {@link  AppearanceBreadcrumbs } ) additionally configures `links` and `rootLevel` (both default `true`)."
         },
         "contentDecorator": {
           "const": "secondary",
@@ -2721,6 +2743,10 @@
             }
           ],
           "description": "The order of the group."
+        },
+        "page": {
+          "description": "Makes the group itself a real page (the \"Group Page\" feature). When set, the group resolves to this route — so it becomes a clickable breadcrumb automatically. (Clickable group headers in the sidebar are still Coming Soon.)",
+          "type": "string"
         },
         "pages": {
           "description": "The relative paths to the markdown files that will serve as pages. Note: groups are recursive, so to add a sub-folder add another group object in the page array.",

--- a/packages/xyd-components/src/writer/Breadcrumbs/Breadcrumbs.styles.ts
+++ b/packages/xyd-components/src/writer/Breadcrumbs/Breadcrumbs.styles.ts
@@ -17,7 +17,17 @@ export const BreadcrumbsHost = css`
             transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
             transition-duration: 300ms;
         }
-        
+
+        [part="item"] a {
+            color: inherit;
+            text-decoration: none;
+        }
+
+        [part="item"] a:hover {
+            color: var(--xyd-breadcrumbs-color--hover, var(--xyd-content-color, currentColor));
+            text-decoration: underline;
+        }
+
         [part="item"][data-active="true"] {
         }
     }

--- a/packages/xyd-core/src/types/settings.ts
+++ b/packages/xyd-core/src/types/settings.ts
@@ -361,6 +361,24 @@ export interface AppearanceLogo {
   header?: boolean | "mobile" | "desktop";
 }
 
+/**
+ * Fine-grained breadcrumbs options (the object form of
+ * {@link AppearanceContent.breadcrumbs}).
+ */
+export interface AppearanceBreadcrumbs {
+  /**
+   * If `true` (default) breadcrumb items that resolve to a real route render as
+   * clickable links; if `false` every crumb is plain text.
+   */
+  links?: boolean;
+
+  /**
+   * If `true` (default) the top-level segment (the tab/route the page belongs to,
+   * e.g. "Guides") is included; if `false` it is omitted.
+   */
+  rootLevel?: boolean;
+}
+
 export interface AppearanceContent {
   /**
    * Content decorator for the theme.
@@ -368,9 +386,11 @@ export interface AppearanceContent {
   contentDecorator?: "secondary";
 
   /**
-   * If `true` then the breadcrumbs will be displayed.
+   * Controls the breadcrumbs. `true`/`false` toggles them; an object
+   * ({@link AppearanceBreadcrumbs}) additionally configures `links` and
+   * `rootLevel` (both default `true`).
    */
-  breadcrumbs?: boolean;
+  breadcrumbs?: boolean | AppearanceBreadcrumbs;
 
   /**
    * If `true` then the section separator will be displayed.
@@ -683,6 +703,13 @@ export interface SidebarRoute {
 export interface Sidebar {
   /** The name of the group */
   group?: string | false;
+
+  /**
+   * Makes the group itself a real page (the "Group Page" feature). When set, the
+   * group resolves to this route — so it becomes a clickable breadcrumb
+   * automatically. (Clickable group headers in the sidebar are still Coming Soon.)
+   */
+  page?: string;
 
   /**
    * The relative paths to the markdown files that will serve as pages.

--- a/packages/xyd-framework/__tests__/breadcrumbs.test.ts
+++ b/packages/xyd-framework/__tests__/breadcrumbs.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+
+import type { Navigation, MetadataMap } from "@xyd-js/core";
+
+import { resolveBreadcrumbs } from "../packages/hydration/breadcrumbs";
+import { displayBreadcrumbs } from "../packages/react/utils/breadcrumbs";
+
+// route "guides" (labelled by the tab "Guides") → group "Customization" (plain, no route)
+// and a group-with-page "Integrations" (the Group-Page feature) → analytics page.
+const navigation = {
+    tabs: [{ title: "Guides", page: "guides" }],
+    sidebar: [
+        {
+            route: "guides",
+            pages: [
+                { group: "Customization", pages: ["guides/customization-quickstart", "guides/appearance"] },
+                { group: "Integrations", page: "guides/integrations", pages: ["guides/integrations/analytics"] },
+            ],
+        },
+        {
+            // a second route WITHOUT a tab → label falls back to the Title-Cased segment
+            route: "reference",
+            pages: [{ group: "Core", pages: ["reference/core"] }],
+        },
+    ],
+} as unknown as Navigation;
+
+const frontmatters: MetadataMap = {
+    "guides/appearance": { title: "Appearance" },
+    "guides/integrations/analytics": { title: "Analytics" },
+    "reference/core": { title: "Core" },
+} as any;
+
+const crumbs = (slug: string) => resolveBreadcrumbs(navigation, slug, frontmatters, {});
+
+describe("resolveBreadcrumbs", () => {
+    it("includes the top-level tab/route crumb (the bug: 'Guides' was dropped)", () => {
+        const bc = crumbs("guides/appearance");
+        expect(bc.map((c) => c.title)).toEqual(["Guides", "Customization", "Appearance"]);
+    });
+
+    it("gives the root (tab) a real href and the current page a real href", () => {
+        const bc = crumbs("guides/appearance");
+        expect(bc[0]).toEqual({ title: "Guides", href: "/guides" }); // clickable (tab route)
+        expect(bc[2]).toEqual({ title: "Appearance", href: "/guides/appearance" });
+    });
+
+    it("leaves a plain group NON-clickable (empty href)", () => {
+        const bc = crumbs("guides/appearance");
+        expect(bc[1]).toEqual({ title: "Customization", href: "" }); // plain group → text
+    });
+
+    it("makes a group-with-`page` clickable automatically (generic Group-Page detection)", () => {
+        const bc = crumbs("guides/integrations/analytics");
+        expect(bc.map((c) => c.title)).toEqual(["Guides", "Integrations", "Analytics"]);
+        expect(bc[1].href).toBe("/guides/integrations"); // group has a page → real route → link
+    });
+
+    it("detects a canonical Group Page (`page` instead of `group`) — title from frontmatter, clickable", () => {
+        const nav = {
+            sidebar: [
+                { route: "docs", pages: [{ page: "docs/integrations", pages: ["docs/integrations/analytics"] }] },
+            ],
+        } as unknown as Navigation;
+        const fm = {
+            "docs/integrations": { title: "Integrations" },
+            "docs/integrations/analytics": { title: "Analytics" },
+        } as any;
+        const bc = resolveBreadcrumbs(nav, "docs/integrations/analytics", fm, {});
+        expect(bc.map((c) => c.title)).toEqual(["Docs", "Integrations", "Analytics"]);
+        expect(bc[1].href).toBe("/docs/integrations"); // Group Page → link, title from Page Meta
+    });
+
+    it("falls back to the Title-Cased route segment when no tab labels it", () => {
+        const bc = crumbs("reference/core");
+        expect(bc[0]).toEqual({ title: "Reference", href: "/reference" });
+    });
+
+    it("returns [] for an unknown page", () => {
+        expect(crumbs("does/not/exist")).toEqual([]);
+    });
+
+    it("only crumbs with a truthy href are links (the render rule)", () => {
+        // mirrors Breadcrumbs.tsx: `item.href && !lastActive`
+        const bc = crumbs("guides/integrations/analytics");
+        const linkable = bc.slice(0, -1).filter((c) => !!c.href).map((c) => c.title);
+        expect(linkable).toEqual(["Guides", "Integrations"]); // plain groups would be excluded
+    });
+});
+
+describe("displayBreadcrumbs (content.breadcrumbs options)", () => {
+    const trail = crumbs("guides/appearance"); // [Guides, Customization, Appearance]
+
+    it("defaults (true / bare boolean): keeps hrefs and the root crumb", () => {
+        expect(displayBreadcrumbs(trail, true)).toEqual(trail);
+        expect(displayBreadcrumbs(trail, undefined)).toEqual(trail);
+        expect(displayBreadcrumbs(trail, {})).toEqual(trail);
+    });
+
+    it("links:false → strips every href (all plain text)", () => {
+        const out = displayBreadcrumbs(trail, { links: false });
+        expect(out.map((c) => c.href)).toEqual(["", "", ""]);
+        expect(out.map((c) => c.title)).toEqual(["Guides", "Customization", "Appearance"]);
+    });
+
+    it("rootLevel:false → drops the top 'Guides' crumb (hrefs preserved)", () => {
+        const out = displayBreadcrumbs(trail, { rootLevel: false });
+        expect(out.map((c) => c.title)).toEqual(["Customization", "Appearance"]);
+        expect(out[1].href).toBe("/guides/appearance");
+    });
+
+    it("both toggles compose", () => {
+        const out = displayBreadcrumbs(trail, { links: false, rootLevel: false });
+        expect(out.map((c) => c.title)).toEqual(["Customization", "Appearance"]);
+        expect(out.every((c) => c.href === "")).toBe(true);
+    });
+});

--- a/packages/xyd-framework/packages/hydration/breadcrumbs.ts
+++ b/packages/xyd-framework/packages/hydration/breadcrumbs.ts
@@ -1,0 +1,172 @@
+// server-only — pure breadcrumb resolution (unit-tested in isolation).
+//
+// Extracted from mapSettingsToProps. Produces the FULL path from the top-level
+// tab/route down to the current page, with a real `href` on every crumb that
+// resolves to a navigable route (tab/route, page, or a group that declares a
+// `page`). Plain groups (no route) get `href: ""` → rendered as text. The
+// current page (last crumb) is never linked (handled by the UI component).
+
+import type { Navigation, PageURL, Sidebar, MetadataMap } from "@xyd-js/core";
+
+import type { IBreadcrumb } from "@xyd-js/ui";
+
+type Crumb = { type: "group" | "page"; title: string; href: string; page?: string };
+type TabLike = { title?: string; page?: string; href?: string; route?: string };
+
+/** Resolve a page/route string to a link (index → "/", external passthrough,
+ *  ensure leading slash). Mirrors the shared `pageLink` util. */
+function linkFor(page?: string): string {
+    if (!page) return "";
+    if (page === "index" || page === "/index") return "/";
+    if (page.startsWith("http://") || page.startsWith("https://")) return page;
+    return page.startsWith("/") ? page : `/${page}`;
+}
+
+function getGroupTitle(group: any): string {
+    return typeof group === "string" && group.length > 0 ? group : "";
+}
+
+function normRoute(s?: string): string {
+    return (s || "").replace(/^\//, "").replace(/\/+$/, "");
+}
+
+/** Title for a route with no `group` — from the owning tab if one points at it,
+ *  else the Title-Cased last segment of the route. */
+function resolveRouteRoot(tabs: TabLike[] | undefined, route: string): { title: string; href: string } {
+    const r = normRoute(route);
+    const tab = (tabs || []).find(
+        (t) => normRoute(t.page) === r || normRoute(t.href) === r || normRoute(t.route) === r,
+    );
+    if (tab?.title) {
+        return { title: tab.title, href: linkFor(tab.page || tab.href || route) };
+    }
+    const seg = r.split("/").pop() || r;
+    return { title: seg.charAt(0).toUpperCase() + seg.slice(1), href: linkFor(route) };
+}
+
+/** Find the path (root → current page) through the navigation tree. */
+function findPathToPage(
+    sidebar: any[],
+    targetSlug: string,
+    frontmatters: MetadataMap,
+    hiddenPages: { [key: string]: boolean },
+    tabs: TabLike[] | undefined,
+): Crumb[] {
+    const path: Crumb[] = [];
+
+    // A nested-`pages` node is a group. Generic clickability:
+    //  - named group `{ group: "X", pages }` → crumb "X", not a link (no route);
+    //  - clickable named group `{ group: "X", page: "y", pages }` → crumb "X" → link;
+    //  - Group Page `{ page: "y", pages }` (page instead of group) → crumb titled by
+    //    the page's frontmatter → link.
+    // So a group becomes a link the moment it declares a `page` — no special-casing.
+    const groupCrumb = (node: any): Crumb | null => {
+        if (node.group && typeof node.group === "string") {
+            return { type: "group", title: node.group, href: node.page ? linkFor(node.page) : "" };
+        }
+        if (typeof node.page === "string") {
+            return { type: "group", title: frontmatters[node.page]?.title || node.page, href: linkFor(node.page) };
+        }
+        return null;
+    };
+
+    function searchInNavigation(nav: any[], currentPath: Crumb[]): boolean {
+        for (const item of nav) {
+            if (typeof item === "string") {
+                continue;
+            }
+
+            if ("route" in item) {
+                if (item.pages) {
+                    const newPath = [...currentPath];
+                    // ALWAYS emit the route crumb (was: only when it had a `group`) so the
+                    // top-level segment ("Guides") is never dropped. Label from the route's
+                    // `group`, else the owning tab, else the route segment; href = the route.
+                    const groupTitle = getGroupTitle(item.group);
+                    if (groupTitle) {
+                        newPath.push({ type: "group", title: groupTitle, href: linkFor(item.route) });
+                    } else {
+                        const root = resolveRouteRoot(tabs, item.route);
+                        newPath.push({ type: "group", title: root.title, href: root.href });
+                    }
+                    if (searchInPages(item.pages, newPath)) {
+                        path.push(...newPath);
+                        return true;
+                    }
+                }
+            } else {
+                const newPath = [...currentPath];
+                const gc = groupCrumb(item);
+                if (gc) newPath.push(gc);
+                if (item.pages && searchInPages(item.pages, newPath)) {
+                    path.push(...newPath);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    function searchInPages(pages: PageURL[], currentPath: Crumb[]): boolean {
+        for (const page of pages) {
+            if (typeof page === "string") {
+                if (page === targetSlug && !hiddenPages[page]) {
+                    currentPath.push({ type: "page", title: frontmatters[page]?.title || page, href: linkFor(page), page });
+                    return true;
+                }
+            } else if ("virtual" in page) {
+                if (page.page === targetSlug && !hiddenPages[page.page]) {
+                    currentPath.push({ type: "page", title: frontmatters[page.page]?.title || page.page, href: linkFor(page.page), page: page.page });
+                    return true;
+                }
+            } else if ("pages" in page) {
+                const newPath = [...currentPath];
+                const gc = groupCrumb(page);
+                if (gc) newPath.push(gc);
+                if (searchInPages(page.pages || [], newPath)) {
+                    currentPath.length = 0;
+                    currentPath.push(...newPath);
+                    return true;
+                }
+            } else if ("page" in page && typeof page === "object") {
+                const pageName = (page as { page: string }).page;
+                if (pageName === targetSlug && !hiddenPages[pageName]) {
+                    currentPath.push({ type: "page", title: frontmatters[pageName]?.title || pageName, href: linkFor(pageName), page: pageName });
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    searchInNavigation(sidebar, []);
+    return path;
+}
+
+/**
+ * Resolve the full breadcrumb trail for `slug`. Pure: given the navigation
+ * (sidebar + tabs) and the page frontmatters, returns the crumbs top→current
+ * with real hrefs where a crumb is a navigable route.
+ */
+export function resolveBreadcrumbs(
+    navigation: Navigation | undefined,
+    slug: string,
+    frontmatters: MetadataMap,
+    hiddenPages: { [key: string]: boolean },
+): IBreadcrumb[] {
+    const sidebar = (navigation?.sidebar as any[]) || [];
+    const tabs = (navigation as any)?.tabs as TabLike[] | undefined;
+
+    const path = findPathToPage(sidebar, slug, frontmatters, hiddenPages, tabs);
+    if (!path.length) return [];
+
+    const breadcrumbs: IBreadcrumb[] = [];
+    for (const item of path) {
+        if (item.type === "group") {
+            breadcrumbs.push({ title: item.title, href: item.href });
+        } else if (item.type === "page" && item.page) {
+            breadcrumbs.push({ title: frontmatters[item.page]?.title || item.page, href: linkFor(item.page) });
+        }
+    }
+    return breadcrumbs;
+}

--- a/packages/xyd-framework/packages/hydration/mapSettingsToProps.ts
+++ b/packages/xyd-framework/packages/hydration/mapSettingsToProps.ts
@@ -6,6 +6,7 @@ import { IBreadcrumb, INavLinks } from "@xyd-js/ui";
 
 import { FwSidebarItemProps } from "../react";
 import { resolveLocaleSettings } from "./locale";
+import { resolveBreadcrumbs } from "./breadcrumbs";
 
 // TODO: framework vs content responsibility
 
@@ -65,8 +66,9 @@ export async function mapSettingsToProps(
         return acc
     }, {})
 
-    // Build breadcrumbs by finding the path to the current page
-    const breadcrumbs = buildBreadcrumbs(filteredNav, slug, frontmatters, hiddenPages)
+    // Build breadcrumbs from the FULL navigation (not the route-filtered nav) so
+    // the top-level tab/route segment (e.g. "Guides") is included. See ./breadcrumbs.
+    const breadcrumbs = resolveBreadcrumbs(effectiveSettings.navigation, slug, frontmatters, hiddenPages)
 
     function mapItems(
         page: PageURL,
@@ -445,156 +447,6 @@ function findResolvedPagesBFS(sidebar: Sidebar): string[] {
     }
 
     return resolvedPages
-}
-
-// Helper function to safely get group title
-function getGroupTitle(group: any): string {
-    return (typeof group === 'string' && group.length > 0) ? group : ''
-}
-
-// Build breadcrumbs by finding the path to the current page
-function buildBreadcrumbs(
-    navigation: Sidebar[],
-    currentSlug: string,
-    frontmatters: MetadataMap,
-    hiddenPages: { [key: string]: boolean }
-): IBreadcrumb[] {
-    const breadcrumbs: IBreadcrumb[] = []
-
-    // Find the path to the current page
-    const path = findPathToPage(navigation, currentSlug, frontmatters, hiddenPages)
-    if (!path?.length) {
-        return []
-    }
-
-    for (const item of path) {
-        if (item.type === 'group') {
-            breadcrumbs.push({
-                title: item.title,
-                href: item.href
-            })
-        } else if (item.type === 'page' && item.page) {
-            const pageTitle = frontmatters[item.page]?.title || item.page
-            breadcrumbs.push({
-                title: pageTitle,
-                href: safePageLink(item.page)
-            })
-        }
-    }
-
-    return breadcrumbs
-}
-
-// Find the path from root to the current page
-function findPathToPage(
-    navigation: Sidebar[],
-    targetSlug: string,
-    frontmatters: MetadataMap,
-    hiddenPages: { [key: string]: boolean }
-): Array<{ type: 'group' | 'page', title: string, href: string, page?: string }> {
-    const path: Array<{ type: 'group' | 'page', title: string, href: string, page?: string }> = []
-
-    function searchInNavigation(nav: Sidebar[], currentPath: Array<{ type: 'group' | 'page', title: string, href: string, page?: string }>): boolean {
-        for (const item of nav) {
-            if (typeof item === "string") {
-                path.push(item)
-                return false
-            }
-
-            if ("route" in item) {
-                // Handle route-based navigation
-                if (item.pages) {
-                    const newPath = [...currentPath]
-                    if (item.group && typeof item.group === 'string' && item.group.length > 0) {
-                        newPath.push({
-                            type: 'group',
-                            title: getGroupTitle(item.group),
-                            href: (item.route as string) || ""
-                        })
-                    }
-
-                    if (searchInPages(item.pages, newPath)) {
-                        path.push(...newPath)
-                        return true
-                    }
-                }
-            } else {
-                // Handle regular sidebar navigation
-                const newPath = [...currentPath]
-                if (item.group && typeof item.group === 'string') {
-                    newPath.push({
-                        type: 'group',
-                        title: item.group,
-                        href: ""
-                    })
-                }
-
-                if (item.pages && searchInPages(item.pages, newPath)) {
-                    path.push(...newPath)
-                    return true
-                }
-            }
-        }
-        return false
-    }
-
-    function searchInPages(pages: PageURL[], currentPath: Array<{ type: 'group' | 'page', title: string, href: string, page?: string }>): boolean {
-        for (const page of pages) {
-            if (typeof page === "string") {
-                if (page === targetSlug && !hiddenPages[page]) {
-                    currentPath.push({
-                        type: 'page',
-                        title: frontmatters[page]?.title || page,
-                        href: safePageLink(page),
-                        page: page
-                    })
-                    return true
-                }
-            } else if ("virtual" in page) {
-                if (page.page === targetSlug && !hiddenPages[page.page]) {
-                    currentPath.push({
-                        type: 'page',
-                        title: frontmatters[page.page]?.title || page.page,
-                        href: safePageLink(page.page),
-                        page: page.page
-                    })
-                    return true
-                }
-            } else if ("pages" in page) {
-                // Nested sidebar - only add to path if we find the target in this branch
-                const newPath = [...currentPath]
-                if (page.group && typeof page.group === 'string') {
-                    newPath.push({
-                        type: 'group',
-                        title: page.group,
-                        href: ""
-                    })
-                }
-
-                if (searchInPages(page.pages || [], newPath)) {
-                    // Replace current path with the new path that includes the group
-                    currentPath.length = 0
-                    currentPath.push(...newPath)
-                    return true
-                }
-            } else if ("page" in page && typeof page === "object") {
-                const pageName = (page as { page: string }).page
-                if (pageName === targetSlug && !hiddenPages[pageName]) {
-                    currentPath.push({
-                        type: 'page',
-                        title: frontmatters[pageName]?.title || pageName,
-                        href: safePageLink(pageName),
-                        page: pageName
-                    })
-                    return true
-                }
-            }
-        }
-        return false
-    }
-
-    searchInNavigation(navigation, [])
-    return path
 }
 
 // In i18n mode, resolve the right per-language navigation block for the

--- a/packages/xyd-framework/packages/react/components/FwBreadcrumbs.tsx
+++ b/packages/xyd-framework/packages/react/components/FwBreadcrumbs.tsx
@@ -1,18 +1,24 @@
 import React from "react";
 
-import {Breadcrumbs} from "@xyd-js/components/writer";
+import { Breadcrumbs } from "@xyd-js/components/writer";
 
-import {useBreadcrumbs} from "../contexts";
+import { useBreadcrumbs, useAppearance } from "../contexts";
+import { displayBreadcrumbs } from "../utils";
+import { FwLink } from "./FwLink";
 
 export function FwBreadcrumbs() {
     const fwBreadcrumbs = useBreadcrumbs()
+    const appearance = useAppearance()
 
-    const breadcrumbs = fwBreadcrumbs?.map(item => ({
-        title: item.title,
-        href: item.href
-    }))
+    // `content.breadcrumbs` is `boolean | { links?, rootLevel? }` (both default true):
+    // links:false → plain text; rootLevel:false → drop the top tab/route crumb.
+    const breadcrumbs = displayBreadcrumbs(
+        (fwBreadcrumbs as any) || [],
+        appearance?.content?.breadcrumbs,
+    )
 
     return <Breadcrumbs
-        items={breadcrumbs || []}
+        items={breadcrumbs}
+        as={FwLink}
     />
 }

--- a/packages/xyd-framework/packages/react/utils/breadcrumbs.ts
+++ b/packages/xyd-framework/packages/react/utils/breadcrumbs.ts
@@ -1,0 +1,21 @@
+import type { AppearanceContent } from "@xyd-js/core";
+import type { IBreadcrumb } from "@xyd-js/ui";
+
+/**
+ * Apply the `content.breadcrumbs` display options to a resolved trail. Pure, so
+ * the render component (`FwBreadcrumbs`) stays trivial and this stays
+ * unit-testable: `links:false` strips every href (all text); `rootLevel:false`
+ * drops the top (tab/route) crumb. Both default `true`; a bare boolean uses the
+ * defaults.
+ */
+export function displayBreadcrumbs(
+    items: IBreadcrumb[],
+    option: AppearanceContent["breadcrumbs"],
+): IBreadcrumb[] {
+    const links = typeof option === "object" ? option.links ?? true : true;
+    const rootLevel = typeof option === "object" ? option.rootLevel ?? true : true;
+
+    let out = (items || []).map((item) => ({ title: item.title, href: links ? item.href : "" }));
+    if (!rootLevel && out.length) out = out.slice(1);
+    return out;
+}

--- a/packages/xyd-framework/packages/react/utils/index.ts
+++ b/packages/xyd-framework/packages/react/utils/index.ts
@@ -20,3 +20,7 @@ export {
     resolveLogoTrailingSwitcher,
 } from "./segmentLogoTrailing"
 export type { LogoTrailingItem, LogoTrailingSwitcher } from "./segmentLogoTrailing"
+
+export {
+    displayBreadcrumbs,
+} from "./breadcrumbs"


### PR DESCRIPTION
…ks + options

Breadcrumbs were plain text, dropped the top-level segment, and had no clickability logic. Now they show the full path from the owning tab/route down to the current page, and each crumb is a link ONLY when it resolves to a real navigable route — the same thing a user can click in the primary nav. The current page is never a link.

- Full path: the builder now walks the FULL navigation (not the route-filtered nav), so the top-level route crumb is emitted; its label comes from the route's `group`, else the owning tab (`navigation.tabs`), else the Title-Cased route segment.
- Clickable: a generic `resolveCrumbHref` — a crumb links iff it has a route (tab/route, page, or a group that declares a `page`). Plain groups (no route) stay text. This auto-detects the "Group Page" feature (`page` on a sidebar group, or a named group with a `page`) without special-casing; the clickable group HEADER in the sidebar stays Coming Soon (untouched).
- Appearance: `content.breadcrumbs` widened from `boolean` to `boolean | { links?: boolean; rootLevel?: boolean }` (both default true) — `links:false` → all text; `rootLevel:false` → hide the top segment.
- Render: FwBreadcrumbs passes `as={FwLink}` (router links) + applies the options via a pure `displayBreadcrumbs`; the UI `Breadcrumbs` already links truthy-href non-last crumbs. Minimal `[part="item"] a` styling added.

The builder is extracted to a pure `hydration/breadcrumbs.ts` (`resolveBreadcrumbs`) and the display logic to `react/utils/breadcrumbs.ts` (`displayBreadcrumbs`). Types: `AppearanceBreadcrumbs` + `Sidebar.page`. Schema regenerated.

Tests: unit (`breadcrumbs.test.ts` — full path incl. root, plain vs clickable group, Group Page auto-detect, links/rootLevel) + e2e (`4.breadcrumbs`, both engines — full path, real-route links only, group-with-page navigates). Docs: appearance.md (the object form) + navigation.md (Group-Page → clickable breadcrumb note).