### PR TITLE
feat(themes): terrarium — HashiCorp-style full-width theme + product-…

### DIFF
--- a/__tests__/e2e/7.themes/4.terrarium/components/TestSegmentPanel.tsx
+++ b/__tests__/e2e/7.themes/4.terrarium/components/TestSegmentPanel.tsx
@@ -1,0 +1,16 @@
+import React from "react"
+
+import { useActiveLogoTrailingItem } from "@xyd-js/framework/react"
+
+// Custom segment PANEL component (referenced from docs.json's logoTrailing
+// segment). Proves a segment `component` renders as the dropdown panel and can
+// use framework hooks.
+export default function TestSegmentPanel() {
+    const product = useActiveLogoTrailingItem()
+    return (
+        <div part="segment-panel" data-product={product?.title || ""}>
+            <a href="/nomad/docs/what-is-nomad">Nomad docs</a>
+            <a href="/consul/docs/what-is-consul">Consul docs</a>
+        </div>
+    )
+}

--- a/__tests__/e2e/7.themes/4.terrarium/components/TestSidebarWidget.tsx
+++ b/__tests__/e2e/7.themes/4.terrarium/components/TestSidebarWidget.tsx
@@ -1,0 +1,12 @@
+import React from "react"
+
+import { useActiveLogoTrailingItem } from "@xyd-js/framework/react"
+
+// Custom sidebar-item component (referenced from docs.json). Uses a framework
+// hook to prove hooks work inside sidebar components.
+export default function TestSidebarWidget(props: { label?: string }) {
+    const product = useActiveLogoTrailingItem()
+    return <div part="test-widget" data-product={product?.title || ""}>
+        {props.label || "Widget"}
+    </div>
+}

--- a/__tests__/e2e/7.themes/4.terrarium/consul/docs/what-is-consul.md
+++ b/__tests__/e2e/7.themes/4.terrarium/consul/docs/what-is-consul.md
@@ -1,0 +1,5 @@
+---
+title: What is Consul?
+---
+# What is Consul?
+A service networking solution.

--- a/__tests__/e2e/7.themes/4.terrarium/docs.json
+++ b/__tests__/e2e/7.themes/4.terrarium/docs.json
@@ -1,0 +1,185 @@
+{
+    "theme": {
+        "name": "terrarium",
+        "logo": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2NCIgaGVpZ2h0PSIxOCI+PHJlY3Qgd2lkdGg9IjY0IiBoZWlnaHQ9IjE4IiByeD0iMyIgZmlsbD0iIzExMSIvPjx0ZXh0IHg9IjgiIHk9IjEzIiBmb250LWZhbWlseT0ic2Fucy1zZXJpZiIgZm9udC1zaXplPSIxMSIgZm9udC13ZWlnaHQ9IjcwMCIgZmlsbD0iI2ZmZiI+ZG9jczwvdGV4dD48L3N2Zz4="
+    },
+    "components": {
+        "filterSidebar": {
+            "placeholder": "Filter sidebar",
+            "routes": [
+                "nomad"
+            ]
+        }
+    },
+    "navigation": {
+        "segments": [
+            {
+                "title": "Products",
+                "appearance": "logoTrailing",
+                "trigger": "hover",
+                "pages": [
+                    {
+                        "title": "Nomad",
+                        "page": "nomad",
+                        "href": "nomad/docs/what-is-nomad",
+                        "icon": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxNiIgaGVpZ2h0PSIxNiI+PHJlY3Qgd2lkdGg9IjE2IiBoZWlnaHQ9IjE2IiBmaWxsPSIjMDBjYThlIi8+PC9zdmc+",
+                        "color": "#00ca8e"
+                    },
+                    {
+                        "title": "Consul",
+                        "page": "consul",
+                        "href": "consul/docs/what-is-consul",
+                        "icon": "lock",
+                        "color": "#dc477d"
+                    }
+                ],
+                "iconOnly": true,
+                "component": {
+                    "import": "./components/TestSegmentPanel"
+                }
+            },
+            {
+                "route": "nomad",
+                "appearance": "tabs",
+                "pages": [
+                    {
+                        "title": "Documentation",
+                        "page": "nomad/docs",
+                        "href": "nomad/docs/what-is-nomad"
+                    },
+                    {
+                        "title": "API",
+                        "page": "nomad/api",
+                        "href": "nomad/api/overview"
+                    },
+                    {
+                        "title": "Guides",
+                        "trigger": "hover",
+                        "dropdownMenu": {
+                            "itemsPerColumn": 1,
+                            "items": [
+                                {
+                                    "title": "Getting Started",
+                                    "page": "nomad/docs",
+                                    "href": "nomad/docs/what-is-nomad",
+                                    "icon": "book"
+                                },
+                                {
+                                    "title": "API Reference",
+                                    "page": "nomad/api",
+                                    "href": "nomad/api/overview",
+                                    "icon": "server"
+                                }
+                            ]
+                        }
+                    }
+                ]
+            },
+            {
+                "route": "consul",
+                "appearance": "tabs",
+                "pages": [
+                    {
+                        "title": "Documentation",
+                        "page": "consul/docs",
+                        "href": "consul/docs/what-is-consul"
+                    }
+                ]
+            },
+            {
+                "route": "nomad",
+                "appearance": {
+                    "kind": "sidebarDropdown",
+                    "options": {
+                        "fixed": true
+                    }
+                },
+                "pages": [
+                    {
+                        "title": "Documentation",
+                        "page": "nomad/docs",
+                        "href": "nomad/docs/what-is-nomad"
+                    },
+                    {
+                        "title": "API",
+                        "page": "nomad/api",
+                        "href": "nomad/api/overview"
+                    }
+                ]
+            }
+        ],
+        "sidebar": [
+            "overview",
+            {
+                "route": "nomad/docs",
+                "pages": [
+                    {
+                        "fixed": true,
+                        "component": {
+                            "import": "./components/TestSidebarWidget",
+                            "props": {
+                                "label": "Pinned Widget"
+                            }
+                        }
+                    },
+                    {
+                        "group": "Nomad",
+                        "pages": [
+                            "nomad/docs/what-is-nomad",
+                            "nomad/docs/quickstart"
+                        ]
+                    },
+                    {
+                        "group": "Operations",
+                        "pages": [
+                            "nomad/docs/architecture"
+                        ]
+                    }
+                ]
+            },
+            {
+                "route": "nomad/api",
+                "pages": [
+                    {
+                        "fixed": true,
+                        "component": "./components/TestSidebarWidget"
+                    },
+                    {
+                        "group": "HTTP API",
+                        "pages": [
+                            "nomad/api/overview",
+                            {
+                                "group": "Advanced",
+                                "pages": [
+                                    "nomad/api/acl"
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            },
+            {
+                "route": "consul/docs",
+                "pages": [
+                    {
+                        "group": "Consul",
+                        "pages": [
+                            "consul/docs/what-is-consul"
+                        ]
+                    }
+                ]
+            },
+            {
+                "route": "nomad/other",
+                "pages": [
+                    {
+                        "group": "Other",
+                        "pages": [
+                            "nomad/other/index"
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/__tests__/e2e/7.themes/4.terrarium/nomad/api/acl.md
+++ b/__tests__/e2e/7.themes/4.terrarium/nomad/api/acl.md
@@ -1,0 +1,5 @@
+---
+title: ACL - HTTP API
+---
+# ACL HTTP API
+Manage ACL tokens.

--- a/__tests__/e2e/7.themes/4.terrarium/nomad/api/overview.md
+++ b/__tests__/e2e/7.themes/4.terrarium/nomad/api/overview.md
@@ -1,0 +1,5 @@
+---
+title: HTTP API
+---
+# HTTP API
+The Nomad HTTP API.

--- a/__tests__/e2e/7.themes/4.terrarium/nomad/docs/architecture.md
+++ b/__tests__/e2e/7.themes/4.terrarium/nomad/docs/architecture.md
@@ -1,0 +1,5 @@
+---
+title: Architecture
+---
+# Architecture
+Servers, clients, jobs.

--- a/__tests__/e2e/7.themes/4.terrarium/nomad/docs/quickstart.md
+++ b/__tests__/e2e/7.themes/4.terrarium/nomad/docs/quickstart.md
@@ -1,0 +1,5 @@
+---
+title: Quickstart
+---
+# Quickstart
+Run a dev agent.

--- a/__tests__/e2e/7.themes/4.terrarium/nomad/docs/what-is-nomad.md
+++ b/__tests__/e2e/7.themes/4.terrarium/nomad/docs/what-is-nomad.md
@@ -1,0 +1,14 @@
+---
+title: What is Nomad?
+---
+# What is Nomad?
+
+A workload orchestrator. See the [architecture](/nomad/docs/architecture) for details.
+
+## Key features
+
+Deploy containers and legacy apps.
+
+## Architecture overview
+
+Servers, clients, and jobs.

--- a/__tests__/e2e/7.themes/4.terrarium/nomad/other/index.md
+++ b/__tests__/e2e/7.themes/4.terrarium/nomad/other/index.md
@@ -1,0 +1,8 @@
+---
+title: Other Tools
+description: A nomad section that is NOT part of the sidebarDropdown switcher.
+---
+
+# Other Tools
+
+This section is outside the Documentation/API switcher.

--- a/__tests__/e2e/7.themes/4.terrarium/overview.md
+++ b/__tests__/e2e/7.themes/4.terrarium/overview.md
@@ -1,0 +1,5 @@
+---
+title: Overview
+---
+# Overview
+Multi-product docs on the terrarium theme.

--- a/__tests__/e2e/7.themes/4.terrarium/terrarium.test.ts
+++ b/__tests__/e2e/7.themes/4.terrarium/terrarium.test.ts
@@ -1,0 +1,516 @@
+import { test, expect, Page } from '@playwright/test';
+
+import { createXydServer, createXydBunServer, XydServer } from '../../utils/xyd-server';
+
+// The terrarium theme: full-width, high-contrast docs with a ~800px left-aligned
+// content column, a decoupled TOC, a taller nav, a fixed sidebar, non-uppercased
+// group headers, blue links, a per-product brand accent (driven by a logoTrailing
+// product's `color`), HashiCorp-style sidebar chrome, a GLOBAL product switcher
+// (routeless segment), and per-product `appearance:"tabs"` tab bars. The render
+// path is shared, so we assert the same behavior on BOTH engines.
+const ENGINES: { name: string; make: (dir: string) => Promise<XydServer> }[] = [
+    { name: 'bun', make: (dir) => createXydBunServer(dir) },
+    { name: 'vite', make: (dir) => createXydServer(dir) },
+];
+
+for (const engine of ENGINES) {
+    test.describe(`themes — terrarium (${engine.name} engine)`, () => {
+        let server: XydServer;
+
+        test.beforeAll(async () => {
+            server = await engine.make(__dirname);
+        });
+
+        test.afterAll(async () => {
+            await server?.stop();
+        });
+
+        async function goto(page: Page, path: string) {
+            await page.goto(server.getUrl(path));
+            await page.waitForLoadState('networkidle');
+        }
+
+        // The COMPUTED accent — not the inline var. Custom properties resolve where
+        // they're declared, so asserting the inline `--theme-color-primary` alone
+        // once masked a bug where `--color-primary` still computed to the theme
+        // fallback (green) everywhere.
+        const accentOf = (page: Page) =>
+            page.locator('xyd-layout-primary').evaluate(
+                (el) => getComputedStyle(el as HTMLElement).getPropertyValue('--color-primary').trim(),
+            );
+
+        // terrarium renders `appearance:"tabs"` segments in the primary-nav CENTER
+        // (appearance.tabs.surface === "center"), not in a subnav.
+        const tabTexts = (page: Page) =>
+            page.locator('[part="nav-center"] xyd-nav-item').allInnerTexts();
+
+        test('full-width layout: ~800px content column and a 64px nav', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+
+            const navHeight = await page.evaluate(() =>
+                getComputedStyle(document.documentElement).getPropertyValue('--xyd-nav-height').trim(),
+            );
+            expect(navHeight).toBe('64px');
+
+            const maxWidth = await page.locator('[part="page-article"]').evaluate((el) => getComputedStyle(el).maxWidth);
+            expect(maxWidth).toBe('800px');
+
+            const containerMax = await page.locator('[part="page-container"]').first()
+                .evaluate((el) => getComputedStyle(el).maxWidth);
+            expect(containerMax).toBe('100%');
+        });
+
+        test('the left sidebar is fixed (sticky), scrolling independently of content', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            const position = await page.locator('[part="sidebar"]')
+                .evaluate((el) => getComputedStyle(el).position);
+            expect(position).toBe('sticky');
+        });
+
+        test('group headers are NOT uppercased (groupCase: none) and are 13px', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            const header = page.locator('aside[part="sidebar"] [part="item-header"]').first();
+            expect(await header.evaluate((el) => getComputedStyle(el).textTransform)).toBe('none');
+            expect(await header.evaluate((el) => getComputedStyle(el).fontSize)).toBe('13px');
+        });
+
+        test('groups are separated by a divider between sections (none above the first)', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            const headers = page.locator('aside[part="sidebar"] [part="item-header"]');
+            await expect(headers).toHaveCount(2);
+            // the first group has no divider above it…
+            const first = await headers.nth(0).evaluate((el) => parseFloat(getComputedStyle(el).borderTopWidth));
+            expect(first).toBe(0);
+            // …the second group has a top border (the divider below the first group's section)
+            const second = await headers.nth(1).evaluate((el) => parseFloat(getComputedStyle(el).borderTopWidth));
+            expect(second).toBeGreaterThan(0);
+        });
+
+        test('in-content links are blue (#1060ff), independent of the product accent', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            const color = await page.evaluate(() =>
+                getComputedStyle(document.documentElement).getPropertyValue('--xyd-anchor-color').trim(),
+            );
+            // resolves through --terrarium-link → #1060ff
+            expect(color === '#1060ff' || color.includes('terrarium-link')).toBeTruthy();
+        });
+
+        test('text color tiers: headings #0c0c0e, body #3b3d45, inactive nav item #3b3d45', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            const colorOf = (sel: string) =>
+                page.locator(sel).first().evaluate((el) => getComputedStyle(el).color);
+
+            expect(await colorOf('[part="page-article-content"] h1')).toBe('rgb(12, 12, 14)');   // #0c0c0e
+            expect(await colorOf('[part="page-article-content"] p')).toBe('rgb(59, 61, 69)');     // #3b3d45
+            // an inactive center-nav tab (API is inactive on the docs page)
+            const inactive = page.locator('[part="nav-center"] xyd-nav-item:not([data-state="active"])').first();
+            expect(await inactive.evaluate((el) => getComputedStyle(el).color)).toBe('rgb(59, 61, 69)'); // #3b3d45
+        });
+
+        test('in-content prose links are underlined; chrome links are not', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+
+            const proseDeco = await page.locator('[part="page-article-content"] p a', { hasText: 'architecture' })
+                .first().evaluate((el) => getComputedStyle(el).textDecorationLine);
+            expect(proseDeco).toContain('underline');
+
+            // a nav-center tab (chrome) is NOT underlined
+            const navDeco = await page.locator('[part="nav-center"] a').first()
+                .evaluate((el) => getComputedStyle(el).textDecorationLine);
+            expect(navDeco).toBe('none');
+        });
+
+        test('the product switcher is GLOBAL — visible on the landing page (routeless segment)', async ({ page }) => {
+            await goto(page, '/overview');
+            await expect(page.locator('[part="logo"] [data-fw-nav-dropdown]')).toBeVisible();
+        });
+
+        test('per-product accent: Nomad → green', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            expect(await accentOf(page)).toBe('#00ca8e');
+        });
+
+        test('switching products recolors the accent and swaps the sidebar', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            expect(await accentOf(page)).toBe('#00ca8e');
+            await expect(page.locator('aside[part="sidebar"]').getByText('Quickstart')).toBeVisible();
+
+            await goto(page, '/consul/docs/what-is-consul');
+            expect(await accentOf(page)).toBe('#dc477d');
+            await expect(page.locator('aside[part="sidebar"]').getByText('Quickstart')).toHaveCount(0);
+
+            // The DERIVED tokens must recolor too (they're declared at :root, so
+            // they only follow the accent when --theme-color-primary is set at
+            // :root): the ACTIVE SIDEBAR ITEM renders in the product color.
+            const activeItemColor = await page
+                .locator('aside[part="sidebar"] [part="primary-item"][data-active="true"]').first()
+                .evaluate((el) => getComputedStyle(el).color);
+            expect(activeItemColor).toBe('rgb(220, 71, 125)'); // #dc477d
+        });
+
+        test('per-product tabs: Nomad shows Documentation + API, and they persist across the section', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            expect(await tabTexts(page)).toEqual(['Documentation', 'API']);
+
+            // the tab bar stays on a sub-page of the section (route-prefix scoped)
+            await goto(page, '/nomad/docs/quickstart');
+            expect(await tabTexts(page)).toEqual(['Documentation', 'API']);
+        });
+
+        test('the tabs are PER-PRODUCT: Consul shows only Documentation', async ({ page }) => {
+            await goto(page, '/consul/docs/what-is-consul');
+            expect(await tabTexts(page)).toEqual(['Documentation']);
+        });
+
+        test('the tabs render in the nav center, not a subnav', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            await expect(page.locator('[part="nav-center"] xyd-nav-item').first()).toBeVisible();
+            await expect(page.locator('xyd-subnav')).toHaveCount(0);
+        });
+
+        test('search renders on the RIGHT of the nav (the center hosts the tabs)', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            await expect(page.locator('[part="nav-right"] xyd-search-button')).toBeVisible();
+            await expect(page.locator('[part="nav-center"] xyd-search-button')).toHaveCount(0);
+        });
+
+        test('mobile: the logo + product switcher are never crushed off-screen', async ({ page }) => {
+            await page.setViewportSize({ width: 390, height: 844 });
+            await goto(page, '/nomad/docs/what-is-nomad');
+            const left = await page.locator('[part="nav-left"]').boundingBox();
+            expect(left!.x).toBeGreaterThanOrEqual(0);
+            // the switcher trigger stays visible…
+            await expect(page.locator('[part="nav-left"] [data-fw-nav-dropdown]')).toBeVisible();
+            // …and the tabs move to their own FULL-WIDTH second row (the header
+            // wraps), horizontally scrollable — not crammed next to the logo
+            const rows = await page.evaluate(() => {
+                const leftBox = document.querySelector('[part="nav-left"]')!.getBoundingClientRect();
+                const center = document.querySelector('[part="nav-center"]')!;
+                const centerBox = center.getBoundingClientRect();
+                const tablist = center.querySelector('[role="tablist"]')!;
+                const nav = document.querySelector('xyd-nav')!;
+                return {
+                    secondRow: centerBox.top >= leftBox.bottom - 1,
+                    // full row width minus the nav's side padding
+                    fullWidth: centerBox.width >= window.innerWidth * 0.9,
+                    // tabs WRAP to more lines when needed (no horizontal scrolling)
+                    wraps: getComputedStyle(tablist).flexWrap === 'wrap',
+                    // the sticky header is opaque — content must not show through
+                    // behind the wrapped rows
+                    opaque: getComputedStyle(nav).backgroundColor !== 'rgba(0, 0, 0, 0)',
+                    // the border rides the sticky nav itself, so the WHOLE wrapped
+                    // bar (below row 2) ends with the header border
+                    borderBottom: parseFloat(getComputedStyle(nav).borderBottomWidth),
+                };
+            });
+            expect(rows.secondRow).toBe(true);
+            expect(rows.fullWidth).toBe(true);
+            expect(rows.wraps).toBe(true);
+            expect(rows.opaque).toBe(true);
+            expect(rows.borderBottom).toBeGreaterThan(0);
+        });
+
+        test('the active nav tab uses a bottom underline, not a background pill', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            const active = page.locator('[part="nav-center"] xyd-nav-item[data-state="active"]');
+            await expect(active).toBeVisible();
+            const s = await active.evaluate((el) => {
+                const cs = getComputedStyle(el);
+                return { border: cs.borderBottomWidth, bg: cs.backgroundColor };
+            });
+            expect(parseFloat(s.border)).toBeGreaterThan(0);           // has an underline
+            expect(['rgba(0, 0, 0, 0)', 'transparent']).toContain(s.bg); // no pill background
+        });
+
+        test('the sidebar has no scroll shadow', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            await expect(page.locator('aside[part="sidebar"] [part="scroll-shadow"]')).toHaveCount(0);
+        });
+
+        test('clicking a tab switches section: sidebar + active tab change', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            // the "API" tab links to the API section
+            await page.locator('[part="nav-center"] a', { hasText: 'API' }).click();
+            await page.waitForURL(/\/nomad\/api\/overview$/);
+            // sidebar swapped to the API section (its group header appears; the docs
+            // section's pages are gone)
+            await expect(
+                page.locator('aside[part="sidebar"] [part="item-header"]', { hasText: 'HTTP API' }),
+            ).toBeVisible();
+            await expect(page.locator('aside[part="sidebar"]').getByText('Quickstart')).toHaveCount(0);
+        });
+
+        test('the built-in filter is route-scoped (components.filterSidebar.routes)', async ({ page }) => {
+            // routes: ["nomad"] → shown on nomad pages…
+            await goto(page, '/nomad/docs/what-is-nomad');
+            await expect(page.locator('aside[part="sidebar"] input[aria-label="Filter sidebar"]')).toBeVisible();
+            // …but NOT on consul pages (outside the configured routes)
+            await goto(page, '/consul/docs/what-is-consul');
+            await expect(page.locator('aside[part="sidebar"] input[aria-label="Filter sidebar"]')).toHaveCount(0);
+        });
+
+        test('sidebar chrome: "Filter sidebar" input hides non-matching items', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            const sidebar = page.locator('aside[part="sidebar"]');
+            await expect(sidebar.getByText('Quickstart')).toBeVisible();
+            await expect(sidebar.getByText('Architecture')).toBeVisible();
+
+            await sidebar.locator('input[aria-label="Filter sidebar"]').fill('quick');
+
+            await expect(sidebar.getByText('Quickstart')).toBeVisible();
+            await expect(sidebar.getByText('Architecture')).toHaveCount(0);
+        });
+
+        test('the switcher icon renders a custom SVG image (product logo)', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            // the active product (Nomad) icon is a data-uri SVG → rendered as <img>
+            const img = page.locator('[part="dropdown-icon"] img').first();
+            await expect(img).toHaveAttribute('src', /^data:image\/svg/);
+        });
+
+        test('the built-in filter + a custom fixed component live in the pinned region', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            const fixed = page.locator('aside[part="sidebar"] [part="fixed"]');
+            // built-in filter is pinned (not in the scrollable list)
+            await expect(fixed.locator('input[aria-label="Filter sidebar"]')).toBeVisible();
+            // the filter input has a leading filter icon inside the field
+            await expect(fixed.locator('[part="sidebar-filter-icon"] svg')).toBeVisible();
+            // custom `{ fixed: true, component: { import, props } }` widget renders
+            // here, used a hook, and received its config `props` — the label proves
+            // prop flow (it differs from the component's "Widget" fallback)
+            const widget = fixed.locator('[part="test-widget"]');
+            await expect(widget).toHaveText('Pinned Widget');
+            await expect(widget).toHaveAttribute('data-product', 'Nomad');
+        });
+
+        test('collapsible items: custom chevron, instant expand, no weight change', async ({ page }) => {
+            await goto(page, '/nomad/api/overview');
+            const btn = page.locator('aside[part="sidebar"] [part="item-button"]', { hasText: 'Advanced' }).first();
+            await expect(btn).toBeVisible();
+            // terrarium's own chevron glyph (a data-URI mask), rotating fast (0.1s)
+            const chev = await btn.evaluate((el) => {
+                const cs = getComputedStyle(el, '::after');
+                return { mask: cs.maskImage || (cs as any).webkitMaskImage || '', dur: cs.transitionDuration };
+            });
+            expect(chev.mask).toContain('data:image/svg+xml');
+            expect(chev.dur).toContain('0.1s');
+            // expand/collapse is INSTANT — the collapse element has no transition
+            const weightBefore = await btn.evaluate((el) => getComputedStyle(el).fontWeight);
+            await btn.click();
+            const collapse = page.locator('aside[part="sidebar"] [part="subtree"] xyd-collapse').first();
+            await expect(collapse).toHaveAttribute('data-open', 'true');
+            const trans = await collapse.evaluate((el) => getComputedStyle(el).transitionDuration);
+            expect(['0s', '0s, 0s']).toContain(trans);
+            // …and expanding does NOT change the row's weight (whatever it rests at)
+            const weightAfter = await btn.evaluate((el) => getComputedStyle(el).fontWeight);
+            expect(weightAfter).toBe(weightBefore);
+        });
+
+        test('the STRING form of a custom component (no props) renders with its fallback', async ({ page }) => {
+            // nomad/api uses the bare-string form `component: "./components/…"`
+            await goto(page, '/nomad/api/overview');
+            const widget = page.locator('aside[part="sidebar"] [part="fixed"] [part="test-widget"]');
+            await expect(widget).toHaveText('Widget'); // no props → component's fallback
+            await expect(widget).toHaveAttribute('data-product', 'Nomad');
+        });
+
+        test('the switcher is icon-only: no text label, larger icon', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            const trigger = page.locator('[part="logo"] [part="dropdown-trigger"]');
+            // iconOnly hides the trigger text label…
+            await expect(trigger.locator('[part="dropdown-trigger-label"]')).toHaveCount(0);
+            // …and renders the product image at the larger icon-only size (30px)
+            const h = await trigger.locator('[part="dropdown-icon"] img').first()
+                .evaluate((el) => getComputedStyle(el).height);
+            expect(parseFloat(h)).toBeGreaterThanOrEqual(28);
+        });
+
+        test('a tab with `dropdownMenu` renders as a hover dropdown (HashiCorp "Documentation ▾" pattern)', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            // the "Guides" tab is a dropdown trigger in the nav center (NOT a plain tab item)
+            const trigger = page.locator('[part="nav-center"] [part="dropdown-trigger"]', { hasText: 'Guides' });
+            await expect(trigger).toBeVisible();
+            // it's active because a child section (nomad/docs) prefixes the current path
+            await expect(trigger).toHaveAttribute('data-active', 'true');
+            // hovering reveals its sections, each linking to a route that has its own sidebar
+            await trigger.hover();
+            const menu = page.locator('[part="nav-center"] [data-fw-nav-dropdown] [part="dropdown-list"]');
+            await expect(menu.getByText('Getting Started')).toBeVisible();
+            await expect(menu.getByText('API Reference')).toBeVisible();
+            // the menu entries render their configured icons
+            await expect(menu.locator('[part="dropdown-item"] [part="dropdown-icon"] svg')).toHaveCount(2);
+            // `dropdownMenu.itemsPerColumn: 1` → the 2 entries flow into 2 COLUMNS
+            // (grid, column-first): side by side — same top, different left
+            await expect(menu).toHaveAttribute('data-columns', 'true');
+            const boxes = await menu.locator('[part="dropdown-item"]').evaluateAll((els) =>
+                els.map((el) => { const r = el.getBoundingClientRect(); return { top: Math.round(r.top), left: Math.round(r.left) }; }));
+            expect(boxes.length).toBe(2);
+            expect(Math.abs(boxes[0].top - boxes[1].top)).toBeLessThan(3);
+            expect(boxes[1].left).toBeGreaterThan(boxes[0].left);
+        });
+
+        test('a segment `component` renders as the switcher dropdown PANEL', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            await page.locator('[part="logo"] [part="dropdown-trigger"]').hover();
+            // the custom panel renders inside the dropdown (marked data-panel) and used a hook
+            const panel = page.locator('[data-fw-nav-dropdown] [part="dropdown-list"][data-panel="true"] [part="segment-panel"]');
+            await expect(panel).toBeVisible();
+            await expect(panel).toHaveAttribute('data-product', 'Nomad');
+        });
+
+        test('the product switcher is spaced away from the logo', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            const ml = await page.locator('[part="logo"] [data-fw-nav-dropdown]').first()
+                .evaluate((el) => parseFloat(getComputedStyle(el).marginLeft));
+            expect(ml).toBeGreaterThan(0);
+        });
+
+        test('breadcrumb links: underlined ONLY on hover, heavier than the current page, darken on hover', async ({ page }) => {
+            await goto(page, '/nomad/docs/quickstart');
+            const crumb = page.locator('[part="page-article-content"] xyd-breadcrumbs a').first();
+            await expect(crumb).toBeVisible();
+
+            const rest = await crumb.evaluate((el) => {
+                const cs = getComputedStyle(el);
+                return { deco: cs.textDecorationLine, weight: cs.fontWeight, color: cs.color };
+            });
+            // not underlined at rest…
+            expect(rest.deco).toBe('none');
+            // …but underlined on hover, and the color darkens
+            await crumb.hover();
+            const hovered = await crumb.evaluate((el) => {
+                const cs = getComputedStyle(el);
+                return { deco: cs.textDecorationLine, color: cs.color };
+            });
+            expect(hovered.deco).toContain('underline');
+            expect(hovered.color).not.toBe(rest.color);
+
+            // link is heavier than the plain (non-link) current-page crumb
+            const currentWeight = await page.locator('[part="page-article-content"] xyd-breadcrumbs [part="item"][data-active="true"]')
+                .evaluate((el) => getComputedStyle(el).fontWeight);
+            expect(parseFloat(rest.weight)).toBeGreaterThan(parseFloat(currentWeight));
+        });
+
+        test('breadcrumbs have breathing room below (not crowding the content)', async ({ page }) => {
+            await goto(page, '/nomad/docs/quickstart');
+            const mb = await page.locator('[part="page-article-content"] xyd-breadcrumbs').first()
+                .evaluate((el) => parseFloat(getComputedStyle(el).marginBottom));
+            expect(mb).toBeGreaterThanOrEqual(16);
+        });
+
+        test('sidebar group headers are semibold (600), not extrabold', async ({ page }) => {
+            await goto(page, '/nomad/docs/what-is-nomad');
+            const fw = await page.locator('aside[part="sidebar"] [part="item-header"]').first()
+                .evaluate((el) => getComputedStyle(el).fontWeight);
+            expect(fw).toBe('600');
+        });
+
+        test('terrarium sidebar list padding is 8px 16px (general); fixed region holds the blank space below its input', async ({ page }) => {
+            // No fixed region (consul: filter route-scoped out, no fixed component) →
+            // the list keeps the general 8px 16px padding.
+            await goto(page, '/consul/docs/what-is-consul');
+            const consul = await page.locator('aside[part="sidebar"] [part="list"]').first()
+                .evaluate((el) => { const cs = getComputedStyle(el); return { pt: cs.paddingTop, pl: cs.paddingLeft }; });
+            expect(consul.pl).toBe('16px');
+            expect(consul.pt).toBe('8px');
+            // With a fixed region (nomad: filter + fixed widget) the list starts flush
+            // (top padding 0) and the blank space below the pinned input lives in the
+            // FIXED region's own bottom padding — so it survives scrolling (the scrolled
+            // list can't touch the input).
+            await goto(page, '/nomad/docs/what-is-nomad');
+            const nomad = await page.evaluate(() => {
+                const list = document.querySelector('aside[part="sidebar"] [part="list"]') as HTMLElement;
+                const fixed = document.querySelector('aside[part="sidebar"] [part="fixed"]') as HTMLElement;
+                return {
+                    listPt: parseFloat(getComputedStyle(list).paddingTop),
+                    fixedPb: parseFloat(getComputedStyle(fixed).paddingBottom),
+                };
+            });
+            expect(nomad.listPt).toBe(0);
+            expect(nomad.fixedPb).toBeGreaterThan(0);
+        });
+
+        test('no empty item-group adds space at the top of the sidebar', async ({ page }) => {
+            // Consul has no sidebarDropdown / segment-dropdown configured, so
+            // FwSidebarTabsDropdown renders nothing (an empty [part="item-group"]
+            // would add top margin/space).
+            await goto(page, '/consul/docs/what-is-consul');
+            await expect(page.locator('aside[part="sidebar"] [part="item-group"]')).toHaveCount(0);
+        });
+
+        test('a FIXED `sidebarDropdown` segment renders its section switcher in the pinned region', async ({ page }) => {
+            // nomad declares `appearance: { kind: "sidebarDropdown", options: { fixed: true } }`
+            // → the section switcher (Documentation / API) renders inside the sidebar's
+            // FIXED container (above the filter), NOT as an item-group in the list.
+            await goto(page, '/nomad/docs/what-is-nomad');
+            const switcher = page.locator('aside[part="sidebar"] [part="fixed"] xyd-sidebar-tabs-dropdown');
+            await expect(switcher).toBeVisible();
+            // it shows the current section (nomad/docs → "Documentation")…
+            await expect(switcher).toContainText('Documentation');
+            // …and no item-group is left in the scrollable list
+            await expect(page.locator('aside[part="sidebar"] [part="item-group"]')).toHaveCount(0);
+            // the filter input comes BEFORE the switcher in the pinned region
+            const filterFirst = await page.evaluate(() => {
+                const fixed = document.querySelector('aside[part="sidebar"] [part="fixed"]')!;
+                const filter = fixed.querySelector('[part="sidebar-filter"]');
+                const sw = fixed.querySelector('xyd-sidebar-tabs-dropdown');
+                return !!(filter && sw && (filter.compareDocumentPosition(sw) & Node.DOCUMENT_POSITION_FOLLOWING));
+            });
+            expect(filterFirst).toBe(true);
+            // the first group header sits close under the pinned container (its
+            // base 24px top margin is dropped when the fixed region has content)
+            const firstHeaderMt = await page.locator('aside[part="sidebar"] [part="list"] [part="item-header"]').first()
+                .evaluate((el) => parseFloat(getComputedStyle(el).marginTop));
+            expect(firstHeaderMt).toBe(0);
+            // the switcher trigger uses the HashiCorp-style accent-derived soft
+            // GRADIENT background + an inset 1px accent ring, and no card min-height
+            const trig = await switcher.locator('button[part="dropdown-trigger"]').evaluate((el) => {
+                const cs = getComputedStyle(el);
+                return { bgImage: cs.backgroundImage, shadow: cs.boxShadow, minH: cs.minHeight };
+            });
+            expect(trig.bgImage).toContain('linear-gradient');
+            expect(trig.shadow).toContain('inset');
+            expect(trig.minH === '0px' || trig.minH === 'auto').toBe(true);
+            // switcher text is medium weight (500), not the base semibold
+            const labelWeight = await switcher.locator('[part="dropdown-label"]').first()
+                .evaluate((el) => getComputedStyle(el).fontWeight);
+            expect(labelWeight).toBe('500');
+            // popover entries size like sidebar items (compact padding, small
+            // radius) and their labels are NORMAL weight (trigger stays medium)
+            await switcher.locator('button[part="dropdown-trigger"]').click();
+            const entry = await switcher.locator('[part="dropdown-listitem"]').first().evaluate((el) => {
+                const cs = getComputedStyle(el);
+                const label = el.querySelector('[part="dropdown-label"]');
+                return { pt: cs.paddingTop, pl: cs.paddingLeft, labelWeight: label ? getComputedStyle(label).fontWeight : null };
+            });
+            expect(entry.pt).toBe('6px');
+            expect(entry.pl).toBe('12px');
+            expect(entry.labelWeight).toBe('400');
+            await page.keyboard.press('Escape');
+            // scroll="sidebar": the WHOLE sidebar is the scroller (full-height
+            // scrollbar) — the list itself no longer scrolls
+            const scrollHost = await page.evaluate(() => {
+                const host = document.querySelector('aside[part="sidebar"] xyd-sidebar') as HTMLElement;
+                const list = host.querySelector('[part="list"]') as HTMLElement;
+                return {
+                    hostAttr: host.getAttribute('data-scroll'),
+                    hostOverflow: getComputedStyle(host).overflowY,
+                    listOverflow: getComputedStyle(list).overflowY,
+                };
+            });
+            expect(scrollHost.hostAttr).toBe('sidebar');
+            expect(scrollHost.hostOverflow).toBe('auto');
+            expect(scrollHost.listOverflow).toBe('visible');
+        });
+
+        test('the section switcher shows ONLY inside its member sections', async ({ page }) => {
+            // /nomad/other matches the segment ROUTE (nomad) but is not one of the
+            // switcher's sections (nomad/docs, nomad/api) → no switcher there.
+            await goto(page, '/nomad/other/index');
+            await expect(page.locator('aside[part="sidebar"] xyd-sidebar-tabs-dropdown')).toHaveCount(0);
+            // …while member sections still get it
+            await goto(page, '/nomad/api/overview');
+            await expect(page.locator('aside[part="sidebar"] [part="fixed"] xyd-sidebar-tabs-dropdown')).toBeVisible();
+        });
+    });
+}

--- a/apps/docs/guides/appearance.md
+++ b/apps/docs/guides/appearance.md
@@ -169,7 +169,8 @@ Customize sidebar styling and scroll indicators:
                 "externalArrow": "true | false",
                 "scrollShadow": "true | false",
                 "scrollbar": "'secondary'",
-                "scrollbarColor": "#000"
+                "scrollbarColor": "#000",
+                "groupCase": "'none' | 'uppercase'"
             }
         }
     }

--- a/apps/docs/guides/appearance.md
+++ b/apps/docs/guides/appearance.md
@@ -169,8 +169,7 @@ Customize sidebar styling and scroll indicators:
                 "externalArrow": "true | false",
                 "scrollShadow": "true | false",
                 "scrollbar": "'secondary'",
-                "scrollbarColor": "#000",
-                "groupCase": "'none' | 'uppercase'"
+                "scrollbarColor": "#000"
             }
         }
     }

--- a/apps/docs/guides/navigation.md
+++ b/apps/docs/guides/navigation.md
@@ -548,24 +548,21 @@ Thanks to that you can create for example a subheader that will shown only on sp
 
 Set a segment's `appearance` to `"logoTrailing"` to render it as a product-switcher
 right after the logo — wherever your theme places the logo (header, or the sidebar
-like `picasso`). The trigger shows the active product (whichever `page` prefixes the
+like `picasso`). Unlike `sidebarDropdown`, it is **global**: it appears on every page
+(a top-level switcher), so you can switch products from anywhere — including the
+landing page. The trigger shows the active product (whichever `page` prefixes the
 current route), falling back to the segment `title` when none is active; the menu
 switches between the segment `pages` (the active one is checked).
 
-A product switcher should be **global** (visible on every page). Globalness comes
-from **omitting `route`** (or setting `route: false`) — it is not tied to the
-`logoTrailing` appearance. A routeless segment appears everywhere, so you can switch
-products from anywhere, including the landing page. (Give a segment a `route` string
-to scope it to that route prefix instead — see [Tabs](/guides/navigation#tabs).)
-
 This suits docs that span multiple products — e.g. a **Products** switcher over
-_Session Replay_ and _Web Analytics_ (note: no `route`, so it is global):
+_Session Replay_ and _Web Analytics_:
 
 ```json
 {
   "navigation": {
     "segments": [
       {
+        "route": "products",
         "title": "Products",
         // !diff +
         "appearance": "logoTrailing",
@@ -583,91 +580,6 @@ _Session Replay_ and _Web Analytics_ (note: no `route`, so it is global):
 
 The dropdown opens on `trigger: "hover"` (default) or `"click"`. A page may itself
 declare a nested [`dropdownMenu`](/guides/navigation#dropdown-menu) to add submenus.
-
-#### Per-product accent {label="Experimental"}
-
-A `logoTrailing` page can declare a `color` (any CSS color). Accent-aware themes —
-notably [`terrarium`](/guides/themes) — apply the **active** product's `color` as
-`--theme-color-primary`, so links, the active sidebar item, and the active table-of-contents
-entry all recolor per product (e.g. Nomad → green, Consul → pink, Vault → yellow).
-Pair each `page` (the route prefix that drives which product is *active*) with an `href`
-(the landing page the switcher navigates to):
-
-```json
-{
-  "navigation": {
-    "segments": [
-      {
-        "title": "HashiCorp",
-        "appearance": "logoTrailing",
-        "pages": [
-          // !diff +
-          { "title": "Nomad",  "page": "nomad",  "href": "nomad/docs/what-is-nomad",  "icon": "server",         "color": "#00ca8e" },
-          // !diff +
-          { "title": "Consul", "page": "consul", "href": "consul/docs/what-is-consul", "icon": "network-wired", "color": "#dc477d" },
-          // !diff +
-          { "title": "Vault",  "page": "vault",  "href": "vault/docs/what-is-vault",   "icon": "lock",          "color": "#ffcf25" }
-        ]
-      }
-    ]
-  }
-}
-```
-
-Combine this with one route-scoped [`SidebarRoute`](/guides/navigation#routing) per product
-so the sidebar swaps as you switch. The `terrarium` theme additionally renders a
-`‹ {Product} Home` back-link, a colored product-icon header, and a **Filter sidebar** input.
-
-### Tabs {label="Experimental"}
-
-Set a segment's `appearance` to `"tabs"` to render its `pages` as a horizontal tab bar
-in the sub-navigation, **scoped to the segment's `route`**. Because a `tabs` segment is
-route-scoped, you can declare **one per product** to get a per-product tab bar that swaps
-as you switch products — like HashiCorp's _Documentation / API / CLI / Tools / Plugins_.
-
-Each tab is a section: its **`page`** is a route prefix (it decides which tab is *active*
-— the tab stays highlighted across every page of that section) and its **`href`** is the
-landing page the tab links to.
-
-```json
-{
-  "navigation": {
-    "segments": [
-      {
-        // !diff +
-        "route": "nomad",
-        // !diff +
-        "appearance": "tabs",
-        "pages": [
-          { "title": "Documentation", "page": "nomad/docs", "href": "nomad/docs/what-is-nomad" },
-          { "title": "API",           "page": "nomad/api",  "href": "nomad/api/index" },
-          { "title": "CLI",           "page": "nomad/cli",  "href": "nomad/cli/index" }
-        ]
-      },
-      {
-        // a DIFFERENT product → different tabs
-        "route": "vault",
-        "appearance": "tabs",
-        "pages": [
-          { "title": "Documentation", "page": "vault/docs", "href": "vault/docs/what-is-vault" },
-          { "title": "API",           "page": "vault/api",  "href": "vault/api/index" }
-        ]
-      }
-    ]
-  }
-}
-```
-
-Give each section its own route-scoped [`SidebarRoute`](/guides/navigation#routing)
-(`{ "route": "nomad/docs", … }`, `{ "route": "nomad/api", … }`, …) so the left sidebar
-switches with the active tab.
-
-**Where the tabs render** is controlled by `theme.appearance.tabs.surface`:
-
-- default — a **sub-navigation** bar below the primary nav (the same `xyd-subnav` the
-  global [`tabs`](#tabs) use, so every theme styles it consistently);
-- `"center"` — the **center of the primary nav** (like HashiCorp Developer). The
-  `terrarium` theme sets this by default.
 
 ##  File-Convention Routing {label="Coming Soon"}
 :::callout

--- a/apps/docs/guides/navigation.md
+++ b/apps/docs/guides/navigation.md
@@ -548,21 +548,24 @@ Thanks to that you can create for example a subheader that will shown only on sp
 
 Set a segment's `appearance` to `"logoTrailing"` to render it as a product-switcher
 right after the logo — wherever your theme places the logo (header, or the sidebar
-like `picasso`). Unlike `sidebarDropdown`, it is **global**: it appears on every page
-(a top-level switcher), so you can switch products from anywhere — including the
-landing page. The trigger shows the active product (whichever `page` prefixes the
+like `picasso`). The trigger shows the active product (whichever `page` prefixes the
 current route), falling back to the segment `title` when none is active; the menu
 switches between the segment `pages` (the active one is checked).
 
+A product switcher should be **global** (visible on every page). Globalness comes
+from **omitting `route`** (or setting `route: false`) — it is not tied to the
+`logoTrailing` appearance. A routeless segment appears everywhere, so you can switch
+products from anywhere, including the landing page. (Give a segment a `route` string
+to scope it to that route prefix instead — see [Tabs](/guides/navigation#tabs).)
+
 This suits docs that span multiple products — e.g. a **Products** switcher over
-_Session Replay_ and _Web Analytics_:
+_Session Replay_ and _Web Analytics_ (note: no `route`, so it is global):
 
 ```json
 {
   "navigation": {
     "segments": [
       {
-        "route": "products",
         "title": "Products",
         // !diff +
         "appearance": "logoTrailing",
@@ -580,6 +583,91 @@ _Session Replay_ and _Web Analytics_:
 
 The dropdown opens on `trigger: "hover"` (default) or `"click"`. A page may itself
 declare a nested [`dropdownMenu`](/guides/navigation#dropdown-menu) to add submenus.
+
+#### Per-product accent {label="Experimental"}
+
+A `logoTrailing` page can declare a `color` (any CSS color). Accent-aware themes —
+notably [`terrarium`](/guides/themes) — apply the **active** product's `color` as
+`--theme-color-primary`, so links, the active sidebar item, and the active table-of-contents
+entry all recolor per product (e.g. Nomad → green, Consul → pink, Vault → yellow).
+Pair each `page` (the route prefix that drives which product is *active*) with an `href`
+(the landing page the switcher navigates to):
+
+```json
+{
+  "navigation": {
+    "segments": [
+      {
+        "title": "HashiCorp",
+        "appearance": "logoTrailing",
+        "pages": [
+          // !diff +
+          { "title": "Nomad",  "page": "nomad",  "href": "nomad/docs/what-is-nomad",  "icon": "server",         "color": "#00ca8e" },
+          // !diff +
+          { "title": "Consul", "page": "consul", "href": "consul/docs/what-is-consul", "icon": "network-wired", "color": "#dc477d" },
+          // !diff +
+          { "title": "Vault",  "page": "vault",  "href": "vault/docs/what-is-vault",   "icon": "lock",          "color": "#ffcf25" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Combine this with one route-scoped [`SidebarRoute`](/guides/navigation#routing) per product
+so the sidebar swaps as you switch. The `terrarium` theme additionally renders a
+`‹ {Product} Home` back-link, a colored product-icon header, and a **Filter sidebar** input.
+
+### Tabs {label="Experimental"}
+
+Set a segment's `appearance` to `"tabs"` to render its `pages` as a horizontal tab bar
+in the sub-navigation, **scoped to the segment's `route`**. Because a `tabs` segment is
+route-scoped, you can declare **one per product** to get a per-product tab bar that swaps
+as you switch products — like HashiCorp's _Documentation / API / CLI / Tools / Plugins_.
+
+Each tab is a section: its **`page`** is a route prefix (it decides which tab is *active*
+— the tab stays highlighted across every page of that section) and its **`href`** is the
+landing page the tab links to.
+
+```json
+{
+  "navigation": {
+    "segments": [
+      {
+        // !diff +
+        "route": "nomad",
+        // !diff +
+        "appearance": "tabs",
+        "pages": [
+          { "title": "Documentation", "page": "nomad/docs", "href": "nomad/docs/what-is-nomad" },
+          { "title": "API",           "page": "nomad/api",  "href": "nomad/api/index" },
+          { "title": "CLI",           "page": "nomad/cli",  "href": "nomad/cli/index" }
+        ]
+      },
+      {
+        // a DIFFERENT product → different tabs
+        "route": "vault",
+        "appearance": "tabs",
+        "pages": [
+          { "title": "Documentation", "page": "vault/docs", "href": "vault/docs/what-is-vault" },
+          { "title": "API",           "page": "vault/api",  "href": "vault/api/index" }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Give each section its own route-scoped [`SidebarRoute`](/guides/navigation#routing)
+(`{ "route": "nomad/docs", … }`, `{ "route": "nomad/api", … }`, …) so the left sidebar
+switches with the active tab.
+
+**Where the tabs render** is controlled by `theme.appearance.tabs.surface`:
+
+- default — a **sub-navigation** bar below the primary nav (the same `xyd-subnav` the
+  global [`tabs`](#tabs) use, so every theme styles it consistently);
+- `"center"` — the **center of the primary nav** (like HashiCorp Developer). The
+  `terrarium` theme sets this by default.
 
 ##  File-Convention Routing {label="Coming Soon"}
 :::callout

--- a/apps/docs/guides/themes.md
+++ b/apps/docs/guides/themes.md
@@ -42,6 +42,9 @@ You can configure the theme in the [`settings`](/guides/settings) file:
 
     - 
         ::card{title="cosmo" description="Platform-like design with robust navigation feeling." href="https://cosmo.xyd.dev" imgSrc="/public/assets/cosmo-frame.png" logoSrc="/public/assets/cosmo-logo.png"}
+
+    - 
+        ::card{title="terrarium" description="Full-width, high-contrast docs (HashiCorp-style) with ~800px left-aligned content, a decoupled TOC, and a top product switcher that recolors the accent per product."}
 :::
 
 ## Customizing The Theme

--- a/apps/docs/guides/themes.md
+++ b/apps/docs/guides/themes.md
@@ -42,9 +42,6 @@ You can configure the theme in the [`settings`](/guides/settings) file:
 
     - 
         ::card{title="cosmo" description="Platform-like design with robust navigation feeling." href="https://cosmo.xyd.dev" imgSrc="/public/assets/cosmo-frame.png" logoSrc="/public/assets/cosmo-logo.png"}
-
-    - 
-        ::card{title="terrarium" description="Full-width, high-contrast docs (HashiCorp-style) with ~800px left-aligned content, a decoupled TOC, and a top product switcher that recolors the accent per product."}
 :::
 
 ## Customizing The Theme

--- a/apps/docs/public/docs.json
+++ b/apps/docs/public/docs.json
@@ -1099,22 +1099,6 @@
           "description": "If `true` then the sidebar will display a scroll shadow.",
           "type": "boolean"
         },
-        "groupCase": {
-          "description": "Letter-casing of sidebar group headers. Defaults to `\"uppercase\"`; set `\"none\"` to render group labels exactly as authored.",
-          "enum": [
-            "none",
-            "uppercase"
-          ],
-          "type": "string"
-        },
-        "scroll": {
-          "description": "Which element scrolls. `\"list\"` (default): only the item list scrolls, below the fixed (pinned) region. `\"sidebar\"`: the WHOLE sidebar scrolls — the scrollbar spans its full height — and the fixed region sticks to the top while items scroll beneath it.",
-          "enum": [
-            "list",
-            "sidebar"
-          ],
-          "type": "string"
-        },
         "scrollShadow": {
           "description": "If `true` then the sidebar will display a scroll shadow.",
           "type": "boolean"
@@ -1322,66 +1306,12 @@
       ],
       "description": "A type that can be used to represent a component-like structure."
     },
-    "ComponentPage": {
-      "additionalProperties": false,
-      "description": "A custom React component rendered AS a sidebar item.\n\n`component` is a path (relative to the docs project, e.g. `\"./components/TryNewVersion\"`) to a module whose DEFAULT export is a function component. It renders inside the framework context, so it may use `@xyd-js/framework/react` hooks; `props` are passed to it. `fixed: true` pins it in the sidebar's fixed region (above the scrollable list).",
-      "properties": {
-        "component": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/ComponentPageImport"
-            }
-          ],
-          "description": "A path to a default-export React component (relative to the docs project), or an object with that path under `import` plus `props` for the component."
-        },
-        "fixed": {
-          "description": "Pin this item in the sidebar's fixed region (stays visible on scroll).",
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "component"
-      ],
-      "type": "object"
-    },
-    "ComponentPageImport": {
-      "additionalProperties": false,
-      "description": "Object form of `ComponentPage.component`: an import path plus optional props.",
-      "properties": {
-        "import": {
-          "description": "Path to a default-export React component, relative to the docs project.",
-          "type": "string"
-        },
-        "props": {
-          "description": "Props passed to the component.",
-          "type": "object"
-        }
-      },
-      "required": [
-        "import"
-      ],
-      "type": "object"
-    },
     "Components": {
       "additionalProperties": false,
       "properties": {
         "banner": {
           "$ref": "#/definitions/WebEditorBanner",
           "description": "WebEditor banner configuration"
-        },
-        "filterSidebar": {
-          "anyOf": [
-            {
-              "type": "boolean"
-            },
-            {
-              "$ref": "#/definitions/FilterSidebar"
-            }
-          ],
-          "description": "Built-in \"filter sidebar\" input that narrows the sidebar tree to matching items. It renders in the sidebar's fixed (pinned) region. `true` uses the default placeholder; pass a  {@link  FilterSidebar }  object to customize the placeholder and scope it to specific routes."
         },
         "footer": {
           "$ref": "#/definitions/WebEditorFooter",
@@ -1453,27 +1383,6 @@
       },
       "type": "object"
     },
-    "DropdownMenu": {
-      "additionalProperties": false,
-      "description": "Object form of  {@link  NavigationItem.dropdownMenu } : the menu items plus menu-level options.",
-      "properties": {
-        "items": {
-          "description": "The menu items.",
-          "items": {
-            "$ref": "#/definitions/NavigationItem"
-          },
-          "type": "array"
-        },
-        "itemsPerColumn": {
-          "description": "Maximum items rendered in ONE COLUMN — overflowing items wrap into additional columns (e.g. `7` renders a 12-item menu as two columns of 7 + 5). Omit for a single column.",
-          "type": "number"
-        }
-      },
-      "required": [
-        "items"
-      ],
-      "type": "object"
-    },
     "EditLink": {
       "additionalProperties": false,
       "properties": {
@@ -1525,24 +1434,6 @@
         "store": {
           "description": "If `true` then virtual pages will not created and generated content will be stored on disk",
           "type": "boolean"
-        }
-      },
-      "type": "object"
-    },
-    "FilterSidebar": {
-      "additionalProperties": false,
-      "description": "Configuration for the built-in sidebar filter input (`components.filterSidebar`).",
-      "properties": {
-        "placeholder": {
-          "description": "Placeholder text for the filter input. Defaults to `\"Filter sidebar\"`.",
-          "type": "string"
-        },
-        "routes": {
-          "description": "Render the filter ONLY on pages whose route is under one of these prefixes (e.g. `[\"terraform/language\"]`). A page matches when its slug starts with a listed prefix. Omit (or leave empty) to show the filter on every page.",
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
         }
       },
       "type": "object"
@@ -2287,27 +2178,16 @@
       "additionalProperties": false,
       "description": "Core interface for navigation items",
       "properties": {
-        "color": {
-          "description": "Accent color (any CSS color) for this item. Used by `logoTrailing` product switchers and accent-aware themes (e.g. `terrarium`) to recolor the UI per product — the active item's `color` is applied as `--theme-color-primary`.",
-          "type": "string"
-        },
         "description": {
           "description": "The navigation item description",
           "type": "string"
         },
         "dropdownMenu": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/definitions/NavigationItem"
-              },
-              "type": "array"
-            },
-            {
-              "$ref": "#/definitions/DropdownMenu"
-            }
-          ],
-          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs. Accepts a plain item array, or the object form  {@link  DropdownMenu }  carrying menu-level options (e.g. `{ itemsPerColumn: 7, items: [...] }`)."
+          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs.",
+          "items": {
+            "$ref": "#/definitions/NavigationItem"
+          },
+          "type": "array"
         },
         "href": {
           "description": "The navigation href, if set it redirects but does not match based on routing",
@@ -2353,27 +2233,16 @@
           ],
           "type": "string"
         },
-        "color": {
-          "description": "Accent color (any CSS color) for this item. Used by `logoTrailing` product switchers and accent-aware themes (e.g. `terrarium`) to recolor the UI per product — the active item's `color` is applied as `--theme-color-primary`.",
-          "type": "string"
-        },
         "description": {
           "description": "The navigation item description",
           "type": "string"
         },
         "dropdownMenu": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/definitions/NavigationItem"
-              },
-              "type": "array"
-            },
-            {
-              "$ref": "#/definitions/DropdownMenu"
-            }
-          ],
-          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs. Accepts a plain item array, or the object form  {@link  DropdownMenu }  carrying menu-level options (e.g. `{ itemsPerColumn: 7, items: [...] }`)."
+          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs.",
+          "items": {
+            "$ref": "#/definitions/NavigationItem"
+          },
+          "type": "array"
         },
         "href": {
           "description": "The navigation href, if set it redirects but does not match based on routing",
@@ -2415,27 +2284,16 @@
     "NavigationItemSocial": {
       "additionalProperties": false,
       "properties": {
-        "color": {
-          "description": "Accent color (any CSS color) for this item. Used by `logoTrailing` product switchers and accent-aware themes (e.g. `terrarium`) to recolor the UI per product — the active item's `color` is applied as `--theme-color-primary`.",
-          "type": "string"
-        },
         "description": {
           "description": "The navigation item description",
           "type": "string"
         },
         "dropdownMenu": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/definitions/NavigationItem"
-              },
-              "type": "array"
-            },
-            {
-              "$ref": "#/definitions/DropdownMenu"
-            }
-          ],
-          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs. Accepts a plain item array, or the object form  {@link  DropdownMenu }  carrying menu-level options (e.g. `{ itemsPerColumn: 7, items: [...] }`)."
+          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs.",
+          "items": {
+            "$ref": "#/definitions/NavigationItem"
+          },
+          "type": "array"
         },
         "href": {
           "description": "The navigation href, if set it redirects but does not match based on routing",
@@ -2519,9 +2377,6 @@
         },
         {
           "$ref": "#/definitions/Sidebar"
-        },
-        {
-          "$ref": "#/definitions/ComponentPage"
         }
       ],
       "description": "Page URL type"
@@ -2791,30 +2646,8 @@
       "description": "Segment configuration",
       "properties": {
         "appearance": {
-          "anyOf": [
-            {
-              "$ref": "#/definitions/SegmentAppearance"
-            },
-            {
-              "$ref": "#/definitions/SegmentAppearanceConfig"
-            }
-          ],
-          "description": "Appearance of this segment — a  {@link  SegmentAppearance }  string, or the object form  {@link  SegmentAppearanceConfig }  carrying kind-specific options (e.g. `{ kind: \"sidebarDropdown\", options: { fixed: true } }`)."
-        },
-        "component": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "$ref": "#/definitions/ComponentPageImport"
-            }
-          ],
-          "description": "`logoTrailing` only: a custom component rendered AS this segment's dropdown PANEL (e.g. a rich multi-column product mega-menu), instead of the default `pages` list. A path to a default-export React component (relative to the docs project), or `{ import, props }`. Resolved through the same user-components registry as sidebar `ComponentPage` components, so it may use `@xyd-js/framework/react` hooks; the framework also passes it the active item, the segment, and the resolved `items`."
-        },
-        "iconOnly": {
-          "description": "`logoTrailing` only: render the trigger ICON-ONLY — show the active item's icon at a larger size and hide the trigger title label. Use when the icon is a full wordmark image (logo + product name) so a text label is redundant. Defaults to `false`.",
-          "type": "boolean"
+          "$ref": "#/definitions/SegmentAppearance",
+          "description": "Appearance of this segment. See  {@link  SegmentAppearance } ."
         },
         "pages": {
           "description": "Items within this segment",
@@ -2824,16 +2657,8 @@
           "type": "array"
         },
         "route": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "const": false,
-              "type": "boolean"
-            }
-          ],
-          "description": "Route this segment is scoped to. When a **string**, the segment only shows under that route prefix (route-scoped). When **omitted or `false`**, the segment is GLOBAL — always visible (e.g. a top-level product switcher). The globalness comes from the absence of a route, NOT from the `appearance`."
+          "description": "Route for this segment",
+          "type": "string"
         },
         "title": {
           "description": "Title of this segment",
@@ -2849,76 +2674,18 @@
         }
       },
       "required": [
+        "route",
         "pages"
       ],
       "type": "object"
     },
     "SegmentAppearance": {
-      "description": "How a matched  {@link  Segment }  is presented.\n\n- `\"sidebarDropdown\"` — a click dropdown at the top of the sidebar.\n- `\"logoTrailing\"` — a hover product-switcher rendered right after the logo   (wherever the active theme places its logo — header or sidebar). The trigger   shows the active page's title (falling back to the segment `title`), and the   menu is the segment `pages` with a check on the active one.\n- `\"tabs\"` — a horizontal tab bar in the sub-navigation, scoped to the   segment's `route`. Each `page` is a section: its `page` (a route prefix)   decides which tab is active, and its `href` is the landing page the tab   links to. Use one route-scoped `tabs` segment per product to get   per-product tab bars (e.g. Documentation / API / CLI).",
+      "description": "How a matched  {@link  Segment }  is presented.\n\n- `\"sidebarDropdown\"` — a click dropdown at the top of the sidebar.\n- `\"logoTrailing\"` — a hover product-switcher rendered right after the logo   (wherever the active theme places its logo — header or sidebar). The trigger   shows the active page's title (falling back to the segment `title`), and the   menu is the segment `pages` with a check on the active one.",
       "enum": [
         "sidebarDropdown",
-        "logoTrailing",
-        "tabs"
+        "logoTrailing"
       ],
       "type": "string"
-    },
-    "SegmentAppearanceConfig": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/SegmentAppearanceSidebarDropdown"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "kind": {
-              "const": "logoTrailing",
-              "type": "string"
-            }
-          },
-          "required": [
-            "kind"
-          ],
-          "type": "object"
-        },
-        {
-          "additionalProperties": false,
-          "properties": {
-            "kind": {
-              "const": "tabs",
-              "type": "string"
-            }
-          },
-          "required": [
-            "kind"
-          ],
-          "type": "object"
-        }
-      ],
-      "description": "Object form of  {@link  Segment.appearance } : a `kind` (same values as the string form) plus kind-specific `options`. The options shape depends on the kind — currently only `sidebarDropdown` has options."
-    },
-    "SegmentAppearanceSidebarDropdown": {
-      "additionalProperties": false,
-      "description": "`appearance: { kind: \"sidebarDropdown\", options }`",
-      "properties": {
-        "kind": {
-          "const": "sidebarDropdown",
-          "type": "string"
-        },
-        "options": {
-          "additionalProperties": false,
-          "properties": {
-            "fixed": {
-              "description": "Render the section switcher in the sidebar's FIXED (pinned) region — it stays visible while the item list scrolls. Defaults to `false` (rendered at the top of the scrollable list).",
-              "type": "boolean"
-            }
-          },
-          "type": "object"
-        }
-      },
-      "required": [
-        "kind"
-      ],
-      "type": "object"
     },
     "Sidebar": {
       "additionalProperties": false,
@@ -3213,8 +2980,7 @@
         "opener",
         "picasso",
         "gusto",
-        "solar",
-        "terrarium"
+        "solar"
       ],
       "type": "string"
     },
@@ -3416,10 +3182,6 @@
       "additionalProperties": false,
       "description": "WebEditor header configuration",
       "properties": {
-        "color": {
-          "description": "Accent color (any CSS color) for this item. Used by `logoTrailing` product switchers and accent-aware themes (e.g. `terrarium`) to recolor the UI per product — the active item's `color` is applied as `--theme-color-primary`.",
-          "type": "string"
-        },
         "component": {
           "description": "The component type, e.g. \"Button\", \"Card\", etc.",
           "type": "string"
@@ -3433,18 +3195,11 @@
           "type": "boolean"
         },
         "dropdownMenu": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/definitions/NavigationItem"
-              },
-              "type": "array"
-            },
-            {
-              "$ref": "#/definitions/DropdownMenu"
-            }
-          ],
-          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs. Accepts a plain item array, or the object form  {@link  DropdownMenu }  carrying menu-level options (e.g. `{ itemsPerColumn: 7, items: [...] }`)."
+          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs.",
+          "items": {
+            "$ref": "#/definitions/NavigationItem"
+          },
+          "type": "array"
         },
         "float": {
           "description": "Float the header to the right",
@@ -3500,10 +3255,6 @@
       "additionalProperties": false,
       "description": "WebEditor navigation item configuration",
       "properties": {
-        "color": {
-          "description": "Accent color (any CSS color) for this item. Used by `logoTrailing` product switchers and accent-aware themes (e.g. `terrarium`) to recolor the UI per product — the active item's `color` is applied as `--theme-color-primary`.",
-          "type": "string"
-        },
         "component": {
           "description": "The component type, e.g. \"Button\", \"Card\", etc.",
           "type": "string"
@@ -3517,18 +3268,11 @@
           "type": "boolean"
         },
         "dropdownMenu": {
-          "anyOf": [
-            {
-              "items": {
-                "$ref": "#/definitions/NavigationItem"
-              },
-              "type": "array"
-            },
-            {
-              "$ref": "#/definitions/DropdownMenu"
-            }
-          ],
-          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs. Accepts a plain item array, or the object form  {@link  DropdownMenu }  carrying menu-level options (e.g. `{ itemsPerColumn: 7, items: [...] }`)."
+          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs.",
+          "items": {
+            "$ref": "#/definitions/NavigationItem"
+          },
+          "type": "array"
         },
         "href": {
           "description": "The navigation href, if set it redirects but does not match based on routing",

--- a/apps/docs/public/docs.json
+++ b/apps/docs/public/docs.json
@@ -1099,6 +1099,22 @@
           "description": "If `true` then the sidebar will display a scroll shadow.",
           "type": "boolean"
         },
+        "groupCase": {
+          "description": "Letter-casing of sidebar group headers. Defaults to `\"uppercase\"`; set `\"none\"` to render group labels exactly as authored.",
+          "enum": [
+            "none",
+            "uppercase"
+          ],
+          "type": "string"
+        },
+        "scroll": {
+          "description": "Which element scrolls. `\"list\"` (default): only the item list scrolls, below the fixed (pinned) region. `\"sidebar\"`: the WHOLE sidebar scrolls — the scrollbar spans its full height — and the fixed region sticks to the top while items scroll beneath it.",
+          "enum": [
+            "list",
+            "sidebar"
+          ],
+          "type": "string"
+        },
         "scrollShadow": {
           "description": "If `true` then the sidebar will display a scroll shadow.",
           "type": "boolean"
@@ -1306,12 +1322,66 @@
       ],
       "description": "A type that can be used to represent a component-like structure."
     },
+    "ComponentPage": {
+      "additionalProperties": false,
+      "description": "A custom React component rendered AS a sidebar item.\n\n`component` is a path (relative to the docs project, e.g. `\"./components/TryNewVersion\"`) to a module whose DEFAULT export is a function component. It renders inside the framework context, so it may use `@xyd-js/framework/react` hooks; `props` are passed to it. `fixed: true` pins it in the sidebar's fixed region (above the scrollable list).",
+      "properties": {
+        "component": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ComponentPageImport"
+            }
+          ],
+          "description": "A path to a default-export React component (relative to the docs project), or an object with that path under `import` plus `props` for the component."
+        },
+        "fixed": {
+          "description": "Pin this item in the sidebar's fixed region (stays visible on scroll).",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "component"
+      ],
+      "type": "object"
+    },
+    "ComponentPageImport": {
+      "additionalProperties": false,
+      "description": "Object form of `ComponentPage.component`: an import path plus optional props.",
+      "properties": {
+        "import": {
+          "description": "Path to a default-export React component, relative to the docs project.",
+          "type": "string"
+        },
+        "props": {
+          "description": "Props passed to the component.",
+          "type": "object"
+        }
+      },
+      "required": [
+        "import"
+      ],
+      "type": "object"
+    },
     "Components": {
       "additionalProperties": false,
       "properties": {
         "banner": {
           "$ref": "#/definitions/WebEditorBanner",
           "description": "WebEditor banner configuration"
+        },
+        "filterSidebar": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "$ref": "#/definitions/FilterSidebar"
+            }
+          ],
+          "description": "Built-in \"filter sidebar\" input that narrows the sidebar tree to matching items. It renders in the sidebar's fixed (pinned) region. `true` uses the default placeholder; pass a  {@link  FilterSidebar }  object to customize the placeholder and scope it to specific routes."
         },
         "footer": {
           "$ref": "#/definitions/WebEditorFooter",
@@ -1383,6 +1453,27 @@
       },
       "type": "object"
     },
+    "DropdownMenu": {
+      "additionalProperties": false,
+      "description": "Object form of  {@link  NavigationItem.dropdownMenu } : the menu items plus menu-level options.",
+      "properties": {
+        "items": {
+          "description": "The menu items.",
+          "items": {
+            "$ref": "#/definitions/NavigationItem"
+          },
+          "type": "array"
+        },
+        "itemsPerColumn": {
+          "description": "Maximum items rendered in ONE COLUMN — overflowing items wrap into additional columns (e.g. `7` renders a 12-item menu as two columns of 7 + 5). Omit for a single column.",
+          "type": "number"
+        }
+      },
+      "required": [
+        "items"
+      ],
+      "type": "object"
+    },
     "EditLink": {
       "additionalProperties": false,
       "properties": {
@@ -1434,6 +1525,24 @@
         "store": {
           "description": "If `true` then virtual pages will not created and generated content will be stored on disk",
           "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
+    "FilterSidebar": {
+      "additionalProperties": false,
+      "description": "Configuration for the built-in sidebar filter input (`components.filterSidebar`).",
+      "properties": {
+        "placeholder": {
+          "description": "Placeholder text for the filter input. Defaults to `\"Filter sidebar\"`.",
+          "type": "string"
+        },
+        "routes": {
+          "description": "Render the filter ONLY on pages whose route is under one of these prefixes (e.g. `[\"terraform/language\"]`). A page matches when its slug starts with a listed prefix. Omit (or leave empty) to show the filter on every page.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "type": "object"
@@ -2178,16 +2287,27 @@
       "additionalProperties": false,
       "description": "Core interface for navigation items",
       "properties": {
+        "color": {
+          "description": "Accent color (any CSS color) for this item. Used by `logoTrailing` product switchers and accent-aware themes (e.g. `terrarium`) to recolor the UI per product — the active item's `color` is applied as `--theme-color-primary`.",
+          "type": "string"
+        },
         "description": {
           "description": "The navigation item description",
           "type": "string"
         },
         "dropdownMenu": {
-          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs.",
-          "items": {
-            "$ref": "#/definitions/NavigationItem"
-          },
-          "type": "array"
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/definitions/NavigationItem"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/DropdownMenu"
+            }
+          ],
+          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs. Accepts a plain item array, or the object form  {@link  DropdownMenu }  carrying menu-level options (e.g. `{ itemsPerColumn: 7, items: [...] }`)."
         },
         "href": {
           "description": "The navigation href, if set it redirects but does not match based on routing",
@@ -2233,16 +2353,27 @@
           ],
           "type": "string"
         },
+        "color": {
+          "description": "Accent color (any CSS color) for this item. Used by `logoTrailing` product switchers and accent-aware themes (e.g. `terrarium`) to recolor the UI per product — the active item's `color` is applied as `--theme-color-primary`.",
+          "type": "string"
+        },
         "description": {
           "description": "The navigation item description",
           "type": "string"
         },
         "dropdownMenu": {
-          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs.",
-          "items": {
-            "$ref": "#/definitions/NavigationItem"
-          },
-          "type": "array"
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/definitions/NavigationItem"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/DropdownMenu"
+            }
+          ],
+          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs. Accepts a plain item array, or the object form  {@link  DropdownMenu }  carrying menu-level options (e.g. `{ itemsPerColumn: 7, items: [...] }`)."
         },
         "href": {
           "description": "The navigation href, if set it redirects but does not match based on routing",
@@ -2284,16 +2415,27 @@
     "NavigationItemSocial": {
       "additionalProperties": false,
       "properties": {
+        "color": {
+          "description": "Accent color (any CSS color) for this item. Used by `logoTrailing` product switchers and accent-aware themes (e.g. `terrarium`) to recolor the UI per product — the active item's `color` is applied as `--theme-color-primary`.",
+          "type": "string"
+        },
         "description": {
           "description": "The navigation item description",
           "type": "string"
         },
         "dropdownMenu": {
-          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs.",
-          "items": {
-            "$ref": "#/definitions/NavigationItem"
-          },
-          "type": "array"
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/definitions/NavigationItem"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/DropdownMenu"
+            }
+          ],
+          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs. Accepts a plain item array, or the object form  {@link  DropdownMenu }  carrying menu-level options (e.g. `{ itemsPerColumn: 7, items: [...] }`)."
         },
         "href": {
           "description": "The navigation href, if set it redirects but does not match based on routing",
@@ -2377,6 +2519,9 @@
         },
         {
           "$ref": "#/definitions/Sidebar"
+        },
+        {
+          "$ref": "#/definitions/ComponentPage"
         }
       ],
       "description": "Page URL type"
@@ -2646,8 +2791,30 @@
       "description": "Segment configuration",
       "properties": {
         "appearance": {
-          "$ref": "#/definitions/SegmentAppearance",
-          "description": "Appearance of this segment. See  {@link  SegmentAppearance } ."
+          "anyOf": [
+            {
+              "$ref": "#/definitions/SegmentAppearance"
+            },
+            {
+              "$ref": "#/definitions/SegmentAppearanceConfig"
+            }
+          ],
+          "description": "Appearance of this segment — a  {@link  SegmentAppearance }  string, or the object form  {@link  SegmentAppearanceConfig }  carrying kind-specific options (e.g. `{ kind: \"sidebarDropdown\", options: { fixed: true } }`)."
+        },
+        "component": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "$ref": "#/definitions/ComponentPageImport"
+            }
+          ],
+          "description": "`logoTrailing` only: a custom component rendered AS this segment's dropdown PANEL (e.g. a rich multi-column product mega-menu), instead of the default `pages` list. A path to a default-export React component (relative to the docs project), or `{ import, props }`. Resolved through the same user-components registry as sidebar `ComponentPage` components, so it may use `@xyd-js/framework/react` hooks; the framework also passes it the active item, the segment, and the resolved `items`."
+        },
+        "iconOnly": {
+          "description": "`logoTrailing` only: render the trigger ICON-ONLY — show the active item's icon at a larger size and hide the trigger title label. Use when the icon is a full wordmark image (logo + product name) so a text label is redundant. Defaults to `false`.",
+          "type": "boolean"
         },
         "pages": {
           "description": "Items within this segment",
@@ -2657,8 +2824,16 @@
           "type": "array"
         },
         "route": {
-          "description": "Route for this segment",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "const": false,
+              "type": "boolean"
+            }
+          ],
+          "description": "Route this segment is scoped to. When a **string**, the segment only shows under that route prefix (route-scoped). When **omitted or `false`**, the segment is GLOBAL — always visible (e.g. a top-level product switcher). The globalness comes from the absence of a route, NOT from the `appearance`."
         },
         "title": {
           "description": "Title of this segment",
@@ -2674,18 +2849,76 @@
         }
       },
       "required": [
-        "route",
         "pages"
       ],
       "type": "object"
     },
     "SegmentAppearance": {
-      "description": "How a matched  {@link  Segment }  is presented.\n\n- `\"sidebarDropdown\"` — a click dropdown at the top of the sidebar.\n- `\"logoTrailing\"` — a hover product-switcher rendered right after the logo   (wherever the active theme places its logo — header or sidebar). The trigger   shows the active page's title (falling back to the segment `title`), and the   menu is the segment `pages` with a check on the active one.",
+      "description": "How a matched  {@link  Segment }  is presented.\n\n- `\"sidebarDropdown\"` — a click dropdown at the top of the sidebar.\n- `\"logoTrailing\"` — a hover product-switcher rendered right after the logo   (wherever the active theme places its logo — header or sidebar). The trigger   shows the active page's title (falling back to the segment `title`), and the   menu is the segment `pages` with a check on the active one.\n- `\"tabs\"` — a horizontal tab bar in the sub-navigation, scoped to the   segment's `route`. Each `page` is a section: its `page` (a route prefix)   decides which tab is active, and its `href` is the landing page the tab   links to. Use one route-scoped `tabs` segment per product to get   per-product tab bars (e.g. Documentation / API / CLI).",
       "enum": [
         "sidebarDropdown",
-        "logoTrailing"
+        "logoTrailing",
+        "tabs"
       ],
       "type": "string"
+    },
+    "SegmentAppearanceConfig": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/SegmentAppearanceSidebarDropdown"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "logoTrailing",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "const": "tabs",
+              "type": "string"
+            }
+          },
+          "required": [
+            "kind"
+          ],
+          "type": "object"
+        }
+      ],
+      "description": "Object form of  {@link  Segment.appearance } : a `kind` (same values as the string form) plus kind-specific `options`. The options shape depends on the kind — currently only `sidebarDropdown` has options."
+    },
+    "SegmentAppearanceSidebarDropdown": {
+      "additionalProperties": false,
+      "description": "`appearance: { kind: \"sidebarDropdown\", options }`",
+      "properties": {
+        "kind": {
+          "const": "sidebarDropdown",
+          "type": "string"
+        },
+        "options": {
+          "additionalProperties": false,
+          "properties": {
+            "fixed": {
+              "description": "Render the section switcher in the sidebar's FIXED (pinned) region — it stays visible while the item list scrolls. Defaults to `false` (rendered at the top of the scrollable list).",
+              "type": "boolean"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
     },
     "Sidebar": {
       "additionalProperties": false,
@@ -2980,7 +3213,8 @@
         "opener",
         "picasso",
         "gusto",
-        "solar"
+        "solar",
+        "terrarium"
       ],
       "type": "string"
     },
@@ -3182,6 +3416,10 @@
       "additionalProperties": false,
       "description": "WebEditor header configuration",
       "properties": {
+        "color": {
+          "description": "Accent color (any CSS color) for this item. Used by `logoTrailing` product switchers and accent-aware themes (e.g. `terrarium`) to recolor the UI per product — the active item's `color` is applied as `--theme-color-primary`.",
+          "type": "string"
+        },
         "component": {
           "description": "The component type, e.g. \"Button\", \"Card\", etc.",
           "type": "string"
@@ -3195,11 +3433,18 @@
           "type": "boolean"
         },
         "dropdownMenu": {
-          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs.",
-          "items": {
-            "$ref": "#/definitions/NavigationItem"
-          },
-          "type": "array"
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/definitions/NavigationItem"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/DropdownMenu"
+            }
+          ],
+          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs. Accepts a plain item array, or the object form  {@link  DropdownMenu }  carrying menu-level options (e.g. `{ itemsPerColumn: 7, items: [...] }`)."
         },
         "float": {
           "description": "Float the header to the right",
@@ -3255,6 +3500,10 @@
       "additionalProperties": false,
       "description": "WebEditor navigation item configuration",
       "properties": {
+        "color": {
+          "description": "Accent color (any CSS color) for this item. Used by `logoTrailing` product switchers and accent-aware themes (e.g. `terrarium`) to recolor the UI per product — the active item's `color` is applied as `--theme-color-primary`.",
+          "type": "string"
+        },
         "component": {
           "description": "The component type, e.g. \"Button\", \"Card\", etc.",
           "type": "string"
@@ -3268,11 +3517,18 @@
           "type": "boolean"
         },
         "dropdownMenu": {
-          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs.",
-          "items": {
-            "$ref": "#/definitions/NavigationItem"
-          },
-          "type": "array"
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/definitions/NavigationItem"
+              },
+              "type": "array"
+            },
+            {
+              "$ref": "#/definitions/DropdownMenu"
+            }
+          ],
+          "description": "Nested navigation rendered as a dropdown menu under this item.\n\nRecursive — a child may itself declare `dropdownMenu` to create submenus (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors and tabs. Accepts a plain item array, or the object form  {@link  DropdownMenu }  carrying menu-level options (e.g. `{ itemsPerColumn: 7, items: [...] }`)."
         },
         "href": {
           "description": "The navigation href, if set it redirects but does not match based on routing",

--- a/packages/xyd-cli/scripts/compile.ts
+++ b/packages/xyd-cli/scripts/compile.ts
@@ -52,9 +52,9 @@ const embedTs = path.resolve(DIR, "..", "src", "embed.generated.ts");
 const EMBED_STUB = readFileSync(embedTs, "utf8"); // the committed empty stub
 const REPO_ROOT = path.resolve(DIR, "..", "..", "..");
 const prebuiltDir = path.resolve(DIR, "..", "prebuilt");
-// All 6 built-in themes by default (override with XYD_PREBUILD_THEMES for a
+// All 7 built-in themes by default (override with XYD_PREBUILD_THEMES for a
 // faster proof compile). One shared multi-theme server bundle keeps the size sane.
-const PREBUILD_THEMES = (process.env.XYD_PREBUILD_THEMES || "poetry,cosmo,opener,picasso,gusto,solar")
+const PREBUILD_THEMES = (process.env.XYD_PREBUILD_THEMES || "poetry,cosmo,opener,picasso,gusto,solar,terrarium")
   .split(",").map((s) => s.trim()).filter(Boolean);
 // Absolute path (not the package specifier) so it never resolves to a cached
 // published @xyd-js/documan instead of the workspace source.

--- a/packages/xyd-components/src/layouts/LayoutPrimary/LayoutPrimary.tsx
+++ b/packages/xyd-components/src/layouts/LayoutPrimary/LayoutPrimary.tsx
@@ -13,6 +13,7 @@ export interface LayoutPrimaryProps {
     layout?: PageLayout
     scrollKey?: string
     id?: string
+    style?: React.CSSProperties
 }
 
 const LayoutPrimaryContext = React.createContext<{
@@ -47,6 +48,7 @@ export function LayoutPrimary(props: LayoutPrimaryProps) {
             data-hide-subheader={String(hideMainHeader)}
             data-layout={props.layout}
             id={props.id}
+            style={props.style}
         >
             {props.children}
         </xyd-layout-primary>

--- a/packages/xyd-components/src/writer/Anchor/Anchor.styles.tsx
+++ b/packages/xyd-components/src/writer/Anchor/Anchor.styles.tsx
@@ -18,6 +18,8 @@ export const AnchorHost = css`
         }
 
         color: var(--xyd-anchor-color);
+        text-decoration: var(--xyd-anchor-text-decoration, none);
+        text-underline-offset: var(--xyd-anchor-text-underline-offset, 0.15em);
 
         &:hover {
             color: var(--xyd-anchor-color--hover);

--- a/packages/xyd-components/src/writer/Icon/Icon.tsx
+++ b/packages/xyd-components/src/writer/Icon/Icon.tsx
@@ -14,10 +14,28 @@ interface IconProps {
     color?: string;
 }
 
+/** Whether an icon `name` is actually an image SOURCE (path / URL / data-uri /
+ *  image file) rather than an icon-set key — then it renders as an `<img>`. */
+export function isImageSource(name: string): boolean {
+    if (!name) return false
+    return /^(\/|https?:|data:)/.test(name) || /\.(svg|png|jpe?g|webp|gif)$/i.test(name)
+}
+
 export function Icon(props: IconProps): ReactElement | null {
     const {name, size = 24, color} = props
 
     const iconProvider = use(IconProvider)
+
+    // A path/URL/data-uri icon (e.g. a product logo "/nomad.svg") renders as an
+    // image, keeping its intrinsic aspect ratio (logos are usually not square).
+    if (isImageSource(name)) {
+        return <img
+            src={name}
+            alt=""
+            style={{ height: size, width: "auto", maxHeight: size, display: "inline-block" }}
+        />
+    }
+
     const iconSet = iconProvider?.iconSet
 
     if (!iconSet) {

--- a/packages/xyd-core/src/types/settings.ts
+++ b/packages/xyd-core/src/types/settings.ts
@@ -474,6 +474,20 @@ export interface AppearanceSidebar {
    * The transition behaviour of the sidebar scroll when navigating to a new page.
    */
   scrollTransition?: "smooth" | "instant";
+
+  /**
+   * Letter-casing of sidebar group headers. Defaults to `"uppercase"`; set
+   * `"none"` to render group labels exactly as authored.
+   */
+  groupCase?: "none" | "uppercase";
+
+  /**
+   * Which element scrolls. `"list"` (default): only the item list scrolls, below
+   * the fixed (pinned) region. `"sidebar"`: the WHOLE sidebar scrolls — the
+   * scrollbar spans its full height — and the fixed region sticks to the top
+   * while items scroll beneath it.
+   */
+  scroll?: "list" | "sidebar";
 }
 
 export interface AppearanceButtons {
@@ -562,7 +576,8 @@ export type ThemePresetName =
   | "opener"
   | "picasso"
   | "gusto"
-  | "solar";
+  | "solar"
+  | "terrarium";
 
 /** Search bar location options */
 export type SearchType = "side" | "top";
@@ -731,9 +746,36 @@ export interface Sidebar {
 type Order = 0 | -1 | { after: string } | { before: string };
 
 /**
+ * A custom React component rendered AS a sidebar item.
+ *
+ * `component` is a path (relative to the docs project, e.g.
+ * `"./components/TryNewVersion"`) to a module whose DEFAULT export is a function
+ * component. It renders inside the framework context, so it may use
+ * `@xyd-js/framework/react` hooks; `props` are passed to it. `fixed: true` pins it
+ * in the sidebar's fixed region (above the scrollable list).
+ */
+export interface ComponentPage {
+  /** Pin this item in the sidebar's fixed region (stays visible on scroll). */
+  fixed?: boolean;
+  /**
+   * A path to a default-export React component (relative to the docs project),
+   * or an object with that path under `import` plus `props` for the component.
+   */
+  component: string | ComponentPageImport;
+}
+
+/** Object form of `ComponentPage.component`: an import path plus optional props. */
+export interface ComponentPageImport {
+  /** Path to a default-export React component, relative to the docs project. */
+  import: string;
+  /** Props passed to the component. */
+  props?: Record<string, any>;
+}
+
+/**
  * Page URL type
  */
-export type PageURL = string | VirtualPage | Sidebar;
+export type PageURL = string | VirtualPage | Sidebar | ComponentPage;
 
 /**
  * @internal
@@ -773,24 +815,80 @@ export type VirtualPage =
  *   (wherever the active theme places its logo — header or sidebar). The trigger
  *   shows the active page's title (falling back to the segment `title`), and the
  *   menu is the segment `pages` with a check on the active one.
+ * - `"tabs"` — a horizontal tab bar in the sub-navigation, scoped to the
+ *   segment's `route`. Each `page` is a section: its `page` (a route prefix)
+ *   decides which tab is active, and its `href` is the landing page the tab
+ *   links to. Use one route-scoped `tabs` segment per product to get
+ *   per-product tab bars (e.g. Documentation / API / CLI).
  */
-export type SegmentAppearance = "sidebarDropdown" | "logoTrailing";
+export type SegmentAppearance = "sidebarDropdown" | "logoTrailing" | "tabs";
+
+/**
+ * Object form of {@link Segment.appearance}: a `kind` (same values as the string
+ * form) plus kind-specific `options`. The options shape depends on the kind —
+ * currently only `sidebarDropdown` has options.
+ */
+export type SegmentAppearanceConfig =
+  | SegmentAppearanceSidebarDropdown
+  | { kind: "logoTrailing" }
+  | { kind: "tabs" };
+
+/** `appearance: { kind: "sidebarDropdown", options }` */
+export interface SegmentAppearanceSidebarDropdown {
+  kind: "sidebarDropdown";
+  options?: {
+    /**
+     * Render the section switcher in the sidebar's FIXED (pinned) region — it
+     * stays visible while the item list scrolls. Defaults to `false` (rendered
+     * at the top of the scrollable list).
+     */
+    fixed?: boolean;
+  };
+}
 
 /**
  * Segment configuration
  */
 export interface Segment {
-  /** Route for this segment */
-  route: string;
+  /**
+   * Route this segment is scoped to. When a **string**, the segment only shows
+   * under that route prefix (route-scoped). When **omitted or `false`**, the
+   * segment is GLOBAL — always visible (e.g. a top-level product switcher). The
+   * globalness comes from the absence of a route, NOT from the `appearance`.
+   */
+  route?: string | false;
 
   /** Title of this segment */
   title?: string;
 
-  /** Appearance of this segment. See {@link SegmentAppearance}. */
-  appearance?: SegmentAppearance;
+  /**
+   * Appearance of this segment — a {@link SegmentAppearance} string, or the
+   * object form {@link SegmentAppearanceConfig} carrying kind-specific options
+   * (e.g. `{ kind: "sidebarDropdown", options: { fixed: true } }`).
+   */
+  appearance?: SegmentAppearance | SegmentAppearanceConfig;
 
   /** How a `logoTrailing` segment's dropdown opens. Defaults to `"hover"`. */
   trigger?: "hover" | "click";
+
+  /**
+   * `logoTrailing` only: render the trigger ICON-ONLY — show the active item's
+   * icon at a larger size and hide the trigger title label. Use when the icon is
+   * a full wordmark image (logo + product name) so a text label is redundant.
+   * Defaults to `false`.
+   */
+  iconOnly?: boolean;
+
+  /**
+   * `logoTrailing` only: a custom component rendered AS this segment's dropdown
+   * PANEL (e.g. a rich multi-column product mega-menu), instead of the default
+   * `pages` list. A path to a default-export React component (relative to the docs
+   * project), or `{ import, props }`. Resolved through the same user-components
+   * registry as sidebar `ComponentPage` components, so it may use
+   * `@xyd-js/framework/react` hooks; the framework also passes it the active item,
+   * the segment, and the resolved `items`.
+   */
+  component?: string | ComponentPageImport;
 
   /** Items within this segment */
   pages: NavigationItem[];
@@ -826,18 +924,42 @@ export interface NavigationItem {
   icon?: string | React.ReactNode;
 
   /**
+   * Accent color (any CSS color) for this item. Used by `logoTrailing` product
+   * switchers and accent-aware themes (e.g. `terrarium`) to recolor the UI per
+   * product — the active item's `color` is applied as `--theme-color-primary`.
+   */
+  color?: string;
+
+  /**
    * Nested navigation rendered as a dropdown menu under this item.
    *
    * Recursive — a child may itself declare `dropdownMenu` to create submenus
    * (e.g. `api → [Browser SDK, REST API, GraphQL]`). Supported on header anchors
-   * and tabs.
+   * and tabs. Accepts a plain item array, or the object form {@link DropdownMenu}
+   * carrying menu-level options (e.g. `{ itemsPerColumn: 7, items: [...] }`).
    */
-  dropdownMenu?: NavigationItem[];
+  dropdownMenu?: NavigationItem[] | DropdownMenu;
 
   /**
    * How the `dropdownMenu` opens. Defaults to `"hover"`.
    */
   trigger?: "hover" | "click";
+}
+
+/**
+ * Object form of {@link NavigationItem.dropdownMenu}: the menu items plus
+ * menu-level options.
+ */
+export interface DropdownMenu {
+  /** The menu items. */
+  items: NavigationItem[];
+
+  /**
+   * Maximum items rendered in ONE COLUMN — overflowing items wrap into
+   * additional columns (e.g. `7` renders a 12-item menu as two columns of
+   * 7 + 5). Omit for a single column.
+   */
+  itemsPerColumn?: number;
 }
 
 export type NavigationItemButton = NavigationItem & {
@@ -902,6 +1024,29 @@ export interface Components {
    * WebEditor footer configuration
    */
   footer?: WebEditorFooter;
+
+  /**
+   * Built-in "filter sidebar" input that narrows the sidebar tree to matching
+   * items. It renders in the sidebar's fixed (pinned) region. `true` uses the
+   * default placeholder; pass a {@link FilterSidebar} object to customize the
+   * placeholder and scope it to specific routes.
+   */
+  filterSidebar?: boolean | FilterSidebar;
+}
+
+/**
+ * Configuration for the built-in sidebar filter input (`components.filterSidebar`).
+ */
+export interface FilterSidebar {
+  /** Placeholder text for the filter input. Defaults to `"Filter sidebar"`. */
+  placeholder?: string;
+
+  /**
+   * Render the filter ONLY on pages whose route is under one of these prefixes
+   * (e.g. `["terraform/language"]`). A page matches when its slug starts with a
+   * listed prefix. Omit (or leave empty) to show the filter on every page.
+   */
+  routes?: string[];
 }
 
 // TODO: webeditor appearance?

--- a/packages/xyd-documan/src/bun/buildStatic.ts
+++ b/packages/xyd-documan/src/bun/buildStatic.ts
@@ -8,6 +8,8 @@ import { robotsTxt, sitemapXml, sitemapRoutes } from "./seo";
 import { themePackage, themeShortName } from "./themePkg";
 import { settingsBundleJs } from "./serialize";
 import { pluginPagesEntrySrc, pluginPageRoutes } from "./pluginPages";
+import { sidebarComponentsEntrySrc } from "./sidebarComponents";
+import { collectFederatedComponents, buildUserComponentsServer, buildUserComponentsClient } from "./userComponentsFederation";
 import { prerenderPages } from "./prerenderPool";
 import { writeHtml } from "./htmlOut";
 
@@ -90,7 +92,7 @@ export async function buildStatic(cwd: string = process.cwd()): Promise<void> {
     const clientRes: any = await buildBundle(
       "client",
       // iconSet is NOT baked — the SSR shell injects the project set (step 10).
-      `import Theme from "${themePkg}";\n${pluginPagesEntrySrc()}` +
+      `import Theme from "${themePkg}";\n${pluginPagesEntrySrc()}${sidebarComponentsEntrySrc()}` +
         `import { bootClient } from "./client-entry";\nbootClient(Theme);\n`,
       "browser",
       [],
@@ -140,8 +142,21 @@ export async function buildStatic(cwd: string = process.cwd()): Promise<void> {
   fs.writeFileSync(path.join(clientDir, settingsOut), settingsSrc);
   const settingsJs = "/" + settingsOut;
 
+  // 2d) Project-local user components (sidebar `{ component }` items + MDX/plugin
+  // components) — the binary can't fold them into the embedded client/server graph
+  // (no on-disk framework source), so federate them: a separate chunk whose
+  // react/@xyd-js imports read globalThis.__xydModules at runtime. Non-binary
+  // bundles them via the entry-src, so this is binary-only.
+  const fedComponents = isBin ? collectFederatedComponents() : [];
+  let userComponentsChunkJs: string | undefined;
+  if (fedComponents.length) {
+    const r = await buildUserComponentsClient(fedComponents, clientDir);
+    userComponentsChunkJs = r?.href;
+    console.error(`[build] user-components (federated client, ${fedComponents.length}) → ${userComponentsChunkJs}`);
+  }
+
   // 3) Asset manifest for the (same-process) render bundle.
-  (globalThis as any).__xydBuildAssets = { clientJs, cssLinks, iconSetJs, settingsJs };
+  (globalThis as any).__xydBuildAssets = { clientJs, cssLinks, iconSetJs, settingsJs, userComponentsChunkJs };
 
   // 4) SERVER render bundle → registers globalThis.__xydRenderStatic/__xydSeedForBuild.
   // Capture its path so prerender workers import the SAME bundle instead of rebuilding it.
@@ -161,7 +176,7 @@ export async function buildStatic(cwd: string = process.cwd()): Promise<void> {
     console.error("[build] bundling server render…");
     const serverBundle: string = await buildBundle(
       "buildserver",
-      `import Theme from "${themePkg}";\n${pluginPagesEntrySrc()}` +
+      `import Theme from "${themePkg}";\n${pluginPagesEntrySrc()}${sidebarComponentsEntrySrc()}` +
         `import { renderPageStatic, seedForBuild, buildPageData, renderPluginPageStatic, renderRedirectStatic } from "./renderPage";\n` +
         `globalThis.__xydSeedForBuild = () => seedForBuild(Theme);\n` +
         `globalThis.__xydRenderStatic = (slug, opts) => renderPageStatic(slug, opts);\n` +
@@ -177,6 +192,22 @@ export async function buildStatic(cwd: string = process.cwd()): Promise<void> {
   // The multi-theme server bundle selects the theme by name; the non-binary
   // single-theme entry ignores the arg — so passing themeName is safe for both.
   (globalThis as any).__xydSeedForBuild(themeName);
+
+  // 4b) Project-local user components — SERVER (in-process) federated chunk. Built
+  // AFTER the server bundle (which registered globalThis.__xydModules) and imported
+  // so __xydUserComponentImpls is populated before the serial prerender loop. The
+  // worker pool re-imports the SAME chunk (path passed via ctx).
+  let userComponentsServerChunk = "";
+  if (isBin && fedComponents.length) {
+    const os = await import("node:os");
+    const ucTmp = path.join(os.tmpdir(), `xyd-uc-${Bun.hash(fedComponents.map((c) => c.name + c.importPath).join("|")).toString(16)}`);
+    const chunk = await buildUserComponentsServer(fedComponents, ucTmp);
+    if (chunk) {
+      userComponentsServerChunk = chunk;
+      await import(pathToFileURL(chunk).href);
+      console.error(`[build] user-components (federated server, ${fedComponents.length}) → ${path.basename(chunk)}`);
+    }
+  }
 
   // Serializable data plane for prerender workers: main's already-computed state.
   // Each worker rebuilds render FUNCTIONS via loadPlugins but adopts THIS verbatim
@@ -215,6 +246,7 @@ export async function buildStatic(cwd: string = process.cwd()): Promise<void> {
     clientDir, slugs, accessMap, dataPlane,
     cwd, host: HOST, isBin, argv2: process.argv.slice(2),
     buildAssets: (globalThis as any).__xydBuildAssets, serverBundlePath,
+    userComponentsServerChunk,
   });
   console.error(`[build] wrote ${ok}/${slugs.length} pages`);
 

--- a/packages/xyd-documan/src/bun/buildStatic.ts
+++ b/packages/xyd-documan/src/bun/buildStatic.ts
@@ -228,7 +228,9 @@ export async function buildStatic(cwd: string = process.cwd()): Promise<void> {
   // (e.g. /public/assets/logo.svg) and — because presets prefix logo/favicon and
   // some component images with the basename — ALSO as /<basename>/public/… . Mirror
   // to both so every ref resolves on a static host (dev's serveStatic reconciled
-  // these at request time; a static build must place the files).
+  // these at request time; a static build must place the files). Root-form refs
+  // (/logo.svg — the Vite publicDir convention dev also serves) are mirrored to the
+  // client root at step 7b, AFTER prerender, so generated files always win.
   const publicSrc = getPublicPath();
   copyDir(publicSrc, path.join(clientDir, "public"));
   const baseDir = (settings?.advanced?.basename || "").replace(/^\/+|\/+$/g, "");
@@ -333,6 +335,15 @@ export async function buildStatic(cwd: string = process.cwd()): Promise<void> {
   emitSitemap(clientDir, settings, accessMap, slugs);
   emitRobots(clientDir, settings);
   emitRawRouteFiles(clientDir); // /llms.txt + raw .md (already protected-filtered at appInit)
+
+  // 7b) PUBLIC at ROOT (Vite parity). Vite's publicDir serves public/ contents at
+  // the SITE ROOT, and dev's serveStatic resolves both /file and /public/file — so
+  // a build must ship the root form too (theme.logo: "/logo.svg", segment icons,
+  // …). Runs after every emit above and skips paths the build already wrote, so
+  // generated output always wins (a public/index.html never clobbers the
+  // prerendered one, hashed assets/ are untouched).
+  copyDirIfAbsent(publicSrc, clientDir);
+  if (baseDir) copyDirIfAbsent(publicSrc, path.join(clientDir, baseDir));
 
   // FAIL LOUD on any page that failed to render — otherwise a broken page ships
   // as a 404 while the build reports success (silent broken deploy).
@@ -456,6 +467,21 @@ function copyDir(src: string, dest: string) {
       fs.mkdirSync(d, { recursive: true });
       copyDir(s, d);
     } else {
+      fs.mkdirSync(path.dirname(d), { recursive: true });
+      fs.copyFileSync(s, d);
+    }
+  }
+}
+
+/** copyDir, but an existing destination FILE is left alone (build output wins). */
+function copyDirIfAbsent(src: string, dest: string) {
+  if (!src || !fs.existsSync(src)) return;
+  for (const entry of fs.readdirSync(src, { withFileTypes: true })) {
+    const s = path.join(src, entry.name);
+    const d = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      copyDirIfAbsent(s, d);
+    } else if (!fs.existsSync(d)) {
       fs.mkdirSync(path.dirname(d), { recursive: true });
       fs.copyFileSync(s, d);
     }

--- a/packages/xyd-documan/src/bun/client-entry.tsx
+++ b/packages/xyd-documan/src/bun/client-entry.tsx
@@ -3,6 +3,7 @@ import { hydrateRoot } from "react-dom/client";
 import { createRouterStore, RouterProvider } from "@xyd-js/router";
 
 import { seedGlobals, ShellProviders, slugToPathname } from "./render-tree";
+import { registerFederatedModules } from "./federationRegistry";
 
 /**
  * Client hydration entry (S1/S2). Reads the SSR data embedded by `renderShell`,
@@ -11,7 +12,22 @@ import { seedGlobals, ShellProviders, slugToPathname } from "./render-tree";
  * swap) is wired in a later step; until then navigate() hard-nav falls back to a
  * full load (MPA), so nothing regresses.
  */
-export function bootClient(ThemeCtor: any) {
+export async function bootClient(ThemeCtor: any) {
+  // Expose the shared React/@xyd-js modules, then load the project-local
+  // user-components chunk (binary path) BEFORE hydrating, so its components are on
+  // globalThis.__xydUserComponentImpls when the tree renders — matching the SSR
+  // HTML (no hydration mismatch). No-op on the vite/dev-source path (the chunk URL
+  // is unset; components are already bundled into this client bundle).
+  registerFederatedModules();
+  const chunkUrl = (globalThis as any).__xydUserComponentsChunkUrl;
+  if (chunkUrl) {
+    try {
+      await import(/* @vite-ignore */ chunkUrl);
+    } catch (e) {
+      console.error("[xyd] user-components chunk failed to load:", e);
+    }
+  }
+
   const el = document.getElementById("__xyd_data");
   const data = JSON.parse(el!.textContent || "{}");
 

--- a/packages/xyd-documan/src/bun/federationRegistry.ts
+++ b/packages/xyd-documan/src/bun/federationRegistry.ts
@@ -1,0 +1,39 @@
+// Module-federation registry for project-local user components in the compiled
+// node-free binary.
+//
+// The compiled binary has no on-disk framework source / node_modules, so a
+// project's own components (sidebar `{ component }` items, MDX components) cannot
+// be bundled into the same graph as React/@xyd-js the way the dev/vite path does.
+// Instead we bundle them at `xyd build`/`dev` time as a SEPARATE chunk whose
+// `react` / `@xyd-js/*` imports are rewritten to read this registry at runtime
+// (see userComponentsFederation.ts). This module is imported by BOTH embedded
+// bundles (the prebuilt multi-theme server entry and the per-theme client entry
+// via bootClient), so the shared modules are bundled ONCE and exposed for the
+// federated component chunk to consume — server via globalThis, browser via
+// window (=== globalThis).
+//
+// Keep this list to the stable, client-safe surface a user component is likely to
+// import. Subpath imports not listed here resolve to `{}` in the federated chunk;
+// add them here (and they'll be bundled) if a real component needs them.
+
+import * as React from "react";
+import * as ReactJsxRuntime from "react/jsx-runtime";
+// The unminified SERVER federated chunk emits jsxDEV (dev automatic runtime); the
+// minified CLIENT chunk emits jsx/jsxs. Register BOTH real runtimes so either
+// resolves regardless of how the chunk was built.
+import * as ReactJsxDevRuntime from "react/jsx-dev-runtime";
+import * as FrameworkReact from "@xyd-js/framework/react";
+import * as Framework from "@xyd-js/framework";
+import * as Components from "@xyd-js/components";
+
+export function registerFederatedModules(): void {
+    const g = globalThis as any;
+    g.__xydModules = Object.assign(g.__xydModules || {}, {
+        "react": React,
+        "react/jsx-runtime": ReactJsxRuntime,
+        "react/jsx-dev-runtime": ReactJsxDevRuntime,
+        "@xyd-js/framework/react": FrameworkReact,
+        "@xyd-js/framework": Framework,
+        "@xyd-js/components": Components,
+    });
+}

--- a/packages/xyd-documan/src/bun/prebuild.ts
+++ b/packages/xyd-documan/src/bun/prebuild.ts
@@ -162,6 +162,9 @@ export async function prebuildThemes(host: string, themes: string[], prebuiltDir
       `const THEMES = ${themeDict};\n` +
       `const pick = (name) => THEMES[name] || THEMES[${JSON.stringify(themes[0])}];\n` +
       `import { renderPageStatic, seedForBuild, start, reseed, renderRedirectStatic } from "./renderPage";\n` +
+      // Expose the shared React/@xyd-js modules so runtime-federated project-local
+      // user components (built by userComponentsFederation.ts) resolve at render.
+      `import { registerFederatedModules } from "./federationRegistry";\nregisterFederatedModules();\n` +
       // build (SSG):
       `globalThis.__xydSeedForBuild = (name) => seedForBuild(pick(name));\n` +
       `globalThis.__xydRenderStatic = (slug, opts) => renderPageStatic(slug, opts);\n` +

--- a/packages/xyd-documan/src/bun/prerenderPool.ts
+++ b/packages/xyd-documan/src/bun/prerenderPool.ts
@@ -31,6 +31,9 @@ export interface PrerenderCtx {
   buildAssets: any;
   /** The server render bundle main built/extracted; workers import the same one. */
   serverBundlePath: string;
+  /** Project-local user-components SERVER chunk (binary federation); workers import
+   *  it after the server bundle so __xydUserComponentImpls is populated. "" if none. */
+  userComponentsServerChunk?: string;
 }
 
 export interface PrerenderResult {
@@ -112,6 +115,7 @@ async function prerenderPagesPool(ctx: PrerenderCtx, n: number): Promise<Prerend
           cwd: ctx.cwd, host: ctx.host, isBin: ctx.isBin, argv2: ctx.argv2,
           buildAssets: ctx.buildAssets, clientDir: ctx.clientDir,
           serverBundlePath: ctx.serverBundlePath, cursorSAB,
+          userComponentsServerChunk: ctx.userComponentsServerChunk || "",
           slugs: ctx.slugs, accessMap: ctx.accessMap, dataPlane: ctx.dataPlane,
         };
         const w = new Worker(workerUrl, { workerData: input });

--- a/packages/xyd-documan/src/bun/prerenderWorker.ts
+++ b/packages/xyd-documan/src/bun/prerenderWorker.ts
@@ -31,6 +31,9 @@ export interface WorkerInput {
   /** The server render bundle main built/extracted — importing it registers
    *  globalThis.__xydRenderStatic / __xydSeedForBuild in this worker's heap. */
   serverBundlePath: string;
+  /** Project-local user-components SERVER chunk (binary federation) — imported
+   *  after the server bundle to populate globalThis.__xydUserComponentImpls. */
+  userComponentsServerChunk?: string;
   /** Int32Array-backed shared cursor: Atomics.add hands out slug indices. */
   cursorSAB: SharedArrayBuffer;
   slugs: string[];
@@ -97,6 +100,13 @@ async function run(input: WorkerInput) {
   //    __xydSeedForBuild in this heap) and seed the theme instance.
   await import(pathToFileURL(input.serverBundlePath).href);
   (globalThis as any).__xydSeedForBuild(themeName);
+
+  // 4b) Import the project-local user-components SERVER chunk (binary federation) —
+  //     the server bundle above ran registerFederatedModules(), so this chunk's
+  //     react/@xyd-js shims resolve; it populates __xydUserComponentImpls here.
+  if (input.userComponentsServerChunk) {
+    await import(pathToFileURL(input.userComponentsServerChunk).href);
+  }
 
   parentPort!.postMessage({ type: "ready" });
 

--- a/packages/xyd-documan/src/bun/render-tree.tsx
+++ b/packages/xyd-documan/src/bun/render-tree.tsx
@@ -211,6 +211,9 @@ function DocsBody() {
       a[c.name] = c.component;
       return a;
     }, {});
+    // Binary: real federated impls override the ()=>null placeholders appInit set
+    // for project-local components it couldn't bundle into the embedded graph.
+    Object.assign(userComponents, (globalThis as any).__xydUserComponentImpls || {});
   }
 
   return (
@@ -297,7 +300,14 @@ export function ShellProviders() {
           metadata={loaderData.metadata || {}}
           surfaces={state.surfaces}
           BannerContent={BannerContent}
-          components={{ Search: SearchButton, Logo: FwLogo }}
+          components={{
+            Search: SearchButton,
+            Logo: FwLogo,
+            // Non-binary bun dev: real components bundled via sidebarComponentsEntrySrc.
+            ...((globalThis as any).__xydSidebarComponents || {}),
+            // Binary: project-local components federated at build/dev (real impls win).
+            ...((globalThis as any).__xydUserComponentImpls || {}),
+          }}
         >
           <AtlasContext
             value={

--- a/packages/xyd-documan/src/bun/renderPage.tsx
+++ b/packages/xyd-documan/src/bun/renderPage.tsx
@@ -81,6 +81,11 @@ function renderShell({ settings, bodyHtml, data }: any): string {
     `<div id="root">${bodyHtml}</div>` +
     `<script src="/_xyd/settings.js"></script>` +
     `<script src="/_xyd/iconset.js"></script>` +
+    // Project-local user-components chunk (binary dev federation); bootClient loads
+    // it before hydrating. Unset on the non-binary dev path (components in-bundle).
+    ((globalThis as any).__xydDevUserComponentsChunkUrl
+      ? `<script>window.__xydUserComponentsChunkUrl=${JSON.stringify((globalThis as any).__xydDevUserComponentsChunkUrl)}</script>`
+      : "") +
     `<script id="__xyd_data" type="application/json">${json}</script>` +
     `<script type="module" src="/_bun/client.js"></script>` +
     LIVE_RELOAD +
@@ -378,6 +383,7 @@ function themeHeadHtml(settings: any): string {
 function renderStaticShell({ settings, bodyHtml, data }: any): string {
   const a = (globalThis as any).__xydBuildAssets as {
     clientJs: string; cssLinks: string[]; iconSetJs?: string; settingsJs?: string;
+    userComponentsChunkJs?: string;
   };
   const defaultColorScheme = settings?.theme?.appearance?.colorScheme || "os";
   const metadata = data.loaderData.metadata;
@@ -403,6 +409,11 @@ function renderStaticShell({ settings, bodyHtml, data }: any): string {
     `<div id="root">${bodyHtml}</div>` +
     (a?.settingsJs ? `<script src="${esc(a.settingsJs)}"></script>` : "") +
     (a?.iconSetJs ? `<script src="${esc(a.iconSetJs)}"></script>` : "") +
+    // Project-local user-components chunk URL (binary federation) — bootClient
+    // loads it before hydrating so the impls match the SSR markup.
+    (a?.userComponentsChunkJs
+      ? `<script>window.__xydUserComponentsChunkUrl=${JSON.stringify(a.userComponentsChunkJs)}</script>`
+      : "") +
     `<script id="__xyd_data" type="application/json">${json}</script>` +
     `<script type="module" src="${a?.clientJs || "/assets/client.js"}"></script>` +
     `</body></html>`
@@ -616,6 +627,16 @@ export function start(ThemeCtor: any) {
         return new Response(settingsBundleJs(getSettings(), getSettingsClone()), {
           headers: { "content-type": "text/javascript; charset=utf-8" },
         });
+      }
+      if (url.pathname === "/_bun/user-components.js") {
+        // Project-local user-components federated client chunk (binary dev). Served
+        // from the tmp path startDevServer built it to (globalThis global). 404 →
+        // bootClient just skips it (no components declared).
+        const p = (globalThis as any).__xydDevUserComponentsChunkPath || "";
+        if (p) {
+          return new Response(Bun.file(p), { headers: { "content-type": "text/javascript; charset=utf-8" } });
+        }
+        return new Response("/* no user components */", { headers: { "content-type": "text/javascript" } });
       }
       if (url.pathname === "/_bun/client.js") {
         // Read live — an icon rebuild re-bundles the client and updates this env,

--- a/packages/xyd-documan/src/bun/sidebarComponents.ts
+++ b/packages/xyd-documan/src/bun/sidebarComponents.ts
@@ -1,0 +1,26 @@
+// Custom sidebar-item components (`{ component: "./path" }`) — bun parity with the
+// Vite `virtual:xyd-user-components` path. At bundle time we read the paths collected
+// by appInit (globalThis.__xydSidebarComponentPaths — with ABSOLUTE import paths, since
+// this entry is emitted into documan's dir, not the docs project) and generate ESM
+// that statically imports each component and registers it on
+// globalThis.__xydSidebarComponents keyed by the config path string. The shared render
+// tree merges that into the Framework component map so `FwSidebarComponent` resolves
+// it via `useComponents()`. Returns "" when a project has no such components (common
+// case) → the bundle entries stay byte-identical.
+
+export function sidebarComponentsEntrySrc(): string {
+    const items: { path: string; importPath: string }[] =
+        (globalThis as any).__xydSidebarComponentPaths || [];
+    if (!items.length) return "";
+
+    const imports: string[] = [];
+    const reg: string[] = [];
+    items.forEach((it, i) => {
+        if (!it?.path || !it?.importPath) return;
+        imports.push(`import __SC${i} from ${JSON.stringify(it.importPath)};`);
+        reg.push(`${JSON.stringify(it.path)}: __SC${i}`);
+    });
+    if (!reg.length) return "";
+
+    return imports.join("\n") + `\nglobalThis.__xydSidebarComponents = { ${reg.join(", ")} };\n`;
+}

--- a/packages/xyd-documan/src/bun/startDevServer.ts
+++ b/packages/xyd-documan/src/bun/startDevServer.ts
@@ -10,6 +10,7 @@ import { appInit, getHostPath, pluginIconSet, postWorkspaceSetup } from "../../d
 import { startWatcher, type WatchHandle } from "./watcher";
 import { themePackage, themeShortName } from "./themePkg";
 import { pluginPagesEntrySrc } from "./pluginPages";
+import { sidebarComponentsEntrySrc } from "./sidebarComponents";
 
 /**
  * S1 dev server (Bun.serve + Bun.build — no Vite, no React Router). Reusable
@@ -213,7 +214,7 @@ async function rebundleClient(): Promise<string> {
     // iconSet is NOT baked — the SSR shell injects the project set (step 10).
     // pluginPagesEntrySrc() (empty for most projects) registers login/auth-callback
     // components before bootClient runs, so plugin routes hydrate.
-    `import Theme from "${themePkg}";\n${pluginPagesEntrySrc()}import { bootClient } from "./client-entry";\nbootClient(Theme);\n`,
+    `import Theme from "${themePkg}";\n${pluginPagesEntrySrc()}${sidebarComponentsEntrySrc()}import { bootClient } from "./client-entry";\nbootClient(Theme);\n`,
     "browser",
     [],
     true
@@ -228,7 +229,7 @@ async function rebundleServer(): Promise<string> {
   // trigger a re-seed after a hot re-appInit.
   return buildBundle(
     "server",
-    `import Theme from "${themePkg}";\n${pluginPagesEntrySrc()}` +
+    `import Theme from "${themePkg}";\n${pluginPagesEntrySrc()}${sidebarComponentsEntrySrc()}` +
       `import { start, reseed } from "./renderPage";\n` +
       `globalThis.__xydBunStart  = () => start(Theme);\n` +
       `globalThis.__xydBunReseed = () => reseed(Theme);\n`,
@@ -321,6 +322,31 @@ export async function startDevServer(
   }
 
   await importFresh(serverBundle!);
+
+  // Project-local user components in the binary dev server — the embedded bundles
+  // can't fold them into their graph (no on-disk framework source), so federate:
+  // build a browser chunk (served at /_bun/user-components.js, loaded before
+  // hydration) + a server chunk (imported now — the server bundle above ran
+  // registerFederatedModules() so its react/@xyd-js shims resolve). Binary-only;
+  // the non-binary dev path bundles components via the entry-src.
+  if (isBin) {
+    const { collectFederatedComponents, buildUserComponentsClient, buildUserComponentsServer } =
+      await import("./userComponentsFederation");
+    const fed = collectFederatedComponents();
+    if (fed.length) {
+      const os = await import("node:os");
+      const tmpDir = path.join(os.tmpdir(), `xyd-uc-dev-${Bun.hash(fed.map((c) => c.name + c.importPath).join("|")).toString(16)}`);
+      const cli = await buildUserComponentsClient(fed, tmpDir);
+      if (cli) {
+        (globalThis as any).__xydDevUserComponentsChunkPath = cli.absPath;
+        (globalThis as any).__xydDevUserComponentsChunkUrl = "/_bun/user-components.js";
+      }
+      const srv = await buildUserComponentsServer(fed, tmpDir);
+      if (srv) await import(pathToFileURL(srv).href);
+      console.error(`[dev] user-components (federated, ${fed.length})`);
+    }
+  }
+
   // Pass themeName so the multi-theme binary bundle selects the right theme; the
   // non-binary single-theme entry ignores the arg.
   const server = (globalThis as any).__xydBunStart(themeName);

--- a/packages/xyd-documan/src/bun/userComponentsFederation.ts
+++ b/packages/xyd-documan/src/bun/userComponentsFederation.ts
@@ -1,0 +1,134 @@
+// Runtime bundling of PROJECT-LOCAL user components for the compiled node-free
+// binary (module federation). See federationRegistry.ts for the why.
+//
+// The binary can't fold a project's own components into the prebuilt/embedded
+// client & server bundles (no on-disk framework source to bundle against). So at
+// `xyd build` / `xyd dev` we Bun.build the component files into a SEPARATE chunk
+// whose `react` / `@xyd-js/*` imports are rewritten to a CJS shim that reads
+// `globalThis.__xydModules` (populated by registerFederatedModules() inside the
+// embedded bundles). The chunk registers each component on
+// `globalThis.__xydUserComponentImpls[name]`, which render-tree.tsx merges into
+// the Framework component map. Validated: Bun.build + this shim run inside a
+// `bun --compile` executable with no node_modules.
+
+import * as path from "node:path";
+import * as fs from "node:fs";
+import type { BunPlugin } from "bun";
+
+export interface FederatedComponent {
+    /** registry key used in config + FwSidebarComponent lookup, e.g. "./components/Foo" */
+    name: string;
+    /** absolute path to the component source/dist file */
+    importPath: string;
+}
+
+/** Union of sidebar `{ component }` items and plugin/MDX user components that
+ *  resolve to a real on-disk file — deduped by registry name. */
+export function collectFederatedComponents(): FederatedComponent[] {
+    const g = globalThis as any;
+    const out: FederatedComponent[] = [];
+    const seen = new Set<string>();
+
+    const add = (name?: string, importPath?: string) => {
+        if (!name || !importPath || seen.has(name)) return;
+        if (!fs.existsSync(importPath)) return;
+        seen.add(name);
+        out.push({ name, importPath });
+    };
+
+    for (const c of (g.__xydSidebarComponentPaths || []) as any[]) {
+        add(c.path, c.importPath);
+    }
+    // MDX / plugin user components that ship a real dist file (not inline).
+    for (const c of (g.__xydUserComponents || []) as any[]) {
+        if (c?.isInline || !c?.dist) continue;
+        const abs = path.isAbsolute(c.dist) ? c.dist : path.resolve(process.cwd(), c.dist);
+        add(c.name, abs);
+    }
+    return out;
+}
+
+/** Bun plugin: rewrite `react` / `react/*` / `@xyd-js/*` to a CJS shim that reads
+ *  the runtime federation registry. esbuild turns the component's
+ *  `import { x } from "<spec>"` into a runtime property access on the shim, so no
+ *  export enumeration is needed. */
+function federationPlugin(): BunPlugin {
+    const FED = /^(react$|react\/jsx-runtime$|react\/jsx-dev-runtime$|react-dom$|react-dom\/client$|@xyd-js\/)/;
+    return {
+        name: "xyd-user-components-federation",
+        setup(b) {
+            b.onResolve({ filter: FED }, (a) => ({ path: a.path, namespace: "xyd-fed" }));
+            b.onLoad({ namespace: "xyd-fed", filter: /.*/ }, (a) => ({
+                contents: `module.exports = (globalThis.__xydModules && globalThis.__xydModules[${JSON.stringify(a.path)}]) || {};`,
+                loader: "js",
+            }));
+        },
+    };
+}
+
+function synthEntry(components: FederatedComponent[]): string {
+    const imports = components
+        .map((c, i) => `import __C${i} from ${JSON.stringify(c.importPath)};`)
+        .join("\n");
+    const assigns = components.map((c, i) => `  ${JSON.stringify(c.name)}: __C${i},`).join("\n");
+    return (
+        `${imports}\n` +
+        `const g = globalThis;\n` +
+        `g.__xydUserComponentImpls = Object.assign(g.__xydUserComponentImpls || {}, {\n${assigns}\n});\n`
+    );
+}
+
+/** Build the SERVER (in-process, SSR) federated chunk. Returns the absolute output
+ *  path to import() via pathToFileURL, or null when there are no components. */
+export async function buildUserComponentsServer(
+    components: FederatedComponent[],
+    tmpDir: string,
+): Promise<string | null> {
+    if (!components.length) return null;
+    const entryPath = path.join(tmpDir, ".xyd-user-components.server.entry.tsx");
+    fs.mkdirSync(tmpDir, { recursive: true });
+    fs.writeFileSync(entryPath, synthEntry(components));
+    const res = await Bun.build({
+        entrypoints: [entryPath],
+        target: "bun",
+        outdir: path.join(tmpDir, "server"),
+        naming: "user-components.js",
+        plugins: [federationPlugin()],
+        sourcemap: "none",
+    });
+    if (!res.success) {
+        throw new Error(`user-components (server) bundle failed:\n${res.logs.map((l) => String(l)).join("\n")}`);
+    }
+    return res.outputs.find((o) => o.kind === "entry-point")!.path;
+}
+
+/** Build the BROWSER (hydration) federated chunk into `outDir/assets` (hashed).
+ *  Returns the public href (relative to outDir) + the absolute output path (the dev
+ *  server serves the file directly at a fixed URL), or null when no components. */
+export async function buildUserComponentsClient(
+    components: FederatedComponent[],
+    outDir: string,
+): Promise<{ href: string; absPath: string } | null> {
+    if (!components.length) return null;
+    const tmp = path.join(outDir, ".xyd-uc-client-entry.tsx");
+    fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(tmp, synthEntry(components));
+    try {
+        const res = await Bun.build({
+            entrypoints: [tmp],
+            target: "browser",
+            outdir: outDir,
+            naming: { entry: "assets/user-components-[hash].js", chunk: "assets/[name]-[hash].js" },
+            plugins: [federationPlugin()],
+            minify: true,
+            sourcemap: "none",
+        });
+        if (!res.success) {
+            throw new Error(`user-components (client) bundle failed:\n${res.logs.map((l) => String(l)).join("\n")}`);
+        }
+        const absPath = res.outputs.find((o) => o.kind === "entry-point")!.path;
+        return { href: "/" + path.relative(outDir, absPath).replace(/\\/g, "/"), absPath };
+    } finally {
+        fs.rmSync(tmp, { force: true });
+    }
+}

--- a/packages/xyd-documan/src/utils.ts
+++ b/packages/xyd-documan/src/utils.ts
@@ -50,6 +50,7 @@ import themeOpenerPkg from "../../xyd-theme-opener/package.json";
 import themePicassoPkg from "../../xyd-theme-picasso/package.json";
 import themeGustoPkg from "../../xyd-theme-gusto/package.json";
 import themeSolarPkg from "../../xyd-theme-solar/package.json";
+import themeTerrariumPkg from "../../xyd-theme-terrarium/package.json";
 
 import {
     BUILD_FOLDER_PATH,
@@ -269,6 +270,7 @@ const BUILT_IN_THEME_VERSIONS: Record<string, string> = {
     "@xyd-js/theme-picasso": themePicassoPkg.version,
     "@xyd-js/theme-gusto": themeGustoPkg.version,
     "@xyd-js/theme-solar": themeSolarPkg.version,
+    "@xyd-js/theme-terrarium": themeTerrariumPkg.version,
 };
 
 const NPM_THEME_PREFIX = "npm:";
@@ -575,6 +577,62 @@ export async function appInit(options?: PluginDocsOptions) {
                 }
             }
         });
+
+        // Custom sidebar-item components: collect `{ component: "./path" }` entries
+        // from the navigation and register them (keyed by the path string) so BOTH
+        // engines can resolve them by path at render time:
+        //  - Vite: pushed into componentPlugins → virtualComponentsPlugin bundles them.
+        //  - Bun:  recorded on __xydSidebarComponentPaths → sidebarComponentsEntrySrc()
+        //          emits static imports (needs an ABSOLUTE path since the bun entry
+        //          lives in documan's dir, not the docs project).
+        {
+            const seenComponents = new Set<string>();
+            const componentPaths: { path: string; importPath: string }[] = [];
+            // A component ref is a path string OR `{ import, props }` — key by path.
+            const registerComponent = (rawComp: any) => {
+                const comp = typeof rawComp === "string" ? rawComp : rawComp?.import;
+                if (typeof comp !== "string" || seenComponents.has(comp)) return;
+                seenComponents.add(comp);
+                const { resolvedDist, exists } = resolveComponentDist(comp);
+                componentPlugins.push({
+                    name: comp,              // key by the path string
+                    dist: resolvedDist,
+                    isInline: !exists,
+                    component: () => null,   // placeholder; real one is imported
+                });
+                if (exists) {
+                    componentPaths.push({
+                        path: comp,
+                        importPath: path.isAbsolute(resolvedDist)
+                            ? resolvedDist
+                            : path.resolve(process.cwd(), resolvedDist),
+                    });
+                }
+            };
+            const collectSidebarComponents = (pages: any[]) => {
+                for (const p of pages || []) {
+                    if (!p || typeof p !== "object") continue;
+                    registerComponent((p as any).component);
+                    if (Array.isArray((p as any).pages)) collectSidebarComponents((p as any).pages);
+                }
+            };
+            const walkNav = (nav: any) => {
+                for (const s of ((nav?.sidebar as any[]) || [])) {
+                    if (s && typeof s === "object" && Array.isArray((s as any).pages)) {
+                        collectSidebarComponents((s as any).pages);
+                    }
+                }
+                // Segment custom panel components (`segment.component`).
+                for (const seg of ((nav?.segments as any[]) || [])) {
+                    if (seg && typeof seg === "object") registerComponent((seg as any).component);
+                }
+            };
+            walkNav(preloadSettings?.navigation);
+            for (const lang of ((preloadSettings?.navigation as any)?.languages) || []) {
+                walkNav(lang);
+            }
+            (globalThis as any).__xydSidebarComponentPaths = componentPaths;
+        }
 
         globalThis.__xydUserUniformVitePlugins = userUniformVitePlugins;
         globalThis.__xydUserMarkdownPlugins = userMarkdownPlugins;

--- a/packages/xyd-framework/__tests__/activeLogoTrailingItem.test.ts
+++ b/packages/xyd-framework/__tests__/activeLogoTrailingItem.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import type { Segment } from "@xyd-js/core";
+
+import { resolveActiveLogoTrailingItem } from "../packages/react/utils/segmentLogoTrailing";
+
+const segment: Segment = {
+    route: "products",
+    title: "HashiCorp",
+    appearance: "logoTrailing",
+    pages: [
+        { title: "Nomad", page: "nomad", icon: "server", color: "#00ca8e" },
+        { title: "Nomad Enterprise", page: "nomad-enterprise", icon: "server", color: "#111111" },
+        { title: "Consul", page: "consul", icon: "network-wired", color: "#dc477d" },
+        { title: "Vault", page: "vault", icon: "lock", color: "#ffcf25" },
+    ],
+};
+
+describe("resolveActiveLogoTrailingItem", () => {
+    it("returns the product whose prefix matches the path, with its color", () => {
+        const active = resolveActiveLogoTrailingItem(segment, "/consul/docs/install");
+        expect(active?.title).toBe("Consul");
+        expect(active?.color).toBe("#dc477d");
+    });
+
+    it("matches on the product landing path too", () => {
+        expect(resolveActiveLogoTrailingItem(segment, "/vault")?.title).toBe("Vault");
+    });
+
+    it("returns null when no product is active (e.g. the landing page)", () => {
+        expect(resolveActiveLogoTrailingItem(segment, "/overview")).toBeNull();
+        expect(resolveActiveLogoTrailingItem(segment, "/")).toBeNull();
+    });
+
+    it("disambiguates overlapping prefixes via findLast (last match wins)", () => {
+        // "nomad" prefixes "nomad-enterprise"; both match, findLast picks the
+        // one declared later — so the more specific entry must come after.
+        const active = resolveActiveLogoTrailingItem(segment, "/nomad-enterprise/docs");
+        expect(active?.title).toBe("Nomad Enterprise");
+        expect(active?.color).toBe("#111111");
+    });
+
+    it("returns the plain product when only its own prefix matches", () => {
+        expect(resolveActiveLogoTrailingItem(segment, "/nomad/docs/quickstart")?.title).toBe("Nomad");
+    });
+});

--- a/packages/xyd-framework/__tests__/sidebarFilter.test.ts
+++ b/packages/xyd-framework/__tests__/sidebarFilter.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+
+import { sidebarItemMatchesQuery, type FilterableSidebarItem } from "../packages/react/utils/sidebarFilter";
+
+const group: FilterableSidebarItem = {
+    title: "Get started",
+    items: [
+        { title: "What is Nomad?" },
+        { title: "Quickstart" },
+        {
+            title: "Architecture",
+            items: [
+                { title: "Cluster consensus" },
+                { title: "Multi-region federation" },
+            ],
+        },
+    ],
+};
+
+describe("sidebarItemMatchesQuery", () => {
+    it("keeps everything when the query is empty (filter inactive)", () => {
+        expect(sidebarItemMatchesQuery(group, "")).toBe(true);
+        expect(sidebarItemMatchesQuery({ title: "Anything" }, "")).toBe(true);
+    });
+
+    it("matches a leaf on its own title", () => {
+        expect(sidebarItemMatchesQuery({ title: "Quickstart" }, "quick")).toBe(true);
+        expect(sidebarItemMatchesQuery({ title: "Quickstart" }, "vault")).toBe(false);
+    });
+
+    it("keeps a group when a descendant matches (even if the group title does not)", () => {
+        expect(sidebarItemMatchesQuery(group, "consensus")).toBe(true);
+        expect(sidebarItemMatchesQuery(group, "federation")).toBe(true);
+    });
+
+    it("drops a group when neither it nor any descendant matches", () => {
+        expect(sidebarItemMatchesQuery(group, "billing")).toBe(false);
+    });
+
+    it("keeps a group when the group's own title matches", () => {
+        expect(sidebarItemMatchesQuery(group, "get started")).toBe(true);
+    });
+
+    it("prefers sidebarTitle over title when present", () => {
+        expect(sidebarItemMatchesQuery({ title: "Original", sidebarTitle: "Renamed" }, "renamed")).toBe(true);
+        expect(sidebarItemMatchesQuery({ title: "Original", sidebarTitle: "Renamed" }, "original")).toBe(false);
+    });
+});

--- a/packages/xyd-framework/packages/hydration/mapSettingsToProps.ts
+++ b/packages/xyd-framework/packages/hydration/mapSettingsToProps.ts
@@ -80,6 +80,28 @@ export async function mapSettingsToProps(
             return null
         }
 
+        // Custom-component sidebar item: `{ component: "./path", fixed?, props? }`.
+        // Carries the component path through to the renderer (resolved via the
+        // user-components registry); no frontmatter/href to load.
+        if (typeof page !== "string" && "component" in page) {
+            // `component` is either a path string, or `{ import, props }`.
+            // Normalize to a registry-key path + optional props for the renderer.
+            const rawComponent = (page as any).component
+            const componentPath = typeof rawComponent === "string" ? rawComponent : rawComponent?.import
+            // Malformed (e.g. object form without `import`) → skip, don't emit a blank item.
+            if (!componentPath) return null
+            const componentProps = (rawComponent && typeof rawComponent === "object") ? rawComponent.props : undefined
+            return {
+                title: "",
+                href: "",
+                active: false,
+                uniqIndex: uniqIndex++,
+                component: componentPath,
+                fixed: !!(page as any).fixed,
+                componentProps,
+            }
+        }
+
         if (typeof page !== "string" && !("virtual" in page)) {
             const items = page.pages
                 ?.map((p) => mapItems(p, page, nav))
@@ -166,6 +188,15 @@ export async function mapSettingsToProps(
                 flatItems.push(nav)
 
                 return
+            }
+
+            // Pageless custom-component item at the top level of a route's pages
+            // (`{ component, fixed?, props? }`). It has no `page`/`pages`, so it
+            // must go through mapItems (which carries the component through) rather
+            // than sidebarItems (which would drop it as an empty group).
+            if (typeof nav !== "string" && "component" in nav) {
+                const item = mapItems(nav, {} as Sidebar, filteredNav)
+                return item ? ({ items: [item] } as FwSidebarItemProps) : undefined
             }
 
             // TODO: finish

--- a/packages/xyd-framework/packages/react/components/FwHeaderItems.tsx
+++ b/packages/xyd-framework/packages/react/components/FwHeaderItems.tsx
@@ -4,7 +4,7 @@ import { WebEditorHeader } from "@xyd-js/core";
 import { Icon } from "@xyd-js/components/writer";
 import { Nav } from "@xyd-js/ui"
 
-import { isExternal, pageLink } from "../utils";
+import { isExternal, pageLink, dropdownMenuItems } from "../utils";
 import { useAppearance } from "../contexts";
 import { FwLink } from "../components";
 import { useHeaderItems } from "../hooks";
@@ -33,7 +33,7 @@ export function FwHeaderItem(props: WebEditorHeader) {
 
     // Header anchors / center-surface tabs that declare a nested menu render as a
     // multi-level dropdown (hover default | click) instead of a plain Nav.Item.
-    if (props.dropdownMenu?.length) {
+    if (dropdownMenuItems(props.dropdownMenu).length) {
         return <FwNavDropdown key={keyId(props)} item={props} />
     }
 

--- a/packages/xyd-framework/packages/react/components/FwNav.tsx
+++ b/packages/xyd-framework/packages/react/components/FwNav.tsx
@@ -7,10 +7,11 @@ import {
 import { LayoutPrimary } from "@xyd-js/components/layouts";
 
 import { SurfaceTarget } from "../../../src";
-import { useActivePage, useDefaultHeaderItems } from "../hooks";
+import { useActivePage, useDefaultHeaderItems, useMatchedSegmentTabs } from "../hooks";
 import { Surface } from "./Surfaces";
 import { FwLogo } from "./FwLogo";
 import { FwHeaderItem, FwHeaderItems } from "./FwHeaderItems";
+import { FwSegmentTabs } from "./FwSegmentTabs";
 import { useAppearance, useShowColorSchemeButton } from "../contexts";
 import { WebEditorComponent } from "./WebEditorComponent";
 
@@ -19,6 +20,11 @@ export function FwNav() {
     const activeHeaderPage = useActivePage()
     const appearance = useAppearance()
     const showColorSchemeButton = useShowColorSchemeButton()
+
+    // A route-scoped `appearance:"tabs"` segment renders in the nav CENTER when
+    // `appearance.tabs.surface === "center"` (otherwise it renders as a subnav).
+    const tabsSegment = useMatchedSegmentTabs()
+    const tabsInCenter = !!tabsSegment && appearance?.tabs?.surface === "center"
 
     const Header = FwHeaderItems()
     const logo = appearance?.logo?.header ? <WebEditorComponent.NavItemRaw
@@ -34,7 +40,9 @@ export function FwNav() {
         }}
         logo={logo}
         centerSurface={
-            Header?.center?.length ? <>
+            tabsInCenter ? (
+                <FwSegmentTabs segment={tabsSegment!} />
+            ) : Header?.center?.length ? <>
                 <Nav.Tabs
                     value={activeHeaderPage}
                 >

--- a/packages/xyd-framework/packages/react/components/FwNavDropdown.tsx
+++ b/packages/xyd-framework/packages/react/components/FwNavDropdown.tsx
@@ -1,10 +1,29 @@
 import React from "react";
 
 import type { NavigationItem } from "@xyd-js/core";
+import { Icon, isImageSource } from "@xyd-js/components/writer";
 import { Nav } from "@xyd-js/ui";
 
-import { resolveDropdownItems } from "../utils";
+import { resolveDropdownItems, dropdownMenuItems, dropdownMenuOptions, type ResolvedDropdownItem } from "../utils";
 import { FwLink } from "./FwLink";
+
+/**
+ * Resolve icon-set NAME icons to `<Icon>` elements HERE, in the framework layer.
+ * xyd-ui inlines its own copy of the Icon component, whose IconProvider context
+ * instance differs from the app's — a name lookup inside the ui bundle always
+ * sees an empty icon set and renders nothing. Image-source icons (paths/data
+ * URIs) stay strings: the ui `<img>` branch needs no context and the ui layer
+ * sizes them (e.g. the icon-only switcher trigger).
+ */
+export function resolveDropdownIcons(items: ResolvedDropdownItem[], size = 16): ResolvedDropdownItem[] {
+    return items.map((it) => ({
+        ...it,
+        icon: typeof it.icon === "string" && !isImageSource(it.icon)
+            ? <Icon name={it.icon} size={size} />
+            : it.icon,
+        items: it.items ? resolveDropdownIcons(it.items, size) : undefined,
+    }));
+}
 
 /**
  * Renders a nav item that carries `dropdownMenu` as a {@link Nav.Dropdown} — the
@@ -13,13 +32,15 @@ import { FwLink } from "./FwLink";
  * (works under both the bun and Vite engines). Hrefs (incl. nested submenus) are
  * resolved by the pure `resolveDropdownItems`.
  */
-export function FwNavDropdown({ item }: { item: NavigationItem }) {
+export function FwNavDropdown({ item, active }: { item: NavigationItem; active?: boolean }) {
     return (
         <Nav.Dropdown
             title={item.title}
             icon={item.icon}
             trigger={item.trigger}
-            items={resolveDropdownItems(item.dropdownMenu || [])}
+            active={active}
+            items={resolveDropdownIcons(resolveDropdownItems(dropdownMenuItems(item.dropdownMenu)))}
+            itemsPerColumn={dropdownMenuOptions(item.dropdownMenu).itemsPerColumn}
             as={FwLink}
         />
     );

--- a/packages/xyd-framework/packages/react/components/FwSegmentLogoTrailing.tsx
+++ b/packages/xyd-framework/packages/react/components/FwSegmentLogoTrailing.tsx
@@ -1,11 +1,12 @@
 import React from "react";
-import { useLocation } from "react-router";
 
 import { Nav } from "@xyd-js/ui";
 
-import { useLogoTrailingSegment } from "../hooks";
-import { pageLink, trailingSlash, resolveLogoTrailingSwitcher } from "../utils";
+import { useLogoTrailingSegment, useActiveLogoTrailingItem } from "../hooks";
+import { useComponents } from "../contexts";
+import { resolveLogoTrailingSwitcher } from "../utils";
 import { FwLink } from "./FwLink";
+import { resolveDropdownIcons } from "./FwNavDropdown";
 
 /**
  * Renders a `logoTrailing` segment as a GLOBAL hover product-switcher, hosted on
@@ -20,24 +21,42 @@ import { FwLink } from "./FwLink";
  */
 export function FwSegmentLogoTrailing() {
     const segment = useLogoTrailingSegment()
-    const location = useLocation()
+    const activeItem = useActiveLogoTrailingItem()
+    const components = useComponents() as Record<string, React.ComponentType<any>> | undefined
 
     if (!segment) {
         return null
     }
 
-    const pathname = trailingSlash(location.pathname)
-    const activePage = segment.pages?.findLast(
-        page => !!page.page && pathname.startsWith(pageLink(page.page))
-    )?.page || ""
+    const { triggerLabel, items: rawItems } = resolveLogoTrailingSwitcher(segment, activeItem?.page || "")
+    // Icon-set NAME icons must resolve to <Icon> here (framework) — see
+    // resolveDropdownIcons; image-path icons stay strings for the ui to size.
+    const items = resolveDropdownIcons(rawItems as any)
 
-    const { triggerLabel, items } = resolveLogoTrailingSwitcher(segment, activePage)
+    // Optional custom PANEL component (`segment.component`: path string or
+    // `{ import, props }`), resolved through the user-components registry — same as
+    // sidebar `ComponentPage`. When present, it renders as the dropdown panel
+    // instead of the default `items` list; it receives the config `props` plus the
+    // active item, the segment, and the resolved items.
+    const rawComp = (segment as any).component as string | { import: string; props?: Record<string, any> } | undefined
+    const compPath = typeof rawComp === "string" ? rawComp : rawComp?.import
+    const compProps = rawComp && typeof rawComp === "object" ? rawComp.props : undefined
+    const PanelComp = compPath ? components?.[compPath] : undefined
+    if (compPath && !PanelComp && typeof console !== "undefined") {
+        console.warn(`[xyd] segment component not found: "${compPath}"`)
+    }
+    const content = PanelComp
+        ? <PanelComp {...(compProps || {})} activeItem={activeItem} segment={segment} items={items} />
+        : undefined
 
     return (
         <Nav.Dropdown
             title={triggerLabel}
+            icon={activeItem?.icon}
+            iconOnly={segment.iconOnly}
             trigger={segment.trigger}
             items={items}
+            content={content}
             as={FwLink}
         />
     )

--- a/packages/xyd-framework/packages/react/components/FwSegmentTabs.tsx
+++ b/packages/xyd-framework/packages/react/components/FwSegmentTabs.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { useLocation } from "react-router";
+
+import { Segment } from "@xyd-js/core";
+import { Nav } from "@xyd-js/ui";
+
+import { pageLink, trailingSlash, dropdownMenuItems } from "../utils";
+import { FwLink } from "./FwLink";
+import { FwNavDropdown } from "./FwNavDropdown";
+
+/**
+ * Renders a route-scoped `appearance: "tabs"` segment as a tab bar (Radix
+ * `Nav.Tabs`) — used in the primary nav CENTER when `appearance.tabs.surface`
+ * is `"center"`. The active tab is the page whose `page` (a route prefix)
+ * prefixes the current path; each tab links to its `href` (falling back to
+ * `page`). Pure rendering — the caller supplies the matched segment.
+ */
+export function FwSegmentTabs({ segment }: { segment: Segment }) {
+    const location = useLocation();
+
+    const pathname = trailingSlash(location.pathname);
+    // Radix Tabs `value` (the selected/underlined tab) comes ONLY from PLAIN tabs
+    // whose own `page` prefixes the path. A `dropdownMenu` tab has no `page`/value —
+    // it carries its own active state via the `active` prop (true when any child
+    // section's `page` prefixes the path), so it doesn't hijack the selected tab.
+    const activePage = segment.pages?.findLast(
+        (p) => !!p.page && pathname.startsWith(pageLink(p.page)),
+    );
+    const isDropdownActive = (p: (typeof segment.pages)[number]) =>
+        dropdownMenuItems(p.dropdownMenu).some((c) => !!c.page && pathname.startsWith(pageLink(c.page)));
+
+    return (
+        <Nav.Tabs value={activePage?.page || ""}>
+            {segment.pages?.map((p, i) => {
+                // A tab that carries `dropdownMenu` becomes a hover dropdown (the
+                // HashiCorp "Documentation ▾" pattern): each entry links to a section
+                // that has its own route-scoped sidebar.
+                if (dropdownMenuItems(p.dropdownMenu).length) {
+                    return <FwNavDropdown key={p.page || p.title || i} item={p} active={isDropdownActive(p)} />;
+                }
+                const href = pageLink(typeof p.href === "string" ? p.href : (p.page || ""));
+                return (
+                    <Nav.Item
+                        key={p.page || p.href || i}
+                        // A UNIQUE value per tab. Radix Tabs marks every trigger whose
+                        // value equals the list value as active — so pageless tabs
+                        // (external links: Install/Tutorials/…) must NOT all share the
+                        // empty string, or they'd all light up active. Only a tab with
+                        // a real `page` can match the active value (`activePage?.page`).
+                        value={p.page || p.href || String(i)}
+                        href={href}
+                        as={FwLink}
+                    >
+                        {p.title}
+                    </Nav.Item>
+                );
+            })}
+        </Nav.Tabs>
+    );
+}

--- a/packages/xyd-framework/packages/react/components/FwSidebar.tsx
+++ b/packages/xyd-framework/packages/react/components/FwSidebar.tsx
@@ -1,9 +1,10 @@
 import React, { } from "react";
+import { useMatches } from "react-router";
 
 import { UISidebar } from "@xyd-js/ui"
 
 import { SurfaceTarget } from "../../../src";
-import { useAppearance, useSettings, } from "../contexts";
+import { useAppearance, useSettings, useSidebarGroups, SidebarFilterProvider } from "../contexts";
 
 import { Surface } from "./Surfaces";
 import { FooSidebar } from "../lib";
@@ -12,8 +13,25 @@ import { FwSidebarTabsDropdown } from "./FwSidebarTabsDropdown";
 import { FwSidebarTopAnchors } from "./FwSidebarTopAnchors";
 import { FwWebEditorSidebarTop } from "./FwWebEditorSidebarTop";
 import { FwSidebarMobileHeaderItems } from "./FwSidebarMobileHeaderItems";
+import { FwSidebarFilter } from "./FwSidebarFilter";
+import { FwSidebarComponent } from "./FwSidebarComponent";
+import type { FwSidebarItemElementProps, FwSidebarItemProps } from "./FwSidebarItem";
 import { useSidebarTree } from "./FwSidebarTree";
 import { FwLogo } from "./FwLogo";
+
+/** Collect sidebar items marked `{ fixed: true, component }` — they render in the
+ *  pinned fixed region instead of inline in the scrollable tree. */
+function collectFixedComponents(groups: readonly FwSidebarItemProps[]): FwSidebarItemElementProps[] {
+    const out: FwSidebarItemElementProps[] = []
+    const walk = (items?: FwSidebarItemElementProps[]) => {
+        for (const it of items || []) {
+            if (it?.component && it?.fixed) out.push(it)
+            if (it?.items) walk(it.items)
+        }
+    }
+    for (const g of groups || []) walk((g as any)?.items)
+    return out
+}
 
 const Sidebar = withSidebar(UISidebar)
 
@@ -27,21 +45,58 @@ export function FwSidebar(props: FwSidebarProps) {
     // TODO: active state for footer items?
     const sidebarFooterAnchors = settings.navigation?.anchors?.sidebar?.bottom?.map(FwSidebarNavigationItem)
 
-    return <Sidebar
-        footerItems={sidebarFooterAnchors && sidebarFooterAnchors}
-        scrollShadow={appearance?.sidebar?.scrollShadow}
-        scrollTransition={appearance?.sidebar?.scrollTransition}
-    >
-        <Surface target={SurfaceTarget.SidebarTop} />
+    // Wrap the whole sidebar (surface + tree) in the filter provider so an opt-in
+    // "filter sidebar" input on the `sidebar.top` surface and the tree items share
+    // one query. Default query is "" → no filtering, so themes without a filter
+    // input are unaffected.
+    // The pinned region: a theme-defined `sidebar.fixed` surface + the built-in
+    // filter (opt-in via components.filterSidebar) + sidebar items marked
+    // `{ fixed: true }`. When all are empty the region collapses via
+    // `[part="fixed"]:empty` (Sidebar.styles).
+    const filter = settings.components?.filterSidebar
+    const filterCfg = filter && typeof filter === "object" ? filter : undefined
+    // Route-scoping: when `routes` is set, the filter renders only on pages whose
+    // slug starts with a listed prefix.
+    const matches = useMatches()
+    const slug = (matches[matches.length - 1]?.pathname || "").replace(/^\/+/, "")
+    const filterRoutes = filterCfg?.routes
+    const filterInRoute = !filterRoutes?.length
+        || filterRoutes.some((r) => slug.startsWith(String(r).replace(/^\/+/, "")))
+    const showFilter = !!filter && filterInRoute
+    const fixedComponents = collectFixedComponents(useSidebarGroups())
+    const fixedTop = <>
+        <Surface target={SurfaceTarget.SidebarFixed} />
+        {showFilter && <FwSidebarFilter placeholder={filterCfg?.placeholder} />}
+        {/* A sidebarDropdown segment with `options.fixed` pins its section
+            switcher here, below the filter (the in-list instance skips it). */}
+        <FwSidebarTabsDropdown fixed />
+        {fixedComponents.map((it, i) => <FwSidebarComponent
+            key={`fixed-${i}-${it.component}`}
+            component={it.component as string}
+            props={it.componentProps}
+        />)}
+    </>
 
-        <FwSidebarTopAnchors />
+    return <SidebarFilterProvider>
+        <Sidebar
+            footerItems={sidebarFooterAnchors && sidebarFooterAnchors}
+            fixedTop={fixedTop}
+            scrollShadow={appearance?.sidebar?.scrollShadow}
+            scrollTransition={appearance?.sidebar?.scrollTransition}
+            groupCase={appearance?.sidebar?.groupCase}
+            scroll={appearance?.sidebar?.scroll}
+        >
+            <Surface target={SurfaceTarget.SidebarTop} />
 
-        <FwWebEditorSidebarTop />
+            <FwSidebarTopAnchors />
 
-        <FwSidebarMobileHeaderItems />
+            <FwWebEditorSidebarTop />
 
-        <FwSidebarTabsDropdown />
-    </Sidebar>
+            <FwSidebarMobileHeaderItems />
+
+            <FwSidebarTabsDropdown />
+        </Sidebar>
+    </SidebarFilterProvider>
 }
 
 

--- a/packages/xyd-framework/packages/react/components/FwSidebarComponent.tsx
+++ b/packages/xyd-framework/packages/react/components/FwSidebarComponent.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import { useComponents } from "../contexts";
+
+/**
+ * Renders a custom sidebar-item component referenced by path in `docs.json`
+ * (`{ component: "./path", props? }`). The path is resolved through the
+ * user-components registry (keyed by the path string; `appInit` bundles the file
+ * via `virtual:xyd-user-components`). Rendered inside the framework context, so
+ * the component may use `@xyd-js/framework/react` hooks.
+ */
+export function FwSidebarComponent({ component, props }: { component: string; props?: Record<string, any> }) {
+    const components = useComponents() as Record<string, React.ComponentType<any>> | undefined;
+    const Comp = components?.[component];
+
+    if (!Comp) {
+        if (typeof console !== "undefined") {
+            console.warn(`[xyd] sidebar component not found: "${component}"`);
+        }
+        return null;
+    }
+
+    return <Comp {...(props || {})} />;
+}

--- a/packages/xyd-framework/packages/react/components/FwSidebarFilter.tsx
+++ b/packages/xyd-framework/packages/react/components/FwSidebarFilter.tsx
@@ -1,0 +1,79 @@
+import React from "react";
+
+import { useSidebarFilter } from "../contexts";
+
+// Inline base styles (the framework build does not run the Linaria transform, so
+// no `css` tag here). Themes refine via `[part="sidebar-filter-input"]` /
+// `[part="sidebar-filter-icon"]`.
+const wrapperStyle: React.CSSProperties = {
+    position: "relative",
+    display: "flex",
+    alignItems: "center",
+};
+
+const iconStyle: React.CSSProperties = {
+    position: "absolute",
+    left: "10px",
+    top: "50%",
+    transform: "translateY(-50%)",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    color: "var(--xyd-sidebar-item-color, var(--color-text))",
+    pointerEvents: "none",
+};
+
+const inputStyle: React.CSSProperties = {
+    width: "100%",
+    boxSizing: "border-box",
+    // extra left padding leaves room for the leading filter icon (10px gutter +
+    // 16px icon + 6px gap)
+    padding: "8px 10px 8px 32px",
+    fontSize: "var(--xyd-font-size-small, 14px)",
+    color: "var(--color-text)",
+    background: "var(--color-bg)",
+    border: "1px solid var(--xyd-sidebar-filter-border-color, var(--xyd-sidebar-divider-color))",
+    borderRadius: "var(--xyd-border-radius-medium, 8px)",
+    outline: "none",
+};
+
+/**
+ * Built-in sidebar tree filter — an opt-in input (enabled via
+ * `components.filterSidebar`) that narrows the sidebar to matching items. Reads
+ * the `SidebarFilterContext` that `FwSidebar` provides; `FwSidebarItem` consults
+ * the same query to hide non-matching items + auto-expand groups.
+ */
+export function FwSidebarFilter({ placeholder }: { placeholder?: string }) {
+    const { query, setQuery } = useSidebarFilter();
+    const label = placeholder || "Filter sidebar";
+
+    return (
+        <div part="sidebar-filter">
+            <div part="sidebar-filter-field" style={wrapperStyle}>
+                <span part="sidebar-filter-icon" style={iconStyle}>
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="16"
+                        height="16"
+                        fill="none"
+                        viewBox="0 0 16 16"
+                        aria-hidden="true"
+                    >
+                        <g fill="currentColor">
+                            <path d="M1 3.75A.75.75 0 011.75 3h12.5a.75.75 0 010 1.5H1.75A.75.75 0 011 3.75zM3.5 7.75A.75.75 0 014.25 7h7.5a.75.75 0 010 1.5h-7.5a.75.75 0 01-.75-.75zM6.75 11a.75.75 0 000 1.5h2.5a.75.75 0 000-1.5h-2.5z" />
+                        </g>
+                    </svg>
+                </span>
+                <input
+                    part="sidebar-filter-input"
+                    type="text"
+                    style={inputStyle}
+                    placeholder={label}
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    aria-label={label}
+                />
+            </div>
+        </div>
+    );
+}

--- a/packages/xyd-framework/packages/react/components/FwSidebarItem.tsx
+++ b/packages/xyd-framework/packages/react/components/FwSidebarItem.tsx
@@ -6,7 +6,10 @@ import { UISidebar } from "@xyd-js/ui";
 
 
 import { Surface } from "./Surfaces";
+import { FwSidebarComponent } from "./FwSidebarComponent";
 import { FooSidebarItemProps, useFooSidebar, useSidebarActive } from "../lib";
+import { useSidebarFilter } from "../contexts";
+import { sidebarItemMatchesQuery } from "../utils";
 
 export interface FwSidebarItemProps {
     group: string
@@ -19,6 +22,15 @@ export interface FwSidebarItemProps {
 }
 
 export function FwSidebarItem(props: FwSidebarItemProps) {
+    const { query } = useSidebarFilter()
+    const q = query.trim().toLowerCase()
+
+    // Sidebar filter (opt-in): drop a whole group (header + items) when nothing
+    // in it matches. No-op when there is no query.
+    if (q && !props.items.some(item => sidebarItemMatchesQuery(item, q))) {
+        return null
+    }
+
     const icon = props.icon ? <Icon name={props.icon || ""} size={16} /> : null
 
     return <>
@@ -28,22 +40,36 @@ export function FwSidebarItem(props: FwSidebarItemProps) {
             </UISidebar.ItemHeader>
         }
 
-        {props.items.map((item, index) => <FwSidebarItem.Item
-            uniqIndex={item.uniqIndex}
-            group={item.group}
-            groupIndex={props.groupIndex}
-            level={0}
-            itemIndex={index}
-            key={index + item.href}
-            title={item.title}
-            sidebarTitle={item.sidebarTitle}
-            url={item.url}
-            pageMeta={item.pageMeta}
-            href={item.href}
-            items={item.items}
-            active={item.active}
-            icon={item.icon}
-        />)}
+        {props.items.map((item, index) => {
+            // A custom-component sidebar item (`{ component: "./path" }`). `fixed`
+            // ones are pinned in the fixed region (rendered by FwSidebar), so skip
+            // them here; non-fixed ones render inline in tree order.
+            if (item.component) {
+                if (item.fixed) return null
+                return <FwSidebarComponent
+                    key={`component-${index}-${item.component}`}
+                    component={item.component}
+                    props={item.componentProps}
+                />
+            }
+
+            return <FwSidebarItem.Item
+                uniqIndex={item.uniqIndex}
+                group={item.group}
+                groupIndex={props.groupIndex}
+                level={0}
+                itemIndex={index}
+                key={index + item.href}
+                title={item.title}
+                sidebarTitle={item.sidebarTitle}
+                url={item.url}
+                pageMeta={item.pageMeta}
+                href={item.href}
+                items={item.items}
+                active={item.active}
+                icon={item.icon}
+            />
+        })}
     </>
 }
 
@@ -65,6 +91,15 @@ export interface FwSidebarItemElementProps extends FooSidebarItemProps {
     url?: string
 
     pageMeta?: Metadata
+
+    /** Custom-component sidebar item: path resolved via the components registry. */
+    component?: string
+
+    /** Pin this item in the sidebar's fixed region (hoisted out of the tree). */
+    fixed?: boolean
+
+    /** Props passed to the custom `component`. */
+    componentProps?: Record<string, any>
 }
 
 // Whether an injected active href lives anywhere under these items (drives a
@@ -79,7 +114,10 @@ function containsHref(items: FwSidebarItemElementProps[] | undefined, href: stri
 FwSidebarItem.Item = function FwSidebarItem(props: FwSidebarItemElementProps) {
     const { active } = useFooSidebar()
     const { activeHref } = useSidebarActive()
+    const { query } = useSidebarFilter()
     const [isActive, setActive] = active(props)
+
+    const q = query.trim().toLowerCase()
 
     // Mount the subtree while open, AND briefly while it closes so UICollapse can
     // animate the collapse (it measures the children's height — if they've
@@ -97,6 +135,14 @@ FwSidebarItem.Item = function FwSidebarItem(props: FwSidebarItemElementProps) {
 
     const title = props.sidebarTitle || props.title || ""
     const nested = !!props.items?.length
+
+    // Sidebar filter (opt-in): hide items whose subtree has no title match, and
+    // force-expand a group that contains a match so the hit is visible. No-op
+    // when there is no query.
+    const forceExpand = !!q && nested && (props.items || []).some(item => sidebarItemMatchesQuery(item, q))
+    if (q && !sidebarItemMatchesQuery(props, q)) {
+        return null
+    }
 
     function handleClick() {
         if (!nested) {
@@ -181,8 +227,8 @@ FwSidebarItem.Item = function FwSidebarItem(props: FwSidebarItemElementProps) {
             </>
         }
         {
-            props.group !== false && props.items?.length && <UISidebar.SubTree isOpen={isActive}>
-                {renderChildren && <>
+            props.group !== false && props.items?.length && <UISidebar.SubTree isOpen={isActive || forceExpand}>
+                {(renderChildren || forceExpand) && <>
                     {
                         props.items?.map((item, index) => <FwSidebarItem
                             uniqIndex={item.uniqIndex}

--- a/packages/xyd-framework/packages/react/components/FwSidebarTabsDropdown.tsx
+++ b/packages/xyd-framework/packages/react/components/FwSidebarTabsDropdown.tsx
@@ -7,9 +7,19 @@ import { SidebarTabsDropdown, UISidebar } from "@xyd-js/ui"
 
 import { useActivePage, useActiveSegment, useMatchedSegmentSidebarDropdown } from "../hooks"
 import { NavigationItem } from "@xyd-js/core"
-import { pageLink } from "../utils"
+import { pageLink, segmentAppearanceOptions } from "../utils"
 
-export function FwSidebarTabsDropdown() {
+/**
+ * The sidebar section switcher: the global `navigation.sidebarDropdown` plus the
+ * matched `appearance: "sidebarDropdown"` segment.
+ *
+ * `fixed` selects the render SITE. A segment declaring
+ * `appearance: { kind: "sidebarDropdown", options: { fixed: true } }` renders in
+ * the sidebar's FIXED (pinned) region — FwSidebar mounts one instance there with
+ * `fixed`, and one at the top of the scrollable list without it; each instance
+ * shows only the content that belongs to its site.
+ */
+export function FwSidebarTabsDropdown({ fixed = false }: { fixed?: boolean } = {}) {
     const settings = useSettings()
 
     const activeSegment = useActiveSegment()
@@ -17,9 +27,20 @@ export function FwSidebarTabsDropdown() {
 
     const activePage = useActivePage(true)
 
-    const sidebarDropdown = settings.navigation?.sidebarDropdown || []
+    // The global config has no `fixed` concept → always the in-list site.
+    const sidebarDropdown = fixed ? [] : (settings.navigation?.sidebarDropdown || [])
+    const segmentIsFixed = !!segmentAppearanceOptions<{ fixed?: boolean }>(matchedSegmentSidebarDropdown).fixed
+    const segmentDropdownPages = (matchedSegmentSidebarDropdown && segmentIsFixed === fixed)
+        ? (matchedSegmentSidebarDropdown.pages || [])
+        : []
 
-    return <UISidebar.ItemGroup>
+    // Nothing to show → render nothing (an empty `[part="item-group"]` would still
+    // add its top margin + separator space at the top of the sidebar).
+    if (!sidebarDropdown.length && !segmentDropdownPages.length) {
+        return null
+    }
+
+    const content = <>
         <$NavigationItemsSidebarTabs
             active={activePage || ""}
             items={sidebarDropdown || []}
@@ -27,9 +48,17 @@ export function FwSidebarTabsDropdown() {
 
         <$NavigationItemsSidebarTabs
             active={activeSegment || ""}
-            items={matchedSegmentSidebarDropdown?.pages || []}
+            items={segmentDropdownPages}
         />
-    </UISidebar.ItemGroup>
+    </>
+
+    // In the fixed (pinned) container there's no surrounding item list, so the
+    // `[part="item-group"]` list chrome (top margin, separator) is skipped.
+    if (fixed) {
+        return content
+    }
+
+    return <UISidebar.ItemGroup>{content}</UISidebar.ItemGroup>
 }
 
 function $NavigationItemsSidebarTabs({ items, active }: { items: NavigationItem[], active?: string }) {

--- a/packages/xyd-framework/packages/react/components/FwSidebarTree.tsx
+++ b/packages/xyd-framework/packages/react/components/FwSidebarTree.tsx
@@ -22,7 +22,10 @@ export function useSidebarTree(): [React.ReactElement[], { initialActiveItems: a
     const sidebarTree = React.useMemo(
         () =>
             groups?.map((group, index) => <FwSidebarItem
-                key={index + group.group}
+                // `index + group.group` is NaN for a groupless group (flat items,
+                // pageless component wrap) → key collisions. Index is stable +
+                // unique here (groups don't reorder).
+                key={`group-${index}-${group.group ?? ""}`}
                 {...group}
                 groupIndex={index}
             />) || [],

--- a/packages/xyd-framework/packages/react/components/FwSubNav.tsx
+++ b/packages/xyd-framework/packages/react/components/FwSubNav.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { SubNav } from "@xyd-js/ui";
 
-import { pageLink } from "../utils";
+import { pageLink, dropdownMenuItems } from "../utils";
 import { useActiveMatchedSubNav, useMatchedSubNav } from "../hooks";
 import { FwLink } from "./FwLink";
 import { FwNavDropdown } from "./FwNavDropdown";
@@ -23,7 +23,7 @@ export function FwSubNav() {
     >
         {matchedSubnav?.pages?.map((item, index) => {
             // A tab that declares a nested menu renders as a multi-level dropdown.
-            if (item.dropdownMenu?.length) {
+            if (dropdownMenuItems(item.dropdownMenu).length) {
                 return <FwNavDropdown
                     key={item.title || item.page || item.href || index}
                     item={item}

--- a/packages/xyd-framework/packages/react/components/index.ts
+++ b/packages/xyd-framework/packages/react/components/index.ts
@@ -21,6 +21,10 @@ export {FwSidebar} from "./FwSidebar";
 
 export {FwSegmentLogoTrailing} from "./FwSegmentLogoTrailing";
 
+export {FwSegmentTabs} from "./FwSegmentTabs";
+
+export {FwSidebarFilter} from "./FwSidebarFilter";
+
 export {FwSubNav} from "./FwSubNav";
 
 export {FwToc} from "./FwToc";

--- a/packages/xyd-framework/packages/react/contexts/SidebarFilterContext.tsx
+++ b/packages/xyd-framework/packages/react/contexts/SidebarFilterContext.tsx
@@ -1,0 +1,35 @@
+import React, { createContext, useContext, useMemo, useState } from "react";
+
+/**
+ * A tiny opt-in filter layer for the sidebar tree. A theme mounts
+ * {@link SidebarFilterProvider} around `<FwSidebar/>` and renders an input bound
+ * to `setQuery` (e.g. terrarium's "Filter sidebar"); `FwSidebarItem` consults
+ * `query` to hide non-matching items and auto-expand groups that contain a match.
+ *
+ * Default context = empty query, so themes that never mount the provider render
+ * the full sidebar unchanged (no behavior change).
+ */
+export interface SidebarFilterValue {
+    query: string;
+    setQuery: (query: string) => void;
+}
+
+const SidebarFilterContext = createContext<SidebarFilterValue>({
+    query: "",
+    setQuery: () => { },
+});
+
+export function SidebarFilterProvider({ children }: { children: React.ReactNode }) {
+    const [query, setQuery] = useState("");
+    const value = useMemo(() => ({ query, setQuery }), [query]);
+
+    return (
+        <SidebarFilterContext.Provider value={value}>
+            {children}
+        </SidebarFilterContext.Provider>
+    );
+}
+
+export function useSidebarFilter(): SidebarFilterValue {
+    return useContext(SidebarFilterContext);
+}

--- a/packages/xyd-framework/packages/react/contexts/index.ts
+++ b/packages/xyd-framework/packages/react/contexts/index.ts
@@ -1,2 +1,3 @@
 export * from "./framework"
+export * from "./SidebarFilterContext"
 

--- a/packages/xyd-framework/packages/react/hooks/index.ts
+++ b/packages/xyd-framework/packages/react/hooks/index.ts
@@ -43,8 +43,16 @@ export {
 } from "./useLogoTrailingSegment";
 
 export {
+    useActiveLogoTrailingItem
+} from "./useActiveLogoTrailingItem";
+
+export {
     useMatchedSubNav,
 } from "./useMatchedSubNav";
+
+export {
+    useMatchedSegmentTabs
+} from "./useMatchedSegmentTabs";
 
 export {
     useTabSegments

--- a/packages/xyd-framework/packages/react/hooks/useActiveLogoTrailingItem.ts
+++ b/packages/xyd-framework/packages/react/hooks/useActiveLogoTrailingItem.ts
@@ -1,0 +1,27 @@
+import { NavigationItem } from "@xyd-js/core";
+import { useLocation } from "react-router";
+
+import { resolveActiveLogoTrailingItem } from "../utils";
+
+import { useLogoTrailingSegment } from "./useLogoTrailingSegment";
+
+/**
+ * The active product of the (global) `logoTrailing` segment — whichever page's
+ * route prefixes the current path (`findLast`, so the deepest/last match wins on
+ * overlapping prefixes). Returns `null` when there is no logoTrailing segment or
+ * no product is active (e.g. the landing page).
+ *
+ * Shared by {@link FwSegmentLogoTrailing} (the switcher trigger) and
+ * accent-aware themes (which read the active item's `color` to recolor the UI
+ * per product). Delegates to the pure {@link resolveActiveLogoTrailingItem}.
+ */
+export function useActiveLogoTrailingItem(): NavigationItem | null {
+    const segment = useLogoTrailingSegment()
+    const location = useLocation()
+
+    if (!segment) {
+        return null
+    }
+
+    return resolveActiveLogoTrailingItem(segment, location.pathname)
+}

--- a/packages/xyd-framework/packages/react/hooks/useActivePage.ts
+++ b/packages/xyd-framework/packages/react/hooks/useActivePage.ts
@@ -25,7 +25,7 @@ export function useActivePage(match: boolean = false) {
         }
 
         if (matchedSubnav) {
-            const routeMatch = pageLink(item.page || "") === pageLink(matchedSubnav?.route)
+            const routeMatch = pageLink(item.page || "") === pageLink(matchedSubnav?.route || "")
 
             if (routeMatch) {
                 return routeMatch

--- a/packages/xyd-framework/packages/react/hooks/useActivePageRoute.ts
+++ b/packages/xyd-framework/packages/react/hooks/useActivePageRoute.ts
@@ -18,7 +18,7 @@ export function useActivePageRoute(match: boolean = false) {
     
     let active = sidebarRoutes?.find?.(item => {
         if (matchedSubnav) {
-            const routeMatch = pageLink(item.route || "") === pageLink(matchedSubnav?.route)
+            const routeMatch = pageLink(item.route || "") === pageLink(matchedSubnav?.route || "")
 
             if (routeMatch) {
                 return routeMatch

--- a/packages/xyd-framework/packages/react/hooks/useLogoTrailingSegment.ts
+++ b/packages/xyd-framework/packages/react/hooks/useLogoTrailingSegment.ts
@@ -1,6 +1,7 @@
 import { Segment } from "@xyd-js/core";
 
 import { useSettings } from "../contexts";
+import { segmentAppearanceKind } from "../utils";
 
 /**
  * The (first) segment declaring `appearance: "logoTrailing"`.
@@ -15,6 +16,6 @@ export function useLogoTrailingSegment(): Segment | null {
     const settings = useSettings()
 
     return settings.navigation?.segments?.find(
-        segment => segment.appearance === "logoTrailing"
+        segment => segmentAppearanceKind(segment) === "logoTrailing"
     ) || null
 }

--- a/packages/xyd-framework/packages/react/hooks/useMatchedSegment.ts
+++ b/packages/xyd-framework/packages/react/hooks/useMatchedSegment.ts
@@ -10,18 +10,26 @@ export function useMatchedSegment(): Segment | null {
     const matches = useMatches()
 
     const lastMatchId = matches[matches.length - 1]?.id
+    const segments = settings.navigation?.segments
 
-    const matchedSegment = settings.navigation?.segments
-        ?.find?.(item => {
-            if (matches?.find(m => sanitizeUrl(m.id) === sanitizeUrl(item.route))) {
-                return true
-            }
-
-            return item.pages?.find?.(page => {
-                return sanitizeUrl(page.page || "") === sanitizeUrl(lastMatchId)
-            })
+    // A ROUTE-SCOPED segment (route is a string) matches when a router match id
+    // equals its route, or one of its pages' `page` equals the current match id.
+    let matchedSegment = segments?.find?.(item => {
+        if (typeof item.route !== "string") {
+            return false
+        }
+        if (matches?.find(m => sanitizeUrl(m.id) === sanitizeUrl(item.route as string))) {
+            return true
+        }
+        return item.pages?.find?.(page => {
+            return sanitizeUrl(page.page || "") === sanitizeUrl(lastMatchId || "")
         })
+    })
 
+    // Otherwise fall back to a GLOBAL segment (no `route` / `route: false`).
+    if (!matchedSegment) {
+        matchedSegment = segments?.find?.(item => item.route == null || item.route === false)
+    }
 
     return matchedSegment || null
 }

--- a/packages/xyd-framework/packages/react/hooks/useMatchedSegmentSidebarDropdown.ts
+++ b/packages/xyd-framework/packages/react/hooks/useMatchedSegmentSidebarDropdown.ts
@@ -1,18 +1,33 @@
 import { Segment } from "@xyd-js/core";
+import { useLocation } from "react-router";
 
-import { useMatchedSegment } from "./useMatchedSegment";
+import { useSettings } from "../contexts";
+import { pageLink, trailingSlash, segmentAppearanceKind } from "../utils";
 
-// TODO: better data structures
+/**
+ * The `appearance: "sidebarDropdown"` segment scoped to the current route — a
+ * section switcher rendered at the top of the sidebar (e.g. flip between
+ * "Intro to Terraform", "Terraform CLI", … from the left sidebar). Matched DIRECTLY
+ * by appearance + route PREFIX (not via {@link useMatchedSegment}) so it coexists
+ * with a `tabs` segment on the same `route`.
+ *
+ * A switcher only makes sense INSIDE one of its member sections — so when the
+ * segment's pages declare `page` route-prefixes, the current path must be under
+ * one of them (e.g. the Documentation switcher shows on `terraform/language/**`
+ * but NOT on `terraform/install/**`, even though both share the `terraform`
+ * route). `findLast` → the deepest matching route wins; a segment with no
+ * `route` is global. Returns `null` when none matches.
+ */
 export function useMatchedSegmentSidebarDropdown(): Segment | null {
-    const matchedSegment = useMatchedSegment()
-    if (!matchedSegment) {
-        return null
-    }
+    const settings = useSettings()
+    const pathname = trailingSlash(useLocation().pathname)
 
-    if (matchedSegment.appearance === "sidebarDropdown") {
-        return matchedSegment
-    }
+    return settings.navigation?.segments?.findLast?.(seg => {
+        if (segmentAppearanceKind(seg) !== "sidebarDropdown") return false
+        if (typeof seg.route === "string" && !pathname.startsWith(pageLink(seg.route))) return false
 
-    return null
+        const sectionPrefixes = (seg.pages || []).filter(p => typeof p.page === "string")
+        if (!sectionPrefixes.length) return true
+        return sectionPrefixes.some(p => pathname.startsWith(pageLink(p.page as string)))
+    }) || null
 }
-

--- a/packages/xyd-framework/packages/react/hooks/useMatchedSegmentTabs.ts
+++ b/packages/xyd-framework/packages/react/hooks/useMatchedSegmentTabs.ts
@@ -1,0 +1,26 @@
+import { Segment } from "@xyd-js/core";
+import { useLocation } from "react-router";
+
+import { useSettings } from "../contexts";
+import { pageLink, trailingSlash, segmentAppearanceKind } from "../utils";
+
+/**
+ * The `appearance: "tabs"` segment whose `route` prefixes the current path — a
+ * PER-PRODUCT tab bar. Unlike {@link useMatchedSegment} (exact match-id / page
+ * equality), this matches by route PREFIX so the tabs stay visible across every
+ * page of the product section (e.g. all of `/nomad/**`). `findLast` so the
+ * deepest/last matching route wins on overlapping prefixes. Returns `null` when
+ * no tabs segment is scoped to the current route.
+ */
+export function useMatchedSegmentTabs(): Segment | null {
+    const settings = useSettings()
+    const location = useLocation()
+
+    const pathname = trailingSlash(location.pathname)
+
+    return settings.navigation?.segments?.findLast?.(seg =>
+        segmentAppearanceKind(seg) === "tabs" &&
+        typeof seg.route === "string" &&
+        pathname.startsWith(pageLink(seg.route))
+    ) || null
+}

--- a/packages/xyd-framework/packages/react/hooks/useMatchedSubNav.ts
+++ b/packages/xyd-framework/packages/react/hooks/useMatchedSubNav.ts
@@ -1,14 +1,24 @@
 import { Segment } from "@xyd-js/core";
 
 import { useMatchedSegment } from "./useMatchedSegment";
+import { useMatchedSegmentTabs } from "./useMatchedSegmentTabs";
 import { useTabSegments } from "./useTabSegments";
 import { useAppearance } from "../contexts";
 
 // TODO: better data structures
 export function useMatchedSubNav(): Segment | null {
+    const tabsSegment = useMatchedSegmentTabs()
     const matchedSegment = useMatchedSegment()
     const tabSegments = useTabSegments()
     const appearance = useAppearance()
+
+    // A route-scoped `appearance: "tabs"` segment (per-product) owns the subnav
+    // slot — its `pages` render as the tab bar, replacing any global `tabs`.
+    // EXCEPT when `appearance.tabs.surface === "center"`: then the tabs render in
+    // the primary-nav center (FwNav) instead of the subnav.
+    if (tabsSegment && appearance?.tabs?.surface !== "center") {
+        return tabsSegment
+    }
 
     if (
         (

--- a/packages/xyd-framework/packages/react/index.ts
+++ b/packages/xyd-framework/packages/react/index.ts
@@ -10,6 +10,7 @@ export {
 } from "./components/Surfaces"
 
 export type { FrameworkProps, IFrameworkI18n } from "./contexts"
+export type { SidebarFilterValue } from "./contexts"
 export {
     Framework, FrameworkPage,
     useMetadata,
@@ -24,6 +25,8 @@ export {
     useDefaultLocale,
     useAvailableLocales,
     useT,
+    SidebarFilterProvider,
+    useSidebarFilter,
 } from "./contexts"
 
 export {
@@ -31,9 +34,15 @@ export {
     useActiveRoute,
     useActivePageRoute,
     useActivePage,
+    useLogoTrailingSegment,
+    useActiveLogoTrailingItem,
 } from "./hooks"
 
 export {
     SidebarActiveProvider,
     useSidebarActive,
 } from "./lib"
+
+export {
+    resolveDropdownHref,
+} from "./utils"

--- a/packages/xyd-framework/packages/react/utils/index.ts
+++ b/packages/xyd-framework/packages/react/utils/index.ts
@@ -13,14 +13,27 @@ export {
 export {
     resolveDropdownItems,
     resolveDropdownHref,
+    dropdownMenuItems,
+    dropdownMenuOptions,
 } from "./navDropdown"
 export type { ResolvedDropdownItem } from "./navDropdown"
 
 export {
     resolveLogoTrailingSwitcher,
+    resolveActiveLogoTrailingItem,
 } from "./segmentLogoTrailing"
 export type { LogoTrailingItem, LogoTrailingSwitcher } from "./segmentLogoTrailing"
 
 export {
     displayBreadcrumbs,
 } from "./breadcrumbs"
+
+export {
+    sidebarItemMatchesQuery,
+} from "./sidebarFilter"
+export type { FilterableSidebarItem } from "./sidebarFilter"
+
+export {
+    segmentAppearanceKind,
+    segmentAppearanceOptions,
+} from "./segmentAppearance"

--- a/packages/xyd-framework/packages/react/utils/navDropdown.ts
+++ b/packages/xyd-framework/packages/react/utils/navDropdown.ts
@@ -1,6 +1,23 @@
-import type { NavigationItem } from "@xyd-js/core";
+import type { NavigationItem, DropdownMenu } from "@xyd-js/core";
 
 import { pageLink } from "./pageLink";
+
+/**
+ * `dropdownMenu` accepts a plain item array or the object form
+ * `{ items, itemsPerColumn }`. These helpers normalize both so every reader
+ * gets the items (and menu-level options) uniformly.
+ */
+export function dropdownMenuItems(menu?: NavigationItem[] | DropdownMenu): NavigationItem[] {
+    if (!menu) return [];
+    return Array.isArray(menu) ? menu : (menu.items || []);
+}
+
+/** Menu-level options of the object form; `{}` for the array form / none. */
+export function dropdownMenuOptions(menu?: NavigationItem[] | DropdownMenu): Omit<DropdownMenu, "items"> {
+    if (!menu || Array.isArray(menu)) return {};
+    const { items: _items, ...options } = menu;
+    return options;
+}
 
 /**
  * A nav item resolved for rendering in a dropdown menu — its link target is
@@ -32,6 +49,8 @@ export function resolveDropdownItems(items: NavigationItem[]): ResolvedDropdownI
         href: resolveDropdownHref(item),
         value: item.page || item.href || item.title,
         icon: item.icon,
-        items: item.dropdownMenu?.length ? resolveDropdownItems(item.dropdownMenu) : undefined,
+        items: dropdownMenuItems(item.dropdownMenu).length
+            ? resolveDropdownItems(dropdownMenuItems(item.dropdownMenu))
+            : undefined,
     }));
 }

--- a/packages/xyd-framework/packages/react/utils/segmentAppearance.ts
+++ b/packages/xyd-framework/packages/react/utils/segmentAppearance.ts
@@ -1,0 +1,24 @@
+import type { Segment, SegmentAppearance } from "@xyd-js/core";
+
+/**
+ * `Segment.appearance` accepts a string (`"sidebarDropdown"`) or an object
+ * (`{ kind: "sidebarDropdown", options: { fixed: true } }`). These helpers
+ * normalize both forms so every appearance reader compares kinds (and reads
+ * kind-specific options) uniformly.
+ */
+export function segmentAppearanceKind(segment?: Segment | null): SegmentAppearance | undefined {
+    const a = segment?.appearance
+    if (!a) return undefined
+    return typeof a === "string" ? a : a.kind
+}
+
+/** Kind-specific options of the object form; `{}` for the string form / none. */
+export function segmentAppearanceOptions<T extends Record<string, any> = Record<string, any>>(
+    segment?: Segment | null,
+): T {
+    const a = segment?.appearance
+    if (a && typeof a === "object") {
+        return (((a as any).options) || {}) as T
+    }
+    return {} as T
+}

--- a/packages/xyd-framework/packages/react/utils/segmentLogoTrailing.ts
+++ b/packages/xyd-framework/packages/react/utils/segmentLogoTrailing.ts
@@ -1,6 +1,22 @@
-import type { Segment } from "@xyd-js/core";
+import type { Segment, NavigationItem } from "@xyd-js/core";
 
-import { resolveDropdownHref, resolveDropdownItems, type ResolvedDropdownItem } from "./navDropdown";
+import { resolveDropdownHref, resolveDropdownItems, dropdownMenuItems, type ResolvedDropdownItem } from "./navDropdown";
+import { pageLink } from "./pageLink";
+import { trailingSlash } from "./trailingSlash";
+
+/**
+ * Pure: the active product of a `logoTrailing` segment for a given pathname —
+ * whichever page's route prefixes the path, `findLast` so the deepest/last match
+ * wins on overlapping prefixes. Returns `null` when none is active. Extracted so
+ * both {@link useActiveLogoTrailingItem} and unit tests share one source of truth.
+ */
+export function resolveActiveLogoTrailingItem(segment: Segment, pathname: string): NavigationItem | null {
+    const normalized = trailingSlash(pathname);
+
+    return segment.pages?.findLast(
+        page => !!page.page && normalized.startsWith(pageLink(page.page))
+    ) || null;
+}
 
 /** A logoTrailing switch target — a resolved dropdown item plus whether it is the
  *  currently-active page (→ rendered with a check by the switcher). */
@@ -32,7 +48,7 @@ export function resolveLogoTrailingSwitcher(segment: Segment, activePage: string
         value: page.page || page.href || page.title,
         icon: page.icon,
         active: isActive(page.page),
-        items: page.dropdownMenu?.length ? resolveDropdownItems(page.dropdownMenu) : undefined,
+        items: dropdownMenuItems(page.dropdownMenu).length ? resolveDropdownItems(dropdownMenuItems(page.dropdownMenu)) : undefined,
     }));
 
     const activeItem = pages.find((page) => isActive(page.page));

--- a/packages/xyd-framework/packages/react/utils/sidebarFilter.ts
+++ b/packages/xyd-framework/packages/react/utils/sidebarFilter.ts
@@ -1,0 +1,19 @@
+/** Minimal shape the sidebar-filter predicate needs (a title + optional children). */
+export interface FilterableSidebarItem {
+    title?: string;
+    sidebarTitle?: string;
+    items?: FilterableSidebarItem[];
+}
+
+/**
+ * Whether an item's own title, or any descendant's, contains the (lowercased)
+ * sidebar-filter query. Empty query → always `true` (filter inactive), so a
+ * theme without a filter input renders the full tree unchanged. Pure, so the
+ * hide/keep decision is unit-testable without the React tree.
+ */
+export function sidebarItemMatchesQuery(item: FilterableSidebarItem, query: string): boolean {
+    if (!query) return true;
+    const title = (item.sidebarTitle || item.title || "").toLowerCase();
+    if (title.includes(query)) return true;
+    return (item.items || []).some(child => sidebarItemMatchesQuery(child, query));
+}

--- a/packages/xyd-framework/src/surfaces.ts
+++ b/packages/xyd-framework/src/surfaces.ts
@@ -5,6 +5,12 @@ export enum SurfaceTarget {
 
     SidebarTop = "sidebar.top",
 
+    // Rendered in the sidebar's FIXED (pinned) region — a sibling ABOVE the
+    // scrollable item list, so its content stays visible while the list scrolls.
+    // Holds the built-in filter (components.filterSidebar), theme chrome, and
+    // sidebar pages marked `{ fixed: true }`.
+    SidebarFixed = "sidebar.fixed",
+
     PageFooterBottom = "page.footer.bottom",
 
     SidebarItemLeft = "sidebar.item.left",

--- a/packages/xyd-theme-terrarium/CHANGELOG.md
+++ b/packages/xyd-theme-terrarium/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @xyd-js/theme-terrarium

--- a/packages/xyd-theme-terrarium/README.md
+++ b/packages/xyd-theme-terrarium/README.md
@@ -1,0 +1,24 @@
+# @xyd-js/theme-terrarium
+
+A full-width, high-contrast documentation theme for [xyd](https://xyd.dev), inspired by the
+HashiCorp Developer docs.
+
+## Traits
+
+- **Full-width** layout — no centered max-width container.
+- **~800px content**, pinned close to the **left** (the "paging sizes" small width token).
+- **Decoupled TOC** pushed to the far right.
+- **Taller nav** (64px) and a **high-contrast** blacks/darks palette.
+- **Green accent** by default (`#00ca8e`), overridable via `theme.appearance.colors.primary`.
+- **Per-product accent** — when a `logoTrailing` product switcher declares a `color`, the whole
+  accent recolors per product (Nomad → green, Consul → pink, Vault → yellow …).
+- **HashiCorp-style sidebar chrome** — a `‹ {Product} Home` back-link, a colored product-icon
+  header, and a "Filter sidebar" input.
+
+## Usage
+
+```json
+{
+  "theme": { "name": "terrarium" }
+}
+```

--- a/packages/xyd-theme-terrarium/package.json
+++ b/packages/xyd-theme-terrarium/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@xyd-js/theme-terrarium",
+  "version": "0.1.0-build.0",
+  "description": "Terrarium theme — full-width, high-contrast docs with a per-product accent (HashiCorp-style).",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    "./index.css": "./dist/index.css",
+    ".": {
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "clean": "rimraf build",
+    "build": "rollup -c rollup.config.js"
+  },
+  "dependencies": {
+    "@linaria/core": "^6.2.0"
+  },
+  "peerDependencies": {
+    "@xyd-js/atlas": "workspace:*",
+    "@xyd-js/ui": "workspace:*",
+    "@xyd-js/components": "workspace:*",
+    "@xyd-js/framework": "workspace:*",
+    "@xyd-js/themes": "workspace:*",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
+    "react-router": "^7.15.0"
+  },
+  "devDependencies": {
+    "@babel/preset-env": "^7.26.0",
+    "@babel/preset-flow": "^7.25.9",
+    "@babel/preset-react": "^7.26.0",
+    "@babel/preset-typescript": "^7.26.0",
+    "@rollup/plugin-alias": "^5.1.1",
+    "@rollup/plugin-babel": "^6.0.4",
+    "@rollup/plugin-commonjs": "^28.0.1",
+    "@rollup/plugin-node-resolve": "^15.3.0",
+    "@rollup/plugin-typescript": "^12.1.1",
+    "@wyw-in-js/rollup": "^0.5.5",
+    "@wyw-in-js/vite": "^0.5.5",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.47",
+    "postcss-import": "^16.1.0",
+    "rimraf": "^3.0.2",
+    "rollup": "^4.27.4",
+    "rollup-plugin-css-only": "^4.5.2",
+    "rollup-plugin-dts": "^6.1.1",
+    "rollup-plugin-postcss": "^4.0.2",
+    "rollup-plugin-terser": "^7.0.2",
+    "tsup": "^8.3.0"
+  }
+}

--- a/packages/xyd-theme-terrarium/rollup.config.js
+++ b/packages/xyd-theme-terrarium/rollup.config.js
@@ -1,0 +1,3 @@
+import themeRollup from '@xyd-js/themes/rollup';
+
+export default themeRollup(import.meta.url)

--- a/packages/xyd-theme-terrarium/src/imports.css
+++ b/packages/xyd-theme-terrarium/src/imports.css
@@ -1,0 +1,1 @@
+/* system font stack — no external font dependency */

--- a/packages/xyd-theme-terrarium/src/index.css
+++ b/packages/xyd-theme-terrarium/src/index.css
@@ -1,0 +1,6 @@
+@layer themes {
+    :root {
+        --font-body-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+        --font-body-weight: 400;
+    }
+}

--- a/packages/xyd-theme-terrarium/src/index.ts
+++ b/packages/xyd-theme-terrarium/src/index.ts
@@ -1,0 +1,1 @@
+export {default} from "./theme"

--- a/packages/xyd-theme-terrarium/src/override.css
+++ b/packages/xyd-theme-terrarium/src/override.css
@@ -1,0 +1,353 @@
+/* Fixed, independently-scrolling left sidebar (sticky, full-height under the
+   nav) — the sticky approach keeps [part="page"] in the flex row, so terrarium's
+   full-width + left-content + decoupled-TOC layout is untouched. */
+@import "@xyd-js/themes/dist/decorators/sidebar-pad.css";
+
+@layer themes {
+    /* Full-width docs: kill the centered max-width container, pin ~800px content
+       to the LEFT (close to the sidebar), and decouple the TOC to the far right. */
+    xyd-layout-primary:not([data-layout="wide"]) {
+        [part="page-container"] {
+            max-width: 100%;
+        }
+
+        [part="page-scroll"] {
+            padding: 0 48px;
+        }
+
+        [part="page-article-container"] {
+            gap: 0;
+            padding: 32px 0;
+        }
+
+        [part="page-article"] {
+            flex: 0 1 var(--xyd-layout-width-small);
+            max-width: var(--xyd-layout-width-small);
+            /* auto margin absorbs the remaining width → content left, TOC far right.
+               More robust than justify-content: content stays left even when the
+               TOC is absent (short pages / wide|page|reader layouts). */
+            margin-right: auto;
+        }
+
+        [part="page-article-nav"] {
+            flex: none;
+        }
+    }
+
+    /* High-contrast frame between sidebar and content */
+    [part="sidebar"] {
+        border-right: 1px solid var(--terrarium-border);
+    }
+
+    xyd-sidebar [part="item-header"] {
+        font-size: 13px;
+        font-weight: var(--xyd-font-weight-semibold);
+    }
+
+    /* built-in filter input focus/placeholder (the base border is the token above) */
+    [part="sidebar-filter-input"]:focus {
+        border-color: var(--color-primary) !important;
+    }
+    [part="sidebar-filter-input"]::placeholder {
+        color: var(--terrarium-gray);
+    }
+
+    /* Divider BETWEEN groups: a rule above every group header that follows a
+       previous group's items (a `[part="item"]`). The first group header follows
+       the sidebar-top separator (`[part="item-group"]`), so it gets no rule — and
+       a sidebar with only one group shows no divider at all. */
+    xyd-sidebar [part="item"] + [part="item-header"] {
+        border-top: 1px solid var(--terrarium-border);
+        padding-top: 20px;
+    }
+
+    /* The sticky nav is OPAQUE (with the wrapped multi-row mobile header the
+       base transparent host let content show through) and carries the header's
+       bottom border ITSELF — on the parent [part="header"] the border doesn't
+       travel with the sticky bar and gets painted over. */
+    xyd-nav {
+        background: var(--color-bg);
+        border-bottom: 1px solid var(--terrarium-border);
+    }
+
+    /* Prose links get a visible underline (this @layer themes rule beats the base
+       @layer defaults anchor rule). Scope to the content column; chrome links
+       (prev/next, heading anchors) stay clean, and breadcrumbs underline ONLY on
+       hover (below). */
+    [part="page-article-content"] a {
+        text-decoration: underline;
+        text-underline-offset: 0.15em;
+    }
+    [part="page-article-content"] xyd-navlinks a,
+    [part="page-article-content"] :is(h1, h2, h3, h4, h5, h6) a {
+        text-decoration: none;
+    }
+
+    /* Breadcrumbs: room below so they don't crowd the content; links underline
+       ONLY on hover (this is more specific than the prose rule above, which would
+       otherwise force it always-on); links are slightly heavier than the plain
+       current-page text so what's clickable is obvious. The hover color darkens via
+       --xyd-breadcrumbs-color--hover (vars.css). */
+    [part="page-article-content"] xyd-breadcrumbs {
+        margin-bottom: 20px;
+    }
+    [part="page-article-content"] xyd-breadcrumbs [part="item"] {
+        font-weight: 400;
+    }
+    [part="page-article-content"] xyd-breadcrumbs a {
+        text-decoration: none;
+        font-weight: var(--xyd-font-weight-medium);
+    }
+    [part="page-article-content"] xyd-breadcrumbs a:hover {
+        text-decoration: underline;
+    }
+
+    /* Cards (GuideCard): a soft ring shadow that reads as a border, lifting
+       slightly on hover — and card links never take the prose underline. */
+    /* equal-height rows: the card fills its grid cell (base host is
+       height:auto, so a short card's box would end before its row-mate's) */
+    xyd-guidecard-list xyd-guidecard {
+        height: 100%;
+    }
+    xyd-guidecard-list xyd-guidecard [part="link"] {
+        display: block;
+        height: 100%;
+    }
+    xyd-guidecard [part="item"] {
+        height: 100%;
+        box-sizing: border-box;
+        padding: 20px;
+        border-radius: var(--xyd-border-radius-medium, 8px);
+        box-shadow: 0 0 0 1px var(--terrarium-border), 0 2px 8px rgba(2, 8, 23, 0.04);
+        transition: box-shadow .15s ease;
+    }
+    xyd-guidecard:hover [part="item"] {
+        box-shadow: 0 0 0 1px color-mix(in srgb, var(--terrarium-gray) 40%, transparent), 0 4px 14px rgba(2, 8, 23, 0.08);
+    }
+    [part="page-article-content"] xyd-guidecard a,
+    [part="page-article-content"] xyd-guidecard a:hover {
+        text-decoration: none;
+    }
+
+    /* Space the product switcher a bit away from the logo. */
+    [part="logo"] [data-fw-nav-dropdown] {
+        margin-left: 14px;
+    }
+
+    /* Gap between the pinned fixed region (filter / fixed components) and the
+       list. The blank space lives in the FIXED region's own bottom padding so it
+       stays put while the list scrolls under it (a list `padding-top` scrolls
+       away, letting the scrolled items touch the input). The list itself starts
+       flush. */
+    xyd-sidebar [part="fixed"]:not(:empty) {
+        padding-bottom: 12px;
+    }
+    xyd-sidebar [part="fixed"]:not(:empty) + [part="list"] {
+        padding-top: 0;
+    }
+    /* …and when the list STARTS with a group header, drop the header's own
+       24px top margin (base ItemHeaderHost) so the first group sits close under
+       the pinned container. Headers between groups (preceded by an item) keep
+       their spacing. */
+    xyd-sidebar [part="fixed"]:not(:empty) + [part="list"] [part="item-header"]:not([part="item"] + *) {
+        margin-top: 0;
+    }
+
+    /* Section switcher (sidebarDropdown segment): no inline padding — the base
+       ghost-item padding indents it so it doesn't line up with sidebar items. */
+    xyd-sidebar-tabs-dropdown {
+        padding-inline: 0;
+    }
+
+    /* The switcher TRIGGER sizes like a normal sidebar item (same paddings, no
+       card chrome / 52px min-height) and is tinted with the per-product accent
+       lightened via alpha. */
+    xyd-sidebar-tabs-dropdown button[part="dropdown-trigger"] {
+        min-height: 0;
+        padding: 6px 12px 6px var(--xyd-sidebar-item-padding-left);
+        gap: 8px;
+        border: none;
+        border-radius: var(--xyd-border-radius-small, 4px);
+        /* HashiCorp-style soft accent gradient + inset ring, both derived from the
+           per-product accent mixed toward the page bg (for terraform purple this
+           lands on ~#f4ecff→#fcfaff with an #ebdbfc-ish ring; mixing toward
+           --color-bg keeps it correct in dark mode). */
+        background: linear-gradient(
+            315deg,
+            color-mix(in srgb, var(--color-primary) 10%, var(--color-bg)) 0%,
+            color-mix(in srgb, var(--color-primary) 2%, var(--color-bg)) 100%
+        );
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-primary) 22%, var(--color-bg));
+        font-size: var(--xyd-font-size-small);
+        color: var(--text-primary);
+    }
+    xyd-sidebar-tabs-dropdown button[part="dropdown-trigger"]:hover,
+    xyd-sidebar-tabs-dropdown button[part="dropdown-trigger"][data-state="open"] {
+        background: linear-gradient(
+            315deg,
+            color-mix(in srgb, var(--color-primary) 15%, var(--color-bg)) 0%,
+            color-mix(in srgb, var(--color-primary) 5%, var(--color-bg)) 100%
+        );
+        border-color: transparent;
+        box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-primary) 30%, var(--color-bg));
+    }
+    /* Icons in the switcher (trigger AND popover entries — the popover renders
+       INLINE inside the host, not portaled) are plain 20px glyphs, not the base
+       34px bordered tiles — so rows match sidebar-item height. */
+    xyd-sidebar-tabs-dropdown [part="dropdown-icon"] {
+        width: 20px;
+        height: 20px;
+        border: none;
+        border-radius: 0;
+    }
+
+    /* Switcher TRIGGER text is medium (base is semibold) — the popover ENTRIES
+       are normal weight, so the selected section stands out over the options. */
+    xyd-sidebar-tabs-dropdown [part="dropdown-label"] {
+        font-weight: var(--xyd-font-weight-medium);
+    }
+    xyd-sidebar-tabs-dropdown [part="dropdown-listitem"] [part="dropdown-label"] {
+        font-weight: var(--xyd-font-weight-normal);
+    }
+
+    /* Popover entries size like sidebar items too — same treatment as the
+       trigger (base is 12px/16px padded cards with 10px radius) — and hover with
+       the SAME bg as the nav segment dropdown items (base uses --dark16, which
+       renders slightly differently). */
+    xyd-sidebar-tabs-dropdown [part="dropdown-listitem"] {
+        padding: 6px 12px;
+        gap: 8px;
+        border-radius: var(--xyd-border-radius-small, 4px);
+    }
+    xyd-sidebar-tabs-dropdown [part="dropdown-listitem"]:hover {
+        background: var(--xyd-nav-dropdown-item-bgcolor--hover, var(--xyd-sidebar-item-bgcolor--active));
+    }
+
+
+    /* Terrarium chevron + FAST expand/collapse:
+       — custom chevron glyph (the base draws it as a mask-image on ::after, so
+         swapping the mask URL is the whole override; open=rotate(0)/down,
+         closed=rotate(-90)/right states come from the base);
+       — snappier chevron rotation (0.1s vs base 0.2s);
+       — expanding/collapsing is INSTANT: no height slide, no fade-in (base
+         animates 300ms via the xyd-collapse CSS transitions). */
+    xyd-sidebar [part="item-button"]:has(+ [part="subtree"] xyd-collapse)::after {
+        -webkit-mask-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'16'%20height%3D'16'%20fill%3D'none'%20viewBox%3D'0%200%2016%2016'%20aria-hidden%3D'true'%3E%3Cpath%20fill%3D'currentColor'%20fill-rule%3D'evenodd'%20d%3D'M3.235%205.205a.75.75%200%20011.06.03L8%209.158l3.705-3.923a.75.75%200%20011.09%201.03l-4.25%204.5a.75.75%200%2001-1.09%200l-4.25-4.5a.75.75%200%2001.03-1.06z'%20clip-rule%3D'evenodd'%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+        mask-image: url("data:image/svg+xml,%3Csvg%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%20width%3D'16'%20height%3D'16'%20fill%3D'none'%20viewBox%3D'0%200%2016%2016'%20aria-hidden%3D'true'%3E%3Cpath%20fill%3D'currentColor'%20fill-rule%3D'evenodd'%20d%3D'M3.235%205.205a.75.75%200%20011.06.03L8%209.158l3.705-3.923a.75.75%200%20011.09%201.03l-4.25%204.5a.75.75%200%2001-1.09%200l-4.25-4.5a.75.75%200%2001.03-1.06z'%20clip-rule%3D'evenodd'%3E%3C%2Fpath%3E%3C%2Fsvg%3E");
+        transition: transform 0.1s ease, background-color 0.1s ease;
+        /* smaller glyph: the base ::after is 16px wide with mask-size: contain,
+           so shrinking the box shrinks the icon */
+        width: 14px;
+    }
+    xyd-sidebar xyd-collapse,
+    xyd-sidebar xyd-collapse [part="child"] {
+        transition: none;
+    }
+
+    /* Expanding a group must NOT change its weight: the base bolds an open
+       group (overridden above) AND semibolds ancestors of the active page
+       ([data-parent-active]) — keep both at the normal item weight. */
+    xyd-sidebar [part="primary-item"][data-parent-active="true"] {
+        font-weight: var(--xyd-font-weight-medium);
+    }
+
+    /* An expanded group (its subtree open) should NOT go bold — keep the regular
+       item weight (base sets it bold on open). */
+    xyd-sidebar [part="item-button"]:has(+ [part="subtree"] > xyd-collapse[data-open="true"]) {
+        font-weight: inherit;
+    }
+
+    /* RWD: never crush the logo + product switcher off-screen — nav-left keeps
+       its intrinsic width; the CENTER (tabs) is the flexible part and scrolls
+       horizontally on narrow viewports instead of squeezing its siblings. */
+    [part="nav-left"] {
+        flex-shrink: 0;
+        overflow: visible;
+    }
+    [part="nav-center"] {
+        min-width: 0;
+        overflow-x: auto;
+        scrollbar-width: none;
+    }
+    [part="nav-center"]::-webkit-scrollbar {
+        display: none;
+    }
+    [part="nav-center"] [role="tablist"] {
+        flex-wrap: nowrap;
+        white-space: nowrap;
+    }
+
+    /* RWD (narrow): a single row can't usably hold logo + switcher + 4 tabs +
+       search — wrap the header into TWO ROWS: row 1 = logo/switcher/search,
+       row 2 = the tabs, full-width and horizontally scrollable. */
+    @media (max-width: 1024px) {
+        xyd-nav [part="nav"] {
+            flex-wrap: wrap;
+            height: auto;
+        }
+        xyd-nav [part="nav-center"] {
+            order: 10;
+            flex: 1 1 100%;
+            min-width: 100%;
+            border-top: 1px solid var(--terrarium-border);
+        }
+        xyd-nav [part="nav-center"] {
+            overflow-x: visible;
+        }
+        xyd-nav [part="nav-center"] [role="tablist"] {
+            flex-wrap: wrap;
+            white-space: normal;
+            height: auto;
+            min-height: 44px;
+        }
+        /* wrapped lines need a fixed row height (desktop stretches items to the
+           64px nav; multi-line rows size by their items) */
+        xyd-nav [part="nav-center"] xyd-nav-item,
+        xyd-nav [part="nav-center"] [part="dropdown-trigger"] {
+            height: 40px;
+        }
+    }
+
+    /* Center nav tabs: the active tab uses a bottom underline that touches the
+       header's bottom edge + darker text — NOT the default pill background. The
+       items stretch to the full nav height so the underline sits on the header
+       bottom line. */
+    [part="nav-center"] [role="tablist"] {
+        height: var(--xyd-nav-height);
+        align-items: stretch;
+    }
+    [part="nav-center"] [role="tablist"] a {
+        display: flex;
+        align-items: stretch;
+    }
+    [part="nav-center"] xyd-nav-item {
+        height: 100%;
+        box-sizing: border-box;
+        background: transparent;
+        border-radius: 0;
+        border-bottom: 2px solid transparent;
+    }
+    [part="nav-center"] xyd-nav-item[data-state="active"] {
+        background: transparent;
+        color: var(--terrarium-black);
+        border-bottom-color: var(--color-primary);
+    }
+
+    /* A dropdown tab (e.g. "Documentation ▾") in the nav center matches the plain
+       tabs: full-height, bottom-underline when active (a child section matches). */
+    [part="nav-center"] [data-fw-nav-dropdown] {
+        display: flex;
+        align-items: stretch;
+    }
+    [part="nav-center"] [part="dropdown-trigger"] {
+        height: 100%;
+        box-sizing: border-box;
+        background: transparent;
+        border-radius: 0;
+        border-bottom: 2px solid transparent;
+    }
+    [part="nav-center"] [part="dropdown-trigger"][data-active] {
+        color: var(--terrarium-black);
+        border-bottom-color: var(--color-primary);
+    }
+}

--- a/packages/xyd-theme-terrarium/src/theme.tsx
+++ b/packages/xyd-theme-terrarium/src/theme.tsx
@@ -1,0 +1,52 @@
+import React from "react"
+
+import { BaseTheme } from "@xyd-js/themes"
+
+import "./imports.css"
+
+import "@xyd-js/themes/index.css"
+
+import './index.css';
+import './vars.css';
+import './override.css';
+
+export default class ThemeTerrarium extends BaseTheme {
+    constructor() {
+        super()
+
+        this.theme.Update({
+            coder: {
+                syntaxHighlight: "dark-plus"
+            },
+            appearance: {
+                logo: {
+                    header: true
+                },
+                search: {
+                    sidebar: "mobile",
+                    // the nav CENTER hosts the per-product tabs — search lives on
+                    // the RIGHT so they never collide
+                    right: "desktop"
+                },
+                content: {
+                    breadcrumbs: true
+                },
+                tabs: {
+                    // per-product `appearance:"tabs"` segments render in the nav center
+                    surface: "center"
+                },
+                sidebar: {
+                    scrollbar: "secondary",
+                    scrollTransition: "smooth",
+                    groupCase: "none",
+                    // the whole sidebar scrolls (full-height scrollbar); the fixed
+                    // region (filter / switcher / pinned components) sticks on top
+                    scroll: "sidebar"
+                }
+            }
+        })
+
+        // The sidebar's fixed (pinned) region hosts the built-in filter
+        // (components.filterSidebar) + any `{ fixed: true }` sidebar components.
+    }
+}

--- a/packages/xyd-theme-terrarium/src/vars.css
+++ b/packages/xyd-theme-terrarium/src/vars.css
@@ -1,0 +1,110 @@
+@import "@xyd-js/themes/dist/decorators/atlas-vars.css";
+
+/* Theme palette — high-contrast blacks/darks on white (HashiCorp-style) */
+:root {
+    --terrarium-black: #0c0c0e;
+    --terrarium-gray-dark: #3b3d45;
+    --terrarium-gray: #656a76;
+    --terrarium-border: #656a7626;
+    --terrarium-active-bg: #f5f5f5;
+
+    /* Default accent = green. Per-product themes recolor via --theme-color-primary
+       (set inline on <xyd-layout-primary> by BaseTheme when the active logoTrailing
+       product declares a `color`), so this whole accent follows the active product. */
+    --terrarium-green: #00ca8e;
+    --color-primary: var(--theme-color-primary, var(--terrarium-green));
+    --color-primary--active: var(--theme-color-primary, var(--terrarium-green));
+
+    /* In-content links use a fixed blue, INDEPENDENT of the per-product accent.
+       Hover darkens the link (mix toward black). */
+    --terrarium-link: #1060ff;
+    --xyd-anchor-color: var(--terrarium-link);
+    --xyd-anchor-color--hover: color-mix(in srgb, var(--terrarium-link) 72%, black);
+}
+
+/* Core high-contrast text/bg */
+:root {
+    --color-bg: var(--white);
+    --color-text: var(--terrarium-black);
+    --text-primary: var(--terrarium-black);
+    --text-secondary: var(--terrarium-gray-dark);
+    --text-tertiary: var(--terrarium-gray);
+}
+
+/* Layout — full-width, taller nav, ~800px content, wider sidebar + TOC */
+:root {
+    --xyd-page-gutter: 0;
+    --xyd-nav-height: 64px;
+    --xyd-sidebar-width: 300px;
+    --xyd-layout-width-small: 800px;
+    --xyd-layout-nav-width-medium: 280px;
+}
+
+/* Sidebar */
+:root {
+    --xyd-sidebar-padding: 8px 16px;
+    /* Pin the derived total (base derives it from --xyd-sidebar-padding, which is
+       now a 2-value shorthand → its calc() would be invalid). Track the 16px
+       horizontal padding so item/subnav/left-pad alignment follows. */
+    --xyd-sidebar-item-padding-total: calc(16px + var(--xyd-sidebar-item-padding-left));
+    --xyd-sidebar-bgcolor: var(--white);
+    --xyd-sidebar-filter-border-color: var(--terrarium-border);
+    --xyd-sidebar-item-color: var(--text-tertiary);         /* items — #656a76 */
+    --xyd-sidebar-item-header-color: var(--text-secondary); /* group text — #3b3d45 */
+
+    /* Active row: neutral light-gray background (stays gray across products),
+       accent-colored text + mark (recolors per product via --color-primary). */
+    --xyd-sidebar-item-color--active: var(--color-primary);
+    --xyd-sidebar-item-bgcolor--active: var(--terrarium-active-bg);
+    --xyd-sidebar-item-bgcolor--active-hover: var(--terrarium-active-bg);
+    --xyd-sidebar-item-bgcolor--active-mark: var(--color-primary);
+}
+
+/* TOC */
+:root {
+    --xyd-toc-item-color: var(--text-tertiary);          /* #656a76 */
+    --xyd-toc-item-color--active: var(--text-primary);   /* active — #0c0c0e */
+}
+
+/* Content — body text is one tier lighter than headings for readable hierarchy */
+:root {
+    --xyd-text-color--default: var(--text-secondary);    /* content text — #3b3d45 */
+    --xyd-heading-color: var(--text-primary);            /* headings — #0c0c0e */
+}
+
+/* Nav items */
+:root {
+    --xyd-nav-item-color: var(--text-secondary);         /* nav items — #3b3d45 */
+}
+
+/* Breadcrumbs — muted by default, darken on hover so links read as clickable */
+:root {
+    --xyd-breadcrumbs-color: var(--text-tertiary);         /* #656a76 */
+    --xyd-breadcrumbs-color--hover: var(--text-primary);   /* darken on hover — #0c0c0e */
+}
+
+@define-mixin dark-theme {
+    --color-bg: var(--terrarium-black);
+    --color-text: #f5f5f5;
+    --text-primary: #f5f5f5;
+    --text-secondary: #c8ccd4;
+    --text-tertiary: var(--terrarium-gray);
+
+    --terrarium-border: #ffffff1a;
+    --terrarium-active-bg: #1c1c1f;
+    --terrarium-link: #5b9bff;
+    /* On dark, hover BRIGHTENS the link (mixing toward black would hide it). */
+    --xyd-anchor-color--hover: color-mix(in srgb, var(--terrarium-link) 78%, white);
+
+    --xyd-sidebar-bgcolor: var(--terrarium-black);
+}
+
+[data-color-scheme="dark"] {
+    @mixin dark-theme;
+}
+
+@media (prefers-color-scheme: dark) {
+    :root:not([data-color-scheme="light"]):not([data-color-scheme="dark"]) {
+        @mixin dark-theme;
+    }
+}

--- a/packages/xyd-theme-terrarium/tsconfig.json
+++ b/packages/xyd-theme-terrarium/tsconfig.json
@@ -1,0 +1,40 @@
+{
+  "compilerOptions": {
+    "paths": {
+        "@xyd-js/themes": ["../xyd-themes/src"],
+    },
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "ES6",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "noEmit": true,
+    "incremental": false,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react",
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "strictNullChecks": true
+  },
+  "include": [
+    "packages/css/src",
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/packages/xyd-themes/src/BaseTheme.tsx
+++ b/packages/xyd-themes/src/BaseTheme.tsx
@@ -42,6 +42,7 @@ import {
     FwCopyPage,
     FwBreadcrumbs,
     useEditLink,
+    useActiveLogoTrailingItem,
 } from "@xyd-js/framework/react";
 
 import { Theme } from "./Theme";
@@ -120,6 +121,7 @@ export class BaseTheme extends Theme {
         const activeRoute = useActiveRoute()
         const meta = useMetadata()
         const appearance = useAppearance()
+        const activeProduct = useActiveLogoTrailingItem()
         const isPage = meta?.layout === "page"
 
         const hideSidebar = this.useHideSidebar()
@@ -130,12 +132,30 @@ export class BaseTheme extends Theme {
 
         const id = activeRoute?.id || matchActivePageRout?.id || undefined
 
+        // Per-product accent (opt-in): when the active `logoTrailing` product
+        // declares a `color`, drive `--theme-color-primary` from it so the whole
+        // accent (links, sidebar/toc active) recolors per product. Baked into the
+        // SSR HTML per route (flash-free); no-op when no product declares a color.
+        //
+        // The var must be set at :ROOT (a <style> tag), not only inline on the
+        // layout host: custom properties resolve where they are DECLARED, and both
+        // `--color-primary` AND its derived tokens (--xyd-sidebar-item-color--active,
+        // …) are declared at :root — an inline var lower in the tree can never
+        // reach those chains. The inline style is kept as a secondary hook
+        // (tokens.css re-declares --color-primary on the host off of it).
+        const accentColor = safeCssColor(activeProduct?.color)
+        const accentStyle = accentColor
+            ? ({ "--theme-color-primary": accentColor } as React.CSSProperties)
+            : undefined
+
         return <UXNode name="BaseTheme.Layout" props={{}}>
+            {accentColor && <style>{`:root{--theme-color-primary:${accentColor};}`}</style>}
             <LayoutPrimary
                 subheader={!!subheader}
                 layout={meta?.layout}
                 scrollKey={location.pathname}
                 id={id}
+                style={accentStyle}
             >
                 <LayoutPrimary.Header
                     banner={banner}
@@ -508,5 +528,13 @@ function isDefaultContent(meta: Metadata) {
         meta.component === "atlas" ||
         meta.uniform ||
         meta.layout === "page"
+}
+
+/** The per-product accent color is emitted into a `<style>` tag — restrict it to
+ *  a plain CSS color charset (hex, rgb()/hsl(), named) so config can't inject CSS. */
+function safeCssColor(color?: string): string | undefined {
+    if (typeof color !== "string") return undefined
+    const c = color.trim()
+    return /^[#a-zA-Z0-9(),.%\s\/-]+$/.test(c) && c.length <= 64 ? c : undefined
 }
 

--- a/packages/xyd-themes/src/Theme.tsx
+++ b/packages/xyd-themes/src/Theme.tsx
@@ -116,7 +116,7 @@ export abstract class Theme {
         this.resetWebeditor()
         this.resetNavigation()
 
-        const searchAppearance = this.theme.appearance?.search?.sidebar || this.theme.appearance?.search?.middle
+        const searchAppearance = this.theme.appearance?.search?.sidebar || this.theme.appearance?.search?.middle || this.theme.appearance?.search?.right
         if (searchAppearance) {
             const hasSearch = this.webeditor.header?.find(item => item.component === "Search")
 
@@ -152,6 +152,19 @@ export abstract class Theme {
                 }
 
                 this.webeditor.header = this.headerPrepend(searchItem, "center")
+            }
+
+            if (this.theme.appearance?.search?.right) {
+                const search: WebEditorNavigationItem = {
+                    component: "Search",
+                    mobile: this.theme.appearance?.search?.right === "mobile" || undefined,
+                    desktop: this.theme.appearance?.search?.right === "desktop" || undefined
+                }
+
+                this.webeditor.header = this.headerAppend({
+                    ...search,
+                    float: "right" as const
+                })
             }
         }
 
@@ -218,7 +231,7 @@ export abstract class Theme {
                 // A header anchor with a nested menu renders as a multi-level
                 // dropdown (FwHeaderItem → Nav.Dropdown). Keep it a plain header
                 // item (no Button component) so `dropdownMenu`/`trigger` survive.
-                if ("dropdownMenu" in item && item.dropdownMenu?.length) {
+                if ("dropdownMenu" in item && (Array.isArray(item.dropdownMenu) ? item.dropdownMenu.length : (item.dropdownMenu as any)?.items?.length)) {
                     this.webeditor.header = this.headerAppend({
                         ...item,
                         float: "right" as const,

--- a/packages/xyd-themes/src/styles/tokens.css
+++ b/packages/xyd-themes/src/styles/tokens.css
@@ -46,6 +46,18 @@
     --xyd-gradient-via-position: ;
 }
 
+/* Per-product accent. BaseTheme.Layout sets `--theme-color-primary` INLINE on
+   <xyd-layout-primary> (from the active logoTrailing product's `color`). A custom
+   property resolves where it is DECLARED — the :root chain above computes its
+   fallback at the root (where the inline var doesn't exist) and descendants
+   inherit that COMPUTED value, so the inline accent would never take effect.
+   Re-declare on the layout host, gated on the inline var actually being present,
+   so theme :root fallbacks are untouched when no product is active. */
+xyd-layout-primary[style*="--theme-color-primary"] {
+    --color-primary: var(--theme-color-primary);
+    --color-primary--active: var(--theme-color-primary-active, var(--theme-color-primary));
+}
+
 /* Dark Mode Global */
 [data-color-scheme="dark"] {
     --white: #0e0e10;

--- a/packages/xyd-ui/src/components/Nav/NavDropdown.styles.tsx
+++ b/packages/xyd-ui/src/components/Nav/NavDropdown.styles.tsx
@@ -66,6 +66,23 @@ export const DropdownList = css`
            edge-to-edge hovered-item backgrounds (touching all four sides). */
         gap: var(--xyd-nav-dropdown-gap, 2px);
         padding: var(--xyd-nav-dropdown-padding, 6px);
+
+        /* A custom panel component (segment.component) controls its own padding +
+           width and may be tall — drop the list padding and give it more room. */
+        &[data-panel] {
+            padding: 0;
+            max-height: min(85vh, 760px);
+        }
+
+        /* Multi-column menu (\`itemsPerColumn\`): fill column-first — N rows down,
+           then the next column (e.g. 12 items with 7/column → 7 + 5). */
+        &[data-columns] {
+            display: grid;
+            grid-auto-flow: column;
+            grid-template-rows: repeat(var(--xyd-nav-dropdown-rows, 7), auto);
+            column-gap: 8px;
+            max-height: none;
+        }
         background: var(--xyd-nav-dropdown-bgcolor, var(--xyd-content-bgcolor, var(--white, #fff)));
         color: var(--xyd-nav-item-color);
         border: 1px solid var(--xyd-nav-dropdown-border-color, var(--color-header-border, var(--dark12, rgba(0, 0, 0, 0.08))));
@@ -112,6 +129,14 @@ export const DropdownList = css`
                 font-weight: var(--xyd-font-weight-semibold, 600);
                 color: var(--xyd-nav-item-color--active);
             }
+        }
+
+        /* The router link wrapping each leaf item IS the Radix menuitem — Radix
+           moves focus to it on hover, so the browser draws a focus outline on the
+           <a> (not on [part="dropdown-item"], which already resets it). Kill it; the
+           row background is the hover affordance. */
+        a {
+            outline: none;
         }
 
         [part="dropdown-icon"] {

--- a/packages/xyd-ui/src/components/Nav/NavDropdown.tsx
+++ b/packages/xyd-ui/src/components/Nav/NavDropdown.tsx
@@ -26,10 +26,26 @@ export interface NavDropdownProps {
     /** Trigger label. */
     title?: string;
     icon?: React.ReactNode | string;
+    /**
+     * Render the trigger ICON-ONLY: show `icon` at a larger size and hide `title`.
+     * For `logoTrailing` switchers whose icon is a wordmark image (logo + name).
+     */
+    iconOnly?: boolean;
     /** How the menu opens. Defaults to `"hover"`. */
     trigger?: "hover" | "click";
     /** Menu entries (recursive). */
     items: NavDropdownItem[];
+    /**
+     * Custom panel content rendered INSIDE the dropdown instead of the default
+     * `items` list — e.g. a rich multi-column mega-menu. When set, `items` is
+     * ignored for rendering (still used for trigger active-state).
+     */
+    content?: React.ReactNode;
+    /**
+     * Maximum items rendered in ONE COLUMN — overflowing items wrap into
+     * additional columns (column-first fill). Omit for a single column.
+     */
+    itemsPerColumn?: number;
     /**
      * Router-agnostic link component used for leaf entries — receives `{ href }`.
      * The framework passes `FwLink`; falls back to a plain anchor.
@@ -49,12 +65,18 @@ function $Link({ children, ...props }: any) {
     return <a {...props}>{children}</a>;
 }
 
-function IconSlot({ icon }: { icon?: React.ReactNode | string }) {
+/** Default dropdown icon size (trigger + menu items). */
+const ICON_SIZE = 16;
+/** Larger trigger icon for `logoTrailing` icon-only mode — the wordmark image
+    carries the product name, so it stands in for the (hidden) text label. */
+const ICON_ONLY_SIZE = 30;
+
+function IconSlot({ icon, size = ICON_SIZE }: { icon?: React.ReactNode | string; size?: number }) {
     if (!icon) return null;
     if (typeof icon === "string") {
         return (
             <span part="dropdown-icon">
-                <Icon name={icon} size={16} />
+                <Icon name={icon} size={size} />
             </span>
         );
     }
@@ -186,7 +208,9 @@ function renderItems(items: NavDropdownItem[], as?: React.ElementType) {
  * `FwLink`) so it works under the bun engine's router.
  */
 export function NavDropdown(props: NavDropdownProps) {
-    const { title, icon, trigger = "hover", items, as, active, className } = props;
+    const { title, icon, iconOnly, trigger = "hover", items, content, itemsPerColumn, as, active, className } = props;
+    // Multi-column only when the items actually overflow one column.
+    const multiCol = !content && !!itemsPerColumn && items.length > itemsPerColumn;
     const [open, setOpen] = useState(false);
     const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
     const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -229,9 +253,17 @@ export function NavDropdown(props: NavDropdownProps) {
                 <DropdownMenu.Trigger
                     part="dropdown-trigger"
                     data-active={active || undefined}
+                    data-icon-only={iconOnly || undefined}
+                    // In icon-only mode the visible label is hidden, so name the
+                    // trigger for AT when there's an icon standing in for it.
+                    aria-label={iconOnly && icon ? title : undefined}
                 >
-                    <IconSlot icon={icon} />
-                    {title && <span part="dropdown-trigger-label">{title}</span>}
+                    <IconSlot icon={icon} size={iconOnly ? ICON_ONLY_SIZE : ICON_SIZE} />
+                    {/* Hide the label in icon-only mode ONLY when there's an icon to
+                        show. With no active product (e.g. the landing page) there's
+                        no icon, so fall back to the label so the trigger isn't a
+                        bare chevron. */}
+                    {(!iconOnly || !icon) && title && <span part="dropdown-trigger-label">{title}</span>}
                     <Chevron />
                 </DropdownMenu.Trigger>
 
@@ -241,8 +273,14 @@ export function NavDropdown(props: NavDropdownProps) {
                     `asChild` → the panel is the styleable `<xyd-nav-dropdown-menu>`
                     custom element (theme/user CSS targets it directly). */}
                 <DropdownMenu.Content asChild align="start" sideOffset={0}>
-                    <xyd-nav-dropdown-menu className={cn.DropdownList} part="dropdown-list">
-                        {renderItems(items, as)}
+                    <xyd-nav-dropdown-menu
+                        className={cn.DropdownList}
+                        part="dropdown-list"
+                        data-panel={content ? "true" : undefined}
+                        data-columns={multiCol ? "true" : undefined}
+                        style={multiCol ? { "--xyd-nav-dropdown-rows": String(itemsPerColumn) } as React.CSSProperties : undefined}
+                    >
+                        {content ?? renderItems(items, as)}
                     </xyd-nav-dropdown-menu>
                 </DropdownMenu.Content>
             </DropdownMenu.Root>

--- a/packages/xyd-ui/src/components/Sidebar/Sidebar.styles.tsx
+++ b/packages/xyd-ui/src/components/Sidebar/Sidebar.styles.tsx
@@ -5,12 +5,18 @@ import ChevronIcon from './chevronIcon.svg';
 export const SidebarHost = css`
     @layer defaults {
         background: var(--xyd-sidebar-bgcolor);
-    
+
         height: 100%;
         border-radius: 4px;
         display: flex;
         flex-direction: column;
-        
+
+        /* appearance.sidebar.groupCase="none" → render group headers as authored */
+        &[data-group-case="none"] [part="item-header"] {
+            text-transform: none;
+            letter-spacing: normal;
+        }
+
         [part="item-group"] {
             & > * {
                 padding-bottom: 4px;
@@ -38,11 +44,39 @@ export const SidebarHost = css`
             right: 0;
         }
 
+        /* Pinned region above the scrollable list — stays visible while the list
+           scrolls (flex:none so it doesn't shrink; the list flex-shrinks around it). */
+        [part="fixed"] {
+            flex: none;
+            padding: var(--xyd-sidebar-padding);
+        }
+        /* collapse when there's no pinned content (no filter / surface / fixed items) */
+        [part="fixed"]:empty {
+            display: none;
+        }
+
         [part="list"] {
             overflow-y: auto;
             overflow-x: hidden;
             height: 100%;
             padding: var(--xyd-sidebar-padding);
+        }
+
+        /* scroll="sidebar": the WHOLE sidebar scrolls (scrollbar spans its full
+           height); the fixed region sticks to the top and items pass beneath it. */
+        &[data-scroll="sidebar"] {
+            overflow-y: auto;
+            overflow-x: hidden;
+        }
+        &[data-scroll="sidebar"] [part="fixed"] {
+            position: sticky;
+            top: 0;
+            z-index: 2;
+            background: var(--xyd-sidebar-bgcolor);
+        }
+        &[data-scroll="sidebar"] [part="list"] {
+            overflow: visible;
+            height: auto;
         }
 
         [part="footer"] {

--- a/packages/xyd-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/xyd-ui/src/components/Sidebar/Sidebar.tsx
@@ -8,21 +8,37 @@ import * as cn from "./Sidebar.styles";
 export interface UISidebarProps {
     children: React.ReactNode;
     footerItems?: React.ReactNode;
+    /** Pinned content rendered ABOVE the scrollable item list (stays visible on scroll). */
+    fixedTop?: React.ReactNode;
     className?: string;
     scrollShadow?: boolean;
     scrollTransition?: "smooth" | "instant";
+    groupCase?: "none" | "uppercase";
+    /**
+     * Which element scrolls. `"list"` (default): only the item list scrolls, below
+     * the fixed region. `"sidebar"`: the WHOLE sidebar scrolls (the scrollbar spans
+     * its full height) and the fixed region sticks to the top.
+     */
+    scroll?: "list" | "sidebar";
 }
 
-export function UISidebar({ children, footerItems, className, scrollShadow, scrollTransition = 'instant' }: UISidebarProps) {
+export function UISidebar({ children, footerItems, fixedTop, className, scrollShadow, scrollTransition = 'instant', groupCase, scroll = "list" }: UISidebarProps) {
     const listRef = useRef<HTMLUListElement>(null);
+    const hostRef = useRef<HTMLElement>(null);
 
-    useSidebarScrollTransition(listRef, scrollTransition);
+    // Active-item centering must target the element that actually scrolls.
+    useSidebarScrollTransition(scroll === "sidebar" ? hostRef : listRef, scrollTransition);
 
     // TODO: in the future theming api?
     return <xyd-sidebar
+        ref={hostRef}
         className={`${cn.SidebarHost} ${className || ""}`}
+        data-group-case={groupCase}
+        data-scroll={scroll === "sidebar" ? "sidebar" : undefined}
     >
         {scrollShadow && <div part="scroll-shadow" />}
+
+        {fixedTop && <div part="fixed">{fixedTop}</div>}
 
         <ul part="list" ref={listRef}>
             {children}
@@ -161,7 +177,7 @@ UISidebar.SubTree = function SidebarSubItem({ children, isOpen }: UISidebarSubTr
 
 // TODO: move to shared code
 function useSidebarScrollTransition(
-    listRef: React.RefObject<HTMLUListElement | null>,
+    listRef: React.RefObject<HTMLElement | null>,
     scrollTransition: "smooth" | "instant" | "auto" = 'auto'
 ) {
     const location = useLocation();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,9 +95,12 @@ importers:
       '@xyd-js/router':
         specifier: workspace:*
         version: link:../../packages/xyd-router
-      '@xyd-js/theme-poetry':
+      '@xyd-js/theme-cosmo':
         specifier: workspace:*
-        version: link:../../packages/xyd-theme-poetry
+        version: link:../../packages/xyd-theme-cosmo
+      '@xyd-js/theme-terrarium':
+        specifier: workspace:*
+        version: link:../../packages/xyd-theme-terrarium
       '@xyd-js/themes':
         specifier: workspace:*
         version: link:../../packages/xyd-themes
@@ -1522,7 +1525,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.14
+        version: 1.4.0
       '@types/express':
         specifier: ^4.17.21
         version: 4.17.25
@@ -1565,7 +1568,7 @@ importers:
     devDependencies:
       '@napi-rs/cli':
         specifier: ^3.8.2
-        version: 3.8.2(@emnapi/runtime@1.9.2)(@types/node@24.12.3)(node-addon-api@7.1.1)
+        version: 3.8.2(@emnapi/runtime@1.11.2)(@types/node@24.12.3)(node-addon-api@7.1.1)
 
   packages/xyd-openapi:
     dependencies:
@@ -3283,6 +3286,100 @@ importers:
       react-router:
         specifier: ^7.15.0
         version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+
+  packages/xyd-theme-terrarium:
+    dependencies:
+      '@linaria/core':
+        specifier: ^6.2.0
+        version: 6.3.0
+      '@xyd-js/atlas':
+        specifier: workspace:*
+        version: link:../xyd-atlas
+      '@xyd-js/components':
+        specifier: workspace:*
+        version: link:../xyd-components
+      '@xyd-js/framework':
+        specifier: workspace:*
+        version: link:../xyd-framework
+      '@xyd-js/themes':
+        specifier: workspace:*
+        version: link:../xyd-themes
+      '@xyd-js/ui':
+        specifier: workspace:*
+        version: link:../xyd-ui
+      react:
+        specifier: ^19.1.0
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.6(react@19.2.6)
+      react-router:
+        specifier: ^7.15.0
+        version: 7.15.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+    devDependencies:
+      '@babel/preset-env':
+        specifier: ^7.26.0
+        version: 7.29.5(@babel/core@7.29.0)
+      '@babel/preset-flow':
+        specifier: ^7.25.9
+        version: 7.27.1(@babel/core@7.29.0)
+      '@babel/preset-react':
+        specifier: ^7.26.0
+        version: 7.28.5(@babel/core@7.29.0)
+      '@babel/preset-typescript':
+        specifier: ^7.26.0
+        version: 7.28.5(@babel/core@7.29.0)
+      '@rollup/plugin-alias':
+        specifier: ^5.1.1
+        version: 5.1.1(rollup@4.60.3)
+      '@rollup/plugin-babel':
+        specifier: ^6.0.4
+        version: 6.1.0(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.60.3)
+      '@rollup/plugin-commonjs':
+        specifier: ^28.0.1
+        version: 28.0.9(rollup@4.60.3)
+      '@rollup/plugin-node-resolve':
+        specifier: ^15.3.0
+        version: 15.3.1(rollup@4.60.3)
+      '@rollup/plugin-typescript':
+        specifier: ^12.1.1
+        version: 12.3.0(rollup@4.60.3)(tslib@2.8.1)(typescript@6.0.3)
+      '@wyw-in-js/rollup':
+        specifier: ^0.5.5
+        version: 0.5.5(rollup@4.60.3)(typescript@6.0.3)
+      '@wyw-in-js/vite':
+        specifier: ^0.5.5
+        version: 0.5.5(typescript@6.0.3)(vite@7.3.3(@types/node@24.12.3)(jiti@2.7.0)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.14))(terser@5.47.1)(yaml@2.8.4))
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.5.0(postcss@8.5.14)
+      postcss:
+        specifier: ^8.4.47
+        version: 8.5.14
+      postcss-import:
+        specifier: ^16.1.0
+        version: 16.1.1(postcss@8.5.14)
+      rimraf:
+        specifier: ^3.0.2
+        version: 3.0.2
+      rollup:
+        specifier: ^4.27.4
+        version: 4.60.3
+      rollup-plugin-css-only:
+        specifier: ^4.5.2
+        version: 4.5.5(rollup@4.60.3)
+      rollup-plugin-dts:
+        specifier: ^6.1.1
+        version: 6.4.1(rollup@4.60.3)(typescript@6.0.3)
+      rollup-plugin-postcss:
+        specifier: ^4.0.2
+        version: 4.0.2(postcss@8.5.14)(ts-node@10.9.2(@swc/core@1.15.33)(@types/node@24.12.3)(typescript@6.0.3))
+      rollup-plugin-terser:
+        specifier: ^7.0.2
+        version: 7.0.2(rollup@4.60.3)
+      tsup:
+        specifier: ^8.3.0
+        version: 8.5.1(@swc/core@1.15.33)(jiti@2.7.0)(postcss@8.5.14)(typescript@6.0.3)(yaml@2.8.4)
 
   packages/xyd-themes:
     dependencies:
@@ -6008,6 +6105,7 @@ packages:
   '@langchain/community@1.1.28':
     resolution: {integrity: sha512-Mb6vmLE4a7LLkH/flxNJgzNXCbrLH/osAvuplXTRqfsysfL8/EjtN7B98kuj/4HwLtBpn8pUQ5HbJIRXLrhP8Q==}
     engines: {node: '>=20'}
+    deprecated: This package has been deprecated. See https://github.com/langchain-ai/langchainjs-community/issues/61 for more info
     peerDependencies:
       '@arcjet/redact': ^v1.2.0
       '@aws-crypto/sha256-js': ^5.0.0
@@ -9329,8 +9427,8 @@ packages:
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
-  '@types/bun@1.3.14':
-    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+  '@types/bun@1.4.0':
+    resolution: {integrity: sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ==}
 
   '@types/clean-css@4.2.11':
     resolution: {integrity: sha512-Y8n81lQVTAfP2TOdtJJEsCoYl1AnOkqDqMvXb9/7pfgZZ7r8YrEyurrAvAoAjHOGXKRybay+5CsExqIH6liccw==}
@@ -10422,8 +10520,8 @@ packages:
   builtins@5.1.0:
     resolution: {integrity: sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg==}
 
-  bun-types@1.3.14:
-    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
+  bun-types@1.4.0:
+    resolution: {integrity: sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q==}
 
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
@@ -10983,6 +11081,7 @@ packages:
   conventional-changelog-core@5.0.1:
     resolution: {integrity: sha512-Rvi5pH+LvgsqGwZPZ3Cq/tz4ty7mjijhr3qR4m9IBXNbxGGYgTVVO+duXzz9aArmHxFtwZ+LRkrNIMDQzgoY4A==}
     engines: {node: '>=14'}
+    deprecated: Deprecated and no longer maintained. Please use conventional-changelog instead.
 
   conventional-changelog-preset-loader@3.0.0:
     resolution: {integrity: sha512-qy9XbdSLmVnwnvzEisjxdDiLA4OmV3o8db+Zdg4WiFw14fP3B6XNz98X0swPPpkTd/pc1K7+adKgEDM1JCUMiA==}
@@ -11097,6 +11196,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   cross-inspect@1.0.1:
     resolution: {integrity: sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A==}
@@ -11825,6 +11925,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -12480,7 +12581,7 @@ packages:
   git-raw-commits@3.0.0:
     resolution: {integrity: sha512-b5OHmZ3vAgGrDn/X0kS+9qCfNKWe4K/jFnhwzVWWg0/k5eLa3060tZShrRg8Dja5kPc+YjS0Gc6y7cRr44Lpjw==}
     engines: {node: '>=14'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -12494,7 +12595,7 @@ packages:
   git-semver-tags@5.0.1:
     resolution: {integrity: sha512-hIvOeZwRbQ+7YEUmCkHqo8FOLQZCEn18yevLHADlFPZY02KJGsu5FZt9YW/lybfK2uhWFI7Qg/07LekJiTv7iA==}
     engines: {node: '>=14'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-up@7.0.0:
@@ -17358,6 +17459,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -21344,7 +21446,7 @@ snapshots:
 
   '@msgpack/msgpack@3.1.3': {}
 
-  '@napi-rs/cli@3.8.2(@emnapi/runtime@1.9.2)(@types/node@24.12.3)(node-addon-api@7.1.1)':
+  '@napi-rs/cli@3.8.2(@emnapi/runtime@1.11.2)(@types/node@24.12.3)(node-addon-api@7.1.1)':
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@24.12.3)
       '@napi-rs/cross-toolchain': 1.0.3
@@ -21360,7 +21462,7 @@ snapshots:
       typanion: 3.14.0
       typescript: 5.9.3
     optionalDependencies:
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/runtime': 1.11.2
     transitivePeerDependencies:
       - '@napi-rs/cross-toolchain-arm64-target-aarch64'
       - '@napi-rs/cross-toolchain-arm64-target-armv7'
@@ -24920,9 +25022,9 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/node': 20.9.0
 
-  '@types/bun@1.3.14':
+  '@types/bun@1.4.0':
     dependencies:
-      bun-types: 1.3.14
+      bun-types: 1.4.0
 
   '@types/clean-css@4.2.11':
     dependencies:
@@ -26493,7 +26595,7 @@ snapshots:
     dependencies:
       semver: 7.8.5
 
-  bun-types@1.3.14:
+  bun-types@1.4.0:
     dependencies:
       '@types/node': 20.9.0
 

--- a/release.js
+++ b/release.js
@@ -112,6 +112,7 @@ async function main() {
             '@xyd-js/theme-picasso',
             '@xyd-js/theme-poetry',
             '@xyd-js/theme-solar',
+            '@xyd-js/theme-terrarium',
             '@xyd-js/themes',
             '@xyd-js/ui',
             '@xyd-js/uniform',


### PR DESCRIPTION
…switcher platform

New built-in theme "terrarium": full-width layout, left-pinned ~800px content, decoupled far-right TOC, taller nav, high-contrast palette, per-product accent.

Platform features (all themes, opt-in):
- per-product accent: NavigationItem.color + useActiveLogoTrailingItem(); BaseTheme.Layout declares --theme-color-primary at :root so derived tokens resolve
- segment appearance object form: {kind: "sidebarDropdown", options: {fixed}} + member-section route scoping; tabs segments with dropdownMenu {items, itemsPerColumn}
- sidebar: components.filterSidebar {placeholder, routes}, fixed top region, appearance.sidebar.scroll: "list" | "sidebar", project-local sidebar/segment components via component: string | {import, props}
- logoTrailing: iconOnly, custom mega-menu panel via Segment.component, icon-name resolution moved to framework (resolveDropdownIcons)
- bun engine: module federation for project-local components in the compiled binary (federationRegistry + userComponentsFederation, server + client chunks)
- Icon: image-source support (local svg/png paths bypass icon-set context)

e2e: __tests__/e2e/7.themes/4.terrarium (35 tests x 2 engines), unit tests for sidebar filter + active logoTrailing item; docs guides + schema regenerated.