### PR TITLE
feat(navigation): sidebar-as-toc — asToc groups compose into one page…

### DIFF
--- a/__tests__/e2e/1.navigation/5.sidebar-as-toc/docs.json
+++ b/__tests__/e2e/1.navigation/5.sidebar-as-toc/docs.json
@@ -1,0 +1,46 @@
+{
+    "theme": {
+        "name": "poetry",
+        "appearance": {
+            "content": {
+                "breadcrumbs": true
+            }
+        }
+    },
+    "navigation": {
+        "sidebar": [
+            {
+                "group": "Operating Systems",
+                "asToc": true,
+                "pages": [
+                    "operating-systems/linux",
+                    "operating-systems/windows",
+                    "operating-systems/macos"
+                ]
+            },
+            {
+                "group": "Programming Languages",
+                "asToc": {},
+                "pages": [
+                    "programming-languages/python",
+                    "programming-languages/javascript",
+                    "programming-languages/java"
+                ]
+            },
+            {
+                "group": "Tools",
+                "asToc": { "indicator": false },
+                "pages": [
+                    "tools/git"
+                ]
+            },
+            {
+                "group": "Resources",
+                "pages": [
+                    "resources/getting-help",
+                    "resources/faq"
+                ]
+            }
+        ]
+    }
+}

--- a/__tests__/e2e/1.navigation/5.sidebar-as-toc/index.md
+++ b/__tests__/e2e/1.navigation/5.sidebar-as-toc/index.md
@@ -1,0 +1,9 @@
+---
+title: Overview
+description: One page composed from the sidebar's asToc sections
+---
+
+# Overview
+
+This page is composed from the sidebar's `asToc` sections. Scroll or click a
+sidebar item to jump to its section.

--- a/__tests__/e2e/1.navigation/5.sidebar-as-toc/operating-systems/linux.md
+++ b/__tests__/e2e/1.navigation/5.sidebar-as-toc/operating-systems/linux.md
@@ -1,0 +1,23 @@
+---
+title: Linux
+---
+
+# Linux
+
+Linux is a family of open-source Unix-like operating systems.
+
+## Linux details
+
+Long-form details about Linux so each section has real height to scroll
+through. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+## Linux notes
+
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste
+natus error sit voluptatem accusantium doloremque laudantium.

--- a/__tests__/e2e/1.navigation/5.sidebar-as-toc/operating-systems/macos.md
+++ b/__tests__/e2e/1.navigation/5.sidebar-as-toc/operating-systems/macos.md
@@ -1,0 +1,23 @@
+---
+title: macOS
+---
+
+# macOS
+
+macOS is the operating system for Apple's Mac computers.
+
+## macOS details
+
+Long-form details about macOS so each section has real height to scroll
+through. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+## macOS notes
+
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste
+natus error sit voluptatem accusantium doloremque laudantium.

--- a/__tests__/e2e/1.navigation/5.sidebar-as-toc/operating-systems/windows.md
+++ b/__tests__/e2e/1.navigation/5.sidebar-as-toc/operating-systems/windows.md
@@ -1,0 +1,23 @@
+---
+title: Windows
+---
+
+# Windows
+
+Windows is a graphical operating system family by Microsoft.
+
+## Windows details
+
+Long-form details about Windows so each section has real height to scroll
+through. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+## Windows notes
+
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste
+natus error sit voluptatem accusantium doloremque laudantium.

--- a/__tests__/e2e/1.navigation/5.sidebar-as-toc/programming-languages/java.md
+++ b/__tests__/e2e/1.navigation/5.sidebar-as-toc/programming-languages/java.md
@@ -1,0 +1,23 @@
+---
+title: Java
+---
+
+# Java
+
+Java is a class-based, object-oriented programming language.
+
+## Java details
+
+Long-form details about Java so each section has real height to scroll
+through. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+## Java notes
+
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste
+natus error sit voluptatem accusantium doloremque laudantium.

--- a/__tests__/e2e/1.navigation/5.sidebar-as-toc/programming-languages/javascript.md
+++ b/__tests__/e2e/1.navigation/5.sidebar-as-toc/programming-languages/javascript.md
@@ -1,0 +1,23 @@
+---
+title: JavaScript
+---
+
+# JavaScript
+
+JavaScript is the scripting language of the Web.
+
+## JavaScript details
+
+Long-form details about JavaScript so each section has real height to scroll
+through. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+## JavaScript notes
+
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste
+natus error sit voluptatem accusantium doloremque laudantium.

--- a/__tests__/e2e/1.navigation/5.sidebar-as-toc/programming-languages/python.md
+++ b/__tests__/e2e/1.navigation/5.sidebar-as-toc/programming-languages/python.md
@@ -1,0 +1,23 @@
+---
+title: Python
+---
+
+# Python
+
+Python is a high-level, general-purpose programming language.
+
+## Python details
+
+Long-form details about Python so each section has real height to scroll
+through. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+eiusmod tempor incididunt ut labore et dolore magna aliqua.
+
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in
+voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+
+## Python notes
+
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+deserunt mollit anim id est laborum. Sed ut perspiciatis unde omnis iste
+natus error sit voluptatem accusantium doloremque laudantium.

--- a/__tests__/e2e/1.navigation/5.sidebar-as-toc/resources/faq.md
+++ b/__tests__/e2e/1.navigation/5.sidebar-as-toc/resources/faq.md
@@ -1,0 +1,11 @@
+---
+title: FAQ
+---
+
+# FAQ
+
+Frequently asked questions.
+
+## Is this a real page?
+
+Yes — unlike asToc sections, Resources pages are real routes.

--- a/__tests__/e2e/1.navigation/5.sidebar-as-toc/resources/getting-help.md
+++ b/__tests__/e2e/1.navigation/5.sidebar-as-toc/resources/getting-help.md
@@ -1,0 +1,11 @@
+---
+title: Getting Help
+---
+
+# Getting Help
+
+A normal, routable page — clicking it in the sidebar navigates here.
+
+## Support channels
+
+Ask in the community forum or open an issue.

--- a/__tests__/e2e/1.navigation/5.sidebar-as-toc/sidebar-as-toc.test.ts
+++ b/__tests__/e2e/1.navigation/5.sidebar-as-toc/sidebar-as-toc.test.ts
@@ -1,0 +1,236 @@
+import { test, expect, Page } from '@playwright/test';
+
+import { createXydServer, createXydBunServer, XydServer } from '../../utils/xyd-server';
+
+// sidebar-as-TOC (`asToc: true` sidebar groups): the groups' pages are NOT
+// real pages — their content is composed into ONE host page (here: the root
+// index) as `[data-astoc-section]` sections. The sidebar items act as that
+// page's TOC: clicking scrolls (hash only, no route change), scrolling marks
+// the matching item active, and the right-hand TOC is hidden on the host.
+// Normal groups ("Resources") keep normal page navigation. Run on BOTH
+// engines — they exercise DIFFERENT pagemap implementations (Rust vs JS).
+const ENGINES: { name: string; make: (dir: string) => Promise<XydServer> }[] = [
+    { name: 'bun', make: (dir) => createXydBunServer(dir) },
+    { name: 'vite', make: (dir) => createXydServer(dir) },
+];
+
+const SECTION_IDS = [
+    'operating-systems-linux',
+    'operating-systems-windows',
+    'operating-systems-macos',
+    'programming-languages-python',
+    'programming-languages-javascript',
+    'programming-languages-java',
+    'tools-git',
+];
+
+for (const engine of ENGINES) {
+    test.describe(`navigation — sidebar-as-toc (${engine.name} engine)`, () => {
+        // One dev server per engine: without serial mode every parallel worker
+        // would run beforeAll and boot its OWN server — concurrent vite boots
+        // regularly exceed the 2-minute start timeout on a loaded machine.
+        test.describe.configure({ mode: 'serial' });
+
+        let server: XydServer;
+
+        test.beforeAll(async () => {
+            server = await engine.make(__dirname);
+        });
+
+        test.afterAll(async () => {
+            await server?.stop();
+        });
+
+        async function goto(page: Page, path: string) {
+            await page.goto(server.getUrl(path));
+            await page.waitForLoadState('networkidle');
+        }
+
+        const sidebar = (page: Page) => page.locator('aside[part="sidebar"]');
+        const itemLink = (page: Page, sectionId: string) =>
+            sidebar(page).locator(`a[href$="#${sectionId}"]`);
+
+        test('sidebar renders asToc items with frontmatter titles under their group headers', async ({ page }) => {
+            await goto(page, '/');
+
+            // innerText reflects CSS text-transform (poetry uppercases group
+            // headers) — compare case-insensitively.
+            const headers = await sidebar(page).locator('[part="item-header"]').allInnerTexts();
+            expect(headers.map(h => h.trim().toLowerCase())).toEqual(
+                expect.arrayContaining(['operating systems', 'programming languages', 'tools', 'resources'])
+            );
+
+            for (const title of ['Linux', 'Windows', 'macOS', 'Python', 'JavaScript', 'Java', 'Git']) {
+                await expect(sidebar(page).getByText(title, { exact: true })).toBeVisible();
+            }
+
+            // asToc items link to host + section anchors, not to page routes
+            for (const id of SECTION_IDS) {
+                await expect(itemLink(page, id)).toHaveCount(1);
+            }
+        });
+
+        test('the host page contains every section in config order, intro first', async ({ page }) => {
+            await goto(page, '/');
+
+            const ids = await page
+                .locator('[data-astoc-section]')
+                .evaluateAll(els => els.map(el => el.id));
+            expect(ids).toEqual(SECTION_IDS);
+
+            await expect(page.getByRole('heading', { name: 'Overview' })).toBeVisible();
+            // Intro renders before the first section
+            const introY = (await page.getByRole('heading', { name: 'Overview' }).boundingBox())!.y;
+            const firstSectionY = (await page.locator('#operating-systems-linux').boundingBox())!.y;
+            expect(introY).toBeLessThan(firstSectionY);
+
+            // Section content is really injected
+            await expect(page.locator('#operating-systems-linux')).toContainText('family of open-source');
+            await expect(page.locator('#programming-languages-java')).toContainText('object-oriented');
+        });
+
+        test('clicking an asToc item scrolls to its section without navigating', async ({ page }) => {
+            await goto(page, '/');
+
+            await itemLink(page, 'operating-systems-macos').click();
+
+            // hash updates via history.replaceState; pathname must NOT change
+            await expect.poll(async () => page.evaluate(() => window.location.hash))
+                .toBe('#operating-systems-macos');
+            expect(await page.evaluate(() => window.location.pathname)).toBe('/');
+
+            // the section lands near the top of the viewport (smooth scroll)
+            await expect.poll(async () => {
+                const box = await page.locator('#operating-systems-macos').boundingBox();
+                return box ? Math.abs(box.y) : Infinity;
+            }, { timeout: 5000 }).toBeLessThan(150);
+        });
+
+        test('scrolling marks the matching sidebar item active (scroll-spy)', async ({ page }) => {
+            await goto(page, '/');
+
+            const activeMarker = (id: string) =>
+                itemLink(page, id).locator('[part="primary-item"][data-active="true"]');
+
+            // scroll to a late section
+            await page.evaluate(() => {
+                const el = document.getElementById('programming-languages-java');
+                window.scrollTo(0, el!.getBoundingClientRect().top + window.pageYOffset - 40);
+            });
+            await expect.poll(async () => activeMarker('programming-languages-java').count())
+                .toBe(1);
+
+            // scroll back to an earlier section — active follows
+            await page.evaluate(() => {
+                const el = document.getElementById('operating-systems-windows');
+                window.scrollTo(0, el!.getBoundingClientRect().top + window.pageYOffset - 40);
+            });
+            await expect.poll(async () => activeMarker('operating-systems-windows').count())
+                .toBe(1);
+            expect(await activeMarker('programming-languages-java').count()).toBe(0);
+        });
+
+        test('the right-hand TOC is hidden on the host page but present on a normal page', async ({ page }) => {
+            await goto(page, '/');
+            await expect(page.locator('xyd-toc')).toHaveCount(0);
+
+            await goto(page, '/resources/getting-help');
+            await expect(page.locator('xyd-toc')).toHaveCount(1);
+        });
+
+        test('normal-group items navigate; an asToc item from there returns to the host + hash', async ({ page }) => {
+            await goto(page, '/');
+
+            await sidebar(page).locator('a[href$="/resources/getting-help"]').click();
+            await expect.poll(async () => page.evaluate(() => window.location.pathname))
+                .toContain('/resources/getting-help');
+            await expect(page.getByRole('heading', { name: 'Getting Help' })).toBeVisible();
+
+            // Off-host, an asToc item is a normal link to <host>#<section> —
+            // it navigates back to the host and scrolls to the section.
+            await itemLink(page, 'programming-languages-python').click();
+            await expect.poll(async () => page.evaluate(() => window.location.pathname))
+                .toBe('/');
+            await expect.poll(async () => page.evaluate(() => window.location.hash))
+                .toBe('#programming-languages-python');
+            await expect.poll(async () => {
+                const box = await page.locator('#programming-languages-python').boundingBox();
+                return box ? Math.abs(box.y) : Infinity;
+            }, { timeout: 5000 }).toBeLessThan(300);
+        });
+
+        test('asToc section paths are NOT real pages — direct visits 404', async ({ page }) => {
+            const resp = await page.goto(server.getUrl('/operating-systems/linux'));
+            expect(resp?.status()).toBe(404);
+        });
+
+        test('CONSECUTIVE asToc groups share ONE TOC track; `indicator: false` opts out', async ({ page }) => {
+            await goto(page, '/');
+
+            // "Operating Systems" (asToc: true) and "Programming Languages"
+            // (asToc: {}) are adjacent — they merge into a SINGLE [data-astoc]
+            // wrapper (headers included) so ONE continuous line spans both,
+            // never a broken per-group line.
+            const wrappers = sidebar(page).locator('[part="item-group"][data-astoc="true"]');
+            await expect(wrappers).toHaveCount(1);
+
+            const wrapper = wrappers.first();
+            await expect(wrapper.locator('a[href$="#operating-systems-linux"]')).toHaveCount(1);
+            await expect(wrapper.locator('a[href$="#programming-languages-python"]')).toHaveCount(1);
+            const headerTexts = await wrapper.locator('[part="item-header"]').allInnerTexts();
+            expect(headerTexts.map(h => h.trim().toLowerCase()))
+                .toEqual(['operating systems', 'programming languages']);
+
+            // "Tools" (asToc: { indicator: false }) — plain look, outside the
+            // wrapper, but its items are still asToc sections (hash hrefs).
+            await expect(wrapper.locator('a[href$="#tools-git"]')).toHaveCount(0);
+            await expect(itemLink(page, 'tools-git')).toHaveCount(1);
+
+            // the wrapper actually draws the track (pseudo-element with 2px width)
+            const trackWidth = await wrapper.evaluate(
+                (el) => getComputedStyle(el, '::before').width,
+            );
+            expect(trackWidth).toBe('2px');
+        });
+
+        test('host-page breadcrumbs follow the section being read', async ({ page }) => {
+            await goto(page, '/');
+
+            const crumbTexts = () => page.locator('xyd-breadcrumbs [part="item"]').allInnerTexts();
+
+            // at the top the first section is active → "Operating Systems / Linux"
+            await expect.poll(crumbTexts).toEqual(['Operating Systems', 'Linux']);
+
+            // scroll to a later section → crumbs follow (breadcrumbs stay
+            // enabled for the indicator-less group — options are independent)
+            await page.evaluate(() => {
+                const el = document.getElementById('programming-languages-java');
+                window.scrollTo(0, el!.getBoundingClientRect().top + window.pageYOffset - 40);
+            });
+            await expect.poll(crumbTexts).toEqual(['Programming Languages', 'Java']);
+        });
+
+        test('joined sections are visually separated and clear the sticky header on scroll', async ({ page }) => {
+            await goto(page, '/');
+
+            const second = page.locator('#operating-systems-windows');
+            const marginTop = await second.evaluate((el) => getComputedStyle(el).marginTop);
+            expect(parseFloat(marginTop)).toBeGreaterThanOrEqual(32);
+
+            const scrollMargin = await second.evaluate((el) => getComputedStyle(el).scrollMarginTop);
+            expect(parseFloat(scrollMargin)).toBeGreaterThan(0);
+        });
+
+        test('prev/next navlinks skip asToc sections', async ({ page }) => {
+            await goto(page, '/resources/getting-help');
+
+            const links = page.locator('xyd-navlinks [part="link"]');
+            const texts = (await links.allInnerTexts()).join(' ');
+            // next → FAQ (the only other real page); no section ever appears
+            expect(texts).toContain('FAQ');
+            for (const sectionTitle of ['Linux', 'Windows', 'macOS', 'Python', 'JavaScript', 'Java', 'Git']) {
+                expect(texts).not.toContain(sectionTitle);
+            }
+        });
+    });
+}

--- a/__tests__/e2e/1.navigation/5.sidebar-as-toc/tools/git.md
+++ b/__tests__/e2e/1.navigation/5.sidebar-as-toc/tools/git.md
@@ -1,0 +1,16 @@
+---
+title: Git
+---
+
+# Git
+
+Git is a distributed version control system.
+
+## Git basics
+
+Commits, branches, and merges — the building blocks of every workflow.
+
+## Git notes
+
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia
+deserunt mollit anim id est laborum.

--- a/crates/xyd_settings/fixtures/pagemap/content/toc/alpha.md
+++ b/crates/xyd_settings/fixtures/pagemap/content/toc/alpha.md
@@ -1,0 +1,5 @@
+---
+title: alpha
+---
+
+# alpha

--- a/crates/xyd_settings/fixtures/pagemap/content/toc/beta.md
+++ b/crates/xyd_settings/fixtures/pagemap/content/toc/beta.md
@@ -1,0 +1,5 @@
+---
+title: beta
+---
+
+# beta

--- a/crates/xyd_settings/fixtures/pagemap/content/toc/nested.md
+++ b/crates/xyd_settings/fixtures/pagemap/content/toc/nested.md
@@ -1,0 +1,5 @@
+---
+title: nested
+---
+
+# nested

--- a/crates/xyd_settings/fixtures/pagemap/content/toc/routed.md
+++ b/crates/xyd_settings/fixtures/pagemap/content/toc/routed.md
@@ -1,0 +1,5 @@
+---
+title: routed
+---
+
+# routed

--- a/crates/xyd_settings/fixtures/pagemap/nav.json
+++ b/crates/xyd_settings/fixtures/pagemap/nav.json
@@ -1,6 +1,8 @@
 {
   "sidebar": [
-    { "group": "Docs", "pages": ["content/docs/intro", "content/docs/setup", { "group": "API", "pages": ["content/docs/api/users", "content/docs/api/missing"] }] },
-    { "route": "/guides", "pages": [{ "group": "G", "pages": ["content/guides/welcome"] }, "content/guides/toplevel-missing"] }
+    { "group": "Docs", "pages": ["content/docs/intro", "content/docs/setup", { "group": "API", "pages": ["content/docs/api/users", "content/docs/api/missing"] }, { "group": "NestedToc", "asToc": true, "pages": ["content/toc/nested"] }] },
+    { "group": "TopToc", "asToc": true, "pages": ["content/toc/alpha"] },
+    { "group": "ObjectToc", "asToc": { "indicator": false }, "pages": ["content/toc/beta"] },
+    { "route": "/guides", "pages": [{ "group": "G", "pages": ["content/guides/welcome"] }, { "group": "RoutedToc", "asToc": true, "pages": ["content/toc/routed"] }, "content/guides/toplevel-missing"] }
   ]
 }

--- a/crates/xyd_settings/src/pagemap.rs
+++ b/crates/xyd_settings/src/pagemap.rs
@@ -14,6 +14,18 @@
 use serde_json::{Map, Value};
 use std::path::Path;
 
+/// `asToc` sidebar groups are sidebar-as-TOC: their pages are sections of the
+/// host page, NOT routable pages — the walk skips the whole subtree (mirrors
+/// the JS gate `asTocEnabled` in @xyd-js/core; the JS-side collector picks the
+/// sections up separately). `true` or an options OBJECT enables (the object
+/// form carries behavior tweaks); `false`/absent/junk disables.
+fn is_as_toc(obj: &Map<String, Value>) -> bool {
+    matches!(
+        obj.get("asToc"),
+        Some(Value::Bool(true)) | Some(Value::Object(_))
+    )
+}
+
 /// Resolve one cwd-relative base path to `base.md` or `base.mdx` (md wins),
 /// returning the RELATIVE path WITH extension, or None. Probes against `cwd`.
 fn existing_file_path(cwd: &Path, base: &str) -> Option<String> {
@@ -58,7 +70,9 @@ impl<'a> Walker<'a> {
                             self.set(page_key, p);
                         }
                     } else if let Some(nested) = obj.get("pages").and_then(|p| p.as_array()) {
-                        self.process_pages(nested);
+                        if !is_as_toc(obj) {
+                            self.process_pages(nested);
+                        }
                     }
                 }
                 _ => {}
@@ -96,7 +110,9 @@ impl<'a> Walker<'a> {
                                         if let Some(nested) =
                                             io.get("pages").and_then(|p| p.as_array())
                                         {
-                                            self.process_pages(nested);
+                                            if !is_as_toc(io) {
+                                                self.process_pages(nested);
+                                            }
                                         }
                                     }
                                     Value::String(s) => {
@@ -111,7 +127,9 @@ impl<'a> Walker<'a> {
                     } else if has_pages {
                         // (c) plain Sidebar group
                         if let Some(pages) = obj.get("pages").and_then(|p| p.as_array()) {
-                            self.process_pages(pages);
+                            if !is_as_toc(obj) {
+                                self.process_pages(pages);
+                            }
                         }
                     }
                 }

--- a/packages/xyd-components/src/content/ContentDecoator.styles.tsx
+++ b/packages/xyd-components/src/content/ContentDecoator.styles.tsx
@@ -173,6 +173,20 @@ export default {
             [data-content-element]:not([data-content-element="false"]) {
                 margin-top: var(--space-medium);
             }
+
+            /* sidebar-as-TOC composed sections: joined page bodies each start
+               with their own h1, which has no top margin (it's normally the
+               first element of a page) — the section wrapper provides the
+               separation between joined sections instead. scroll-margin keeps
+               anchor scrolls (sidebar item clicks, #hash landings) from hiding
+               the section heading under the sticky header stack. */
+            [data-astoc-section] {
+                display: block;
+                scroll-margin-top: calc(var(--xyd-header-total-height, 60px) + var(--space-medium));
+            }
+            [data-astoc-section]:not(:first-child) {
+                margin-top: var(--space-2xlarge);
+            }
         }
     `
 }

--- a/packages/xyd-content/__tests__/asToc.test.ts
+++ b/packages/xyd-content/__tests__/asToc.test.ts
@@ -12,27 +12,29 @@ import { composeAsTocRaw, asTocHostFor, isAsTocSectionPage } from "../src";
  * frontmatter (always with `asTocHost: true`) + the host's intro + every
  * section wrapped in `<div id="<sectionId>" data-astoc-section>`.
  * The recipe comes from globalThis.__xydAsTocPages (set by plugin-docs boot).
+ *
+ * The fake data plane uses ABSOLUTE file paths into a tmp dir — no
+ * process.chdir (unsupported in vitest worker threads: this package's local
+ * vitest 1.x runs the threads pool).
  */
 describe("composeAsTocRaw", () => {
     let tmpDir: string;
-    let prevCwd: string;
 
     beforeEach(() => {
-        prevCwd = process.cwd();
         tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "xyd-astoc-compose-"));
-        process.chdir(tmpDir);
     });
 
     afterEach(() => {
-        process.chdir(prevCwd);
         fs.rmSync(tmpDir, { recursive: true, force: true });
         delete (globalThis as any).__xydAsTocPages;
     });
 
-    function write(rel: string, content: string) {
+    /** writes rel under tmpDir, returns the ABSOLUTE path */
+    function write(rel: string, content: string): string {
         const abs = path.join(tmpDir, rel);
         fs.mkdirSync(path.dirname(abs), { recursive: true });
         fs.writeFileSync(abs, content);
+        return abs;
     }
 
     function setAsTocPages(hosts: any, pages: any = {}) {
@@ -46,22 +48,22 @@ describe("composeAsTocRaw", () => {
     });
 
     it("composes intro + wrapped sections and flags asTocHost in frontmatter", async () => {
-        write("index.md", "---\ntitle: Welcome\n---\n\nIntro text.\n");
-        write("os/linux.md", "---\ntitle: Linux\n---\n\n# Linux\n\nLinux content.\n");
-        write("os/windows.md", "---\ntitle: Windows\n---\n\nWindows content without heading.\n");
+        const indexFile = write("index.md", "---\ntitle: Welcome\n---\n\nIntro text.\n");
+        const linuxFile = write("os/linux.md", "---\ntitle: Linux\n---\n\n# Linux\n\nLinux content.\n");
+        const windowsFile = write("os/windows.md", "---\ntitle: Windows\n---\n\nWindows content without heading.\n");
         setAsTocPages({
             index: {
-                indexFile: "index.md",
+                indexFile,
                 sections: [
-                    { page: "os/linux", file: "os/linux.md", id: "os-linux" },
-                    { page: "os/windows", file: "os/windows.md", id: "os-windows" },
+                    { page: "os/linux", file: linuxFile, id: "os-linux" },
+                    { page: "os/windows", file: windowsFile, id: "os-windows" },
                 ],
             },
         });
 
         const composed = await composeAsTocRaw("index");
         expect(composed).not.toBeNull();
-        expect(composed!.filePath).toBe("index.md");
+        expect(composed!.filePath).toBe(indexFile);
 
         const parsed = matter(composed!.raw);
         // host frontmatter preserved + flagged
@@ -83,11 +85,11 @@ describe("composeAsTocRaw", () => {
     });
 
     it("synthesizes frontmatter when the host has no intro file", async () => {
-        write("os/linux.md", "---\ntitle: Linux\n---\n\ncontent\n");
+        const linuxFile = write("os/linux.md", "---\ntitle: Linux\n---\n\ncontent\n");
         setAsTocPages({
             index: {
                 indexFile: "",
-                sections: [{ page: "os/linux", file: "os/linux.md", id: "os-linux" }],
+                sections: [{ page: "os/linux", file: linuxFile, id: "os-linux" }],
             },
         });
 
@@ -99,13 +101,13 @@ describe("composeAsTocRaw", () => {
     });
 
     it("skips sections whose file vanished", async () => {
-        write("a.md", "---\ntitle: A\n---\n\na\n");
+        const aFile = write("a.md", "---\ntitle: A\n---\n\na\n");
         setAsTocPages({
             index: {
                 indexFile: "",
                 sections: [
-                    { page: "a", file: "a.md", id: "a" },
-                    { page: "gone", file: "gone.md", id: "gone" },
+                    { page: "a", file: aFile, id: "a" },
+                    { page: "gone", file: path.join(tmpDir, "gone.md"), id: "gone" },
                 ],
             },
         });
@@ -116,11 +118,11 @@ describe("composeAsTocRaw", () => {
     });
 
     it("normalizes the slug (leading slash / empty → index) and resolves route hosts", async () => {
-        write("docs.md", "---\ntitle: Docs\n---\n\nintro\n");
-        write("s.md", "s content\n");
+        const docsFile = write("docs.md", "---\ntitle: Docs\n---\n\nintro\n");
+        const sFile = write("s.md", "s content\n");
         setAsTocPages(
             {
-                docs: { indexFile: "docs.md", sections: [{ page: "s", file: "s.md", id: "s" }] },
+                docs: { indexFile: docsFile, sections: [{ page: "s", file: sFile, id: "s" }] },
             },
             { s: { host: "docs", id: "s" } }
         );

--- a/packages/xyd-content/__tests__/asToc.test.ts
+++ b/packages/xyd-content/__tests__/asToc.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import matter from "gray-matter";
+
+import { composeAsTocRaw, asTocHostFor, isAsTocSectionPage } from "../src";
+
+/**
+ * composeAsTocRaw builds ONE raw markdown for a sidebar-as-TOC host page:
+ * frontmatter (always with `asTocHost: true`) + the host's intro + every
+ * section wrapped in `<div id="<sectionId>" data-astoc-section>`.
+ * The recipe comes from globalThis.__xydAsTocPages (set by plugin-docs boot).
+ */
+describe("composeAsTocRaw", () => {
+    let tmpDir: string;
+    let prevCwd: string;
+
+    beforeEach(() => {
+        prevCwd = process.cwd();
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "xyd-astoc-compose-"));
+        process.chdir(tmpDir);
+    });
+
+    afterEach(() => {
+        process.chdir(prevCwd);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+        delete (globalThis as any).__xydAsTocPages;
+    });
+
+    function write(rel: string, content: string) {
+        const abs = path.join(tmpDir, rel);
+        fs.mkdirSync(path.dirname(abs), { recursive: true });
+        fs.writeFileSync(abs, content);
+    }
+
+    function setAsTocPages(hosts: any, pages: any = {}) {
+        (globalThis as any).__xydAsTocPages = { hosts, pages };
+    }
+
+    it("returns null for non-host slugs", async () => {
+        setAsTocPages({});
+        expect(await composeAsTocRaw("index")).toBeNull();
+        expect(asTocHostFor("index")).toBeNull();
+    });
+
+    it("composes intro + wrapped sections and flags asTocHost in frontmatter", async () => {
+        write("index.md", "---\ntitle: Welcome\n---\n\nIntro text.\n");
+        write("os/linux.md", "---\ntitle: Linux\n---\n\n# Linux\n\nLinux content.\n");
+        write("os/windows.md", "---\ntitle: Windows\n---\n\nWindows content without heading.\n");
+        setAsTocPages({
+            index: {
+                indexFile: "index.md",
+                sections: [
+                    { page: "os/linux", file: "os/linux.md", id: "os-linux" },
+                    { page: "os/windows", file: "os/windows.md", id: "os-windows" },
+                ],
+            },
+        });
+
+        const composed = await composeAsTocRaw("index");
+        expect(composed).not.toBeNull();
+        expect(composed!.filePath).toBe("index.md");
+
+        const parsed = matter(composed!.raw);
+        // host frontmatter preserved + flagged
+        expect(parsed.data.title).toBe("Welcome");
+        expect(parsed.data.asTocHost).toBe(true);
+        // intro first, then sections in order
+        const linuxAt = parsed.content.indexOf('<div id="os-linux" data-astoc-section>');
+        const windowsAt = parsed.content.indexOf('<div id="os-windows" data-astoc-section>');
+        expect(parsed.content.indexOf("Intro text.")).toBeGreaterThanOrEqual(0);
+        expect(linuxAt).toBeGreaterThan(parsed.content.indexOf("Intro text."));
+        expect(windowsAt).toBeGreaterThan(linuxAt);
+        // section frontmatter is stripped, content kept
+        expect(parsed.content).not.toContain("title: Linux");
+        expect(parsed.content).toContain("Linux content.");
+        // a section without a leading heading gets one from its title
+        expect(parsed.content).toContain("# Windows\n\nWindows content without heading.");
+        // a section WITH a heading is not double-titled
+        expect(parsed.content).not.toContain("# Linux\n\n# Linux");
+    });
+
+    it("synthesizes frontmatter when the host has no intro file", async () => {
+        write("os/linux.md", "---\ntitle: Linux\n---\n\ncontent\n");
+        setAsTocPages({
+            index: {
+                indexFile: "",
+                sections: [{ page: "os/linux", file: "os/linux.md", id: "os-linux" }],
+            },
+        });
+
+        const composed = await composeAsTocRaw("index");
+        expect(composed!.filePath).toBe("index.md");
+        const parsed = matter(composed!.raw);
+        expect(parsed.data).toEqual({ asTocHost: true });
+        expect(parsed.content).toContain('data-astoc-section');
+    });
+
+    it("skips sections whose file vanished", async () => {
+        write("a.md", "---\ntitle: A\n---\n\na\n");
+        setAsTocPages({
+            index: {
+                indexFile: "",
+                sections: [
+                    { page: "a", file: "a.md", id: "a" },
+                    { page: "gone", file: "gone.md", id: "gone" },
+                ],
+            },
+        });
+
+        const composed = await composeAsTocRaw("index");
+        expect(composed!.raw).toContain('<div id="a"');
+        expect(composed!.raw).not.toContain('id="gone"');
+    });
+
+    it("normalizes the slug (leading slash / empty → index) and resolves route hosts", async () => {
+        write("docs.md", "---\ntitle: Docs\n---\n\nintro\n");
+        write("s.md", "s content\n");
+        setAsTocPages(
+            {
+                docs: { indexFile: "docs.md", sections: [{ page: "s", file: "s.md", id: "s" }] },
+            },
+            { s: { host: "docs", id: "s" } }
+        );
+
+        expect(await composeAsTocRaw("/docs")).not.toBeNull();
+        expect(await composeAsTocRaw("index")).toBeNull();
+        expect(isAsTocSectionPage("s")).toBe(true);
+        expect(isAsTocSectionPage("/s")).toBe(true);
+        expect(isAsTocSectionPage("other")).toBe(false);
+    });
+});

--- a/packages/xyd-content/packages/md/search/index.ts
+++ b/packages/xyd-content/packages/md/search/index.ts
@@ -11,6 +11,7 @@ import type { Node } from 'mdast'
 import GitHubSlugger from 'github-slugger';
 
 import type { Settings, Sidebar, SidebarRoute } from '@xyd-js/core'
+import { asTocEnabled } from '@xyd-js/core'
 
 import { DocSectionSchema } from './types';
 import { markdownPlugins } from "../"
@@ -245,6 +246,11 @@ function flatPages(
 
         // Type guard to check if it's a Sidebar
         if ("group" in side) {
+            // sidebar-as-TOC group: its pages are sections of the host page,
+            // not standalone pages — the host page indexes their content.
+            if (asTocEnabled((side as Sidebar).asToc)) {
+                return
+            }
             const groupKey = side.group || "";
             if (groups[groupKey]) {
                 const link = groups[groupKey];

--- a/packages/xyd-content/src/asToc.ts
+++ b/packages/xyd-content/src/asToc.ts
@@ -1,0 +1,114 @@
+import fs from "fs/promises"
+
+import matter from "gray-matter"
+
+// ---------------------------------------------------------------------------
+// sidebar-as-TOC composition (`asToc: true` sidebar groups)
+//
+// The data plane (globalThis.__xydAsTocPages, owned by @xyd-js/plugin-docs)
+// records which section files compose into which host page. This module turns
+// that recipe into ONE raw markdown string: the host's own intro (if it has an
+// index file) followed by every section wrapped in an anchor container:
+//
+//   <div id="<sectionId>" data-astoc-section>
+//
+//   …section markdown (frontmatter stripped)…
+//
+//   </div>
+//
+// The wrapper ids are what the sidebar items scroll to — deterministic and
+// independent of heading slugs (which can collide across sections). Both page
+// loaders (vite + bun) call composeAsTocRaw() first and fall through to the
+// normal single-file compile when it returns null.
+// ---------------------------------------------------------------------------
+
+interface AsTocSectionLike {
+    page: string
+    file: string
+    id: string
+}
+
+interface AsTocHostLike {
+    indexFile: string
+    sections: AsTocSectionLike[]
+}
+
+interface AsTocPagesLike {
+    hosts: Record<string, AsTocHostLike>
+    pages: Record<string, { host: string, id: string }>
+}
+
+function asTocPages(): AsTocPagesLike | undefined {
+    return (globalThis as any).__xydAsTocPages
+}
+
+/** Normalized host lookup ("" / "/" → "index"). */
+export function asTocHostFor(slug: string): AsTocHostLike | null {
+    const key = slug?.replace(/^\//, "") || "index"
+    return asTocPages()?.hosts?.[key] || null
+}
+
+/** True when `slug` is a section page of an asToc group (⇒ not routable). */
+export function isAsTocSectionPage(slug: string): boolean {
+    const key = slug?.replace(/^\//, "") || ""
+    return !!asTocPages()?.pages?.[key]
+}
+
+export interface ComposedAsToc {
+    /** the full composed markdown (frontmatter + intro + wrapped sections) */
+    raw: string
+    /** path to compile against (host intro file, or a synthetic index.md) */
+    filePath: string
+}
+
+/**
+ * Compose the raw markdown for an asToc host page, or null when `slug` is not
+ * a host. The composed frontmatter always carries `asTocHost: true` so the
+ * post-mount metadata source hides the right-hand TOC too. Sections whose file
+ * vanished since boot are skipped (dev resilience). A section without a
+ * leading `#` heading gets one injected from its frontmatter title so every
+ * section stays visible/scannable in the composed page.
+ */
+export async function composeAsTocRaw(slug: string): Promise<ComposedAsToc | null> {
+    const host = asTocHostFor(slug)
+    if (!host || !host.sections.length) return null
+
+    let intro = ""
+    let frontmatter: Record<string, any> = {}
+    if (host.indexFile) {
+        try {
+            const parsed = matter(await fs.readFile(host.indexFile, "utf-8"))
+            frontmatter = { ...(parsed.data || {}) }
+            intro = parsed.content.trim()
+        } catch {
+            // treat as no intro
+        }
+    }
+    frontmatter.asTocHost = true
+
+    const parts: string[] = []
+    for (const section of host.sections) {
+        let parsed: matter.GrayMatterFile<string>
+        try {
+            parsed = matter(await fs.readFile(section.file, "utf-8"))
+        } catch {
+            continue
+        }
+        let body = parsed.content.trim()
+        const title = parsed.data?.title
+        if (typeof title === "string" && title && !body.startsWith("#")) {
+            body = `# ${title}\n\n${body}`
+        }
+        parts.push(`\n\n<div id="${section.id}" data-astoc-section>\n\n${body}\n\n</div>\n`)
+    }
+
+    if (!parts.length && !intro) return null
+
+    // matter.stringify emits `---\n<yaml>\n---\n<content>`
+    const raw = matter.stringify(intro, frontmatter) + parts.join("")
+
+    return {
+        raw,
+        filePath: host.indexFile || "index.md",
+    }
+}

--- a/packages/xyd-content/src/index.ts
+++ b/packages/xyd-content/src/index.ts
@@ -4,4 +4,11 @@ export {
     pageFrontMatters,
 } from "./navigation"
 
+export {
+    composeAsTocRaw,
+    asTocHostFor,
+    isAsTocSectionPage,
+} from "./asToc"
+export type { ComposedAsToc } from "./asToc"
+
 export type { VarCode } from "./types"

--- a/packages/xyd-core/__tests__/asToc.test.ts
+++ b/packages/xyd-core/__tests__/asToc.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+
+import { asTocEnabled, asTocOptions } from "../src/asToc";
+
+/**
+ * `asToc` accepts `true` or an options object (both enable), everything else
+ * disables. The Rust pagemap gate (crates/xyd_settings/src/pagemap.rs
+ * `is_as_toc`) mirrors asTocEnabled — these cases document the shared contract.
+ */
+describe("asTocEnabled / asTocOptions", () => {
+    it("boolean forms", () => {
+        expect(asTocEnabled(true)).toBe(true);
+        expect(asTocEnabled(false)).toBe(false);
+        expect(asTocEnabled(undefined)).toBe(false);
+    });
+
+    it("object forms enable (junk does not)", () => {
+        expect(asTocEnabled({})).toBe(true);
+        expect(asTocEnabled({ indicator: false })).toBe(true);
+        expect(asTocEnabled(null as any)).toBe(false);
+        expect(asTocEnabled("true" as any)).toBe(false);
+        expect(asTocEnabled(1 as any)).toBe(false);
+    });
+
+    it("resolves defaults: every behavior enabled", () => {
+        expect(asTocOptions(true)).toEqual({ indicator: true, breadcrumbs: true });
+        expect(asTocOptions({})).toEqual({ indicator: true, breadcrumbs: true });
+    });
+
+    it("object form disables selectively", () => {
+        expect(asTocOptions({ indicator: false })).toEqual({ indicator: false, breadcrumbs: true });
+        expect(asTocOptions({ breadcrumbs: false })).toEqual({ indicator: true, breadcrumbs: false });
+        expect(asTocOptions({ indicator: false, breadcrumbs: false }))
+            .toEqual({ indicator: false, breadcrumbs: false });
+    });
+
+    it("disabled values resolve to null", () => {
+        expect(asTocOptions(false)).toBeNull();
+        expect(asTocOptions(undefined)).toBeNull();
+    });
+});

--- a/packages/xyd-core/index.ts
+++ b/packages/xyd-core/index.ts
@@ -7,3 +7,5 @@ export * from "./src/types/settings";
 export * from "./src/types/page-api.i";
 
 export * from "./src/i18n/resolver";
+
+export * from "./src/asToc";

--- a/packages/xyd-core/src/asToc.ts
+++ b/packages/xyd-core/src/asToc.ts
@@ -1,0 +1,33 @@
+import type { Sidebar, SidebarAsTocOptions } from "./types/settings";
+
+/**
+ * sidebar-as-TOC normalization, shared by every sidebar walk (JS pagemap,
+ * route generation, prerender list, search indexing, navlinks, dev preload,
+ * the section collector, and the sidebar renderer). The Rust pagemap's gate
+ * (crates/xyd_settings/src/pagemap.rs `is_as_toc`) mirrors `asTocEnabled` —
+ * keep them in sync: `true` or any object enables, everything else disables.
+ */
+
+/** All options resolved to concrete booleans (defaults applied). */
+export interface ResolvedAsTocOptions {
+    indicator: boolean;
+    breadcrumbs: boolean;
+}
+
+/** Is this group a sidebar-as-TOC group? (`true` or `{...}` — `false`/absent is not.) */
+export function asTocEnabled(value: Sidebar["asToc"]): boolean {
+    return value === true || (typeof value === "object" && value !== null);
+}
+
+/**
+ * Resolve an `asToc` value to its full options (every behavior defaults to
+ * enabled), or `null` when the group is not an asToc group.
+ */
+export function asTocOptions(value: Sidebar["asToc"]): ResolvedAsTocOptions | null {
+    if (!asTocEnabled(value)) return null;
+    const opts: SidebarAsTocOptions = typeof value === "object" && value !== null ? value : {};
+    return {
+        indicator: opts.indicator !== false,
+        breadcrumbs: opts.breadcrumbs !== false,
+    };
+}

--- a/packages/xyd-core/src/types/metadata.ts
+++ b/packages/xyd-core/src/types/metadata.ts
@@ -23,6 +23,14 @@ export interface Metadata<P = void> {
     /** Layout type for the content display */
     layout?: PageLayout
 
+    /**
+     * @internal
+     *
+     * True on a page composed from `asToc: true` sidebar groups — the sidebar
+     * acts as this page's TOC (scroll-spy), so the right-hand TOC is hidden.
+     */
+    asTocHost?: boolean
+
     /** Max depth for table of contents */
     maxTocDepth?: number
 

--- a/packages/xyd-core/src/types/settings.ts
+++ b/packages/xyd-core/src/types/settings.ts
@@ -741,6 +741,36 @@ export interface Sidebar {
    * The order of the group.
    */
   order?: Order;
+
+  /**
+   * Treat this group's pages as a table of contents instead of real pages.
+   * Their markdown files are NOT routable (no routes, no prerender) — the
+   * content of every page is injected as a section into the enclosing route's
+   * index page, sidebar items scroll to those sections (with scroll-spy active
+   * marking), and the right-hand TOC is hidden on that composed page.
+   *
+   * `true` enables it with defaults; the object form tunes behaviors
+   * (all default to enabled).
+   */
+  asToc?: boolean | SidebarAsTocOptions;
+}
+
+/**
+ * Behavior options for an `asToc` sidebar group (the object form).
+ * Every option defaults to `true` — `asToc: true` ≡ `asToc: {}`.
+ */
+export interface SidebarAsTocOptions {
+  /**
+   * TOC-style visual indicator on the group's sidebar items (the vertical
+   * track line the right-hand TOC uses). Default `true`.
+   */
+  indicator?: boolean;
+
+  /**
+   * Breadcrumbs on the composed host page that follow the section being
+   * read (group name / section title, updated by scroll). Default `true`.
+   */
+  breadcrumbs?: boolean;
 }
 
 type Order = 0 | -1 | { after: string } | { before: string };

--- a/packages/xyd-documan/src/bun/buildStatic.ts
+++ b/packages/xyd-documan/src/bun/buildStatic.ts
@@ -222,6 +222,7 @@ export async function buildStatic(cwd: string = process.cwd()): Promise<void> {
     accessMap: (globalThis as any).__xydAccessMap || {},
     i18n: (globalThis as any).__xydI18n,
     i18nTranslations: (globalThis as any).__xydI18nTranslations,
+    asTocPages: (globalThis as any).__xydAsTocPages,
   });
 
   // 5) PUBLIC assets. Content references public files WITH the `public/` segment

--- a/packages/xyd-documan/src/bun/renderPage.tsx
+++ b/packages/xyd-documan/src/bun/renderPage.tsx
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import { mapSettingsToProps } from "@xyd-js/framework/hydration";
 import { resolveLocaleSettings } from "@xyd-js/framework/hydration/locale";
 import { markdownPlugins } from "@xyd-js/content/md";
-import { ContentFS } from "@xyd-js/content";
+import { ContentFS, composeAsTocRaw } from "@xyd-js/content";
 
 import { createRouterStore, RouterProvider } from "@xyd-js/router";
 
@@ -192,10 +192,13 @@ export async function buildPageData(slug: string, opts: { shellOnly?: boolean } 
   const fs = await contentFSFor(s, metadata?.maxTocDepth || s?.theme?.writer?.maxTocDepth || 2);
   const pagePath = globalThis.__xydPagePathMapping[slug];
   if (!pagePath) throw new Error(`No page mapping for slug: ${slug}`);
+  // sidebar-as-TOC host: the page is composed from its asToc groups' section
+  // files (intro + wrapped sections) instead of the mapped single file.
+  const composed = await composeAsTocRaw(slug);
   // Read the file once (compile() would read it again internally); compileContent
   // is exactly what compile() runs after reading, so this is byte-identical.
-  const rawPage = await fs.readRaw(pagePath);
-  const code = await fs.compileContent(rawPage, pagePath);
+  const rawPage = composed ? composed.raw : await fs.readRaw(pagePath);
+  const code = await fs.compileContent(rawPage, composed ? composed.filePath : pagePath);
 
   const baseUrl = s?.integrations?.editLink?.baseUrl;
   const editLink = baseUrl ? `${baseUrl}${pagePath}` : undefined;

--- a/packages/xyd-documan/src/bun/startDevServer.ts
+++ b/packages/xyd-documan/src/bun/startDevServer.ts
@@ -463,6 +463,11 @@ function makeRebuild(ctx: {
 function contentTopologyChanged(cwd: string, paths: string[]): boolean {
   const mapping = (globalThis as any).__xydPagePathMapping || {};
   const known = new Set<string>(Object.values(mapping).map((v: any) => path.resolve(cwd, String(v))));
+  // sidebar-as-TOC section files are known content too (they're excluded from
+  // the page mapping) — an edit is a plain content edit, not a topology change.
+  for (const host of Object.values(((globalThis as any).__xydAsTocPages?.hosts || {}) as Record<string, { sections: Array<{ file: string }> }>)) {
+    for (const s of host.sections) known.add(path.resolve(cwd, s.file));
+  }
   for (const p of paths) {
     const abs = path.resolve(cwd, p);
     if (!known.has(abs)) return true; // new/renamed (or path-form mismatch → safe reinit)

--- a/packages/xyd-documan/src/dev.ts
+++ b/packages/xyd-documan/src/dev.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 
 import { createServer, mergeConfig, searchForWorkspaceRoot, ViteDevServer, Plugin as VitePlugin, PluginOption } from "vite";
 
-import { API, APIFile, Navigation, Settings, SidebarNavigation, } from "@xyd-js/core";
+import { API, APIFile, Navigation, Settings, SidebarNavigation, asTocEnabled } from "@xyd-js/core";
 
 import { appInit, calculateFolderChecksum, commonPostInstallVitePlugins, commonVitePlugins, getAppRoot, getDocsPluginBasePath, getHostPath, getPublicPath, pluginLLMMarkdown, postWorkspaceSetup, preWorkspaceSetup, storeChecksum } from "./utils";
 import { CACHE_FOLDER_PATH, SUPPORTED_SETTINGS_FILES, SUPPORTED_CONTENT_FILES } from "./const";
@@ -729,6 +729,10 @@ function getFirstPageFromNavigation(navigation: Navigation): string | null {
             }
 
             if (typeof page === 'object') {
+                // asToc groups' pages are TOC sections, not routable pages —
+                // never preload them.
+                if (asTocEnabled((page as any).asToc)) continue;
+
                 // Handle SidebarRoute
                 if ('route' in page && page.pages) {
                     const firstPage = extractFirstPage(page.pages);

--- a/packages/xyd-documan/src/utils.ts
+++ b/packages/xyd-documan/src/utils.ts
@@ -660,6 +660,7 @@ export async function appInit(options?: PluginDocsOptions) {
         (globalThis as any).__xydAccessMap = inject.accessMap || {};
         if (inject.i18n) (globalThis as any).__xydI18n = inject.i18n;
         if (inject.i18nTranslations) (globalThis as any).__xydI18nTranslations = inject.i18nTranslations;
+        if (inject.asTocPages) (globalThis as any).__xydAsTocPages = inject.asTocPages;
         return { respPluginDocs: null, resolvedPlugins };
     }
 

--- a/packages/xyd-framework/packages/hydration/mapSettingsToProps.ts
+++ b/packages/xyd-framework/packages/hydration/mapSettingsToProps.ts
@@ -1,6 +1,6 @@
 // server-only
 
-import { Sidebar, MetadataMap, Settings, SidebarRoute, Metadata, PageURL, TranslationCatalog, resolveI18nDeep } from "@xyd-js/core";
+import { Sidebar, MetadataMap, Settings, SidebarRoute, Metadata, PageURL, TranslationCatalog, resolveI18nDeep, asTocEnabled, asTocOptions } from "@xyd-js/core";
 import { pageFrontMatters } from "@xyd-js/content";
 import { IBreadcrumb, INavLinks } from "@xyd-js/ui";
 
@@ -50,9 +50,21 @@ export async function mapSettingsToProps(
         )
     }
 
+    // sidebar-as-TOC: section pages are excluded from the real page mapping
+    // (non-routable), but their titles still come from their own frontmatter —
+    // merge their file map in for the lookup only (routing stays clean).
+    const asTocPages = (globalThis as any).__xydAsTocPages as AsTocPagesLike | undefined
+
     let filteredNav = filterNavigation(effectiveSettings, slug)
     if (!frontmatters) {
-        frontmatters = await pageFrontMatters(filteredNav, pagePathMapping) as MetadataMap
+        let fmMapping = pagePathMapping
+        if (asTocPages) {
+            fmMapping = { ...pagePathMapping }
+            for (const host of Object.values(asTocPages.hosts)) {
+                for (const s of host.sections) fmMapping[s.page] = s.file
+            }
+        }
+        frontmatters = await pageFrontMatters(filteredNav, fmMapping) as MetadataMap
     }
 
     const slugFrontmatter = frontmatters[slug] || null
@@ -114,6 +126,7 @@ export async function mapSettingsToProps(
                 active: false,
                 uniqIndex: uniqIndex++,
                 icon: page.icon,
+                asToc: asTocOptions(page.asToc) || undefined,
                 items,
             }
         }
@@ -145,8 +158,12 @@ export async function mapSettingsToProps(
 
         const meta = frontmatters[pageName]
 
+        // sidebar-as-TOC section: not a routable page — the item links to the
+        // host page + section anchor (scroll target), never triggers navlinks.
+        const asTocEntry = asTocPages?.pages?.[pageName]
+
         // TODO: better data structures - for example flat array of filtered nav
-        if (slugFrontmatter && (slugFrontmatter === meta)) {
+        if (!asTocEntry && slugFrontmatter && (slugFrontmatter === meta)) {
             const nlinks = mapNavToLinks(pageName, currentNav, nav, frontmatters, hiddenPages)
 
             if (nlinks) {
@@ -156,12 +173,17 @@ export async function mapSettingsToProps(
 
         return {
             title,
-            href: safePageLink(pageName),
+            href: asTocEntry
+                ? `${asTocHostHref(asTocEntry.host)}#${asTocEntry.id}`
+                : safePageLink(pageName),
             active: false,
             uniqIndex: uniqIndex++,
             icon: meta?.icon || "",
             sidebarTitle: meta?.sidebarTitle || "",
             url: meta?.url || "",
+            asToc: asTocEntry
+                ? { indicator: asTocEntry.indicator !== false, breadcrumbs: asTocEntry.breadcrumbs !== false }
+                : undefined,
             pageMeta: meta || null,
         }
     }
@@ -176,6 +198,7 @@ export async function mapSettingsToProps(
         return {
             group: nav.group,
             icon: nav?.icon,
+            asToc: asTocOptions(nav.asToc) || undefined,
             items
         } as FwSidebarItemProps
     }
@@ -227,13 +250,35 @@ export async function mapSettingsToProps(
         }
     }
 
+    // sidebar-as-TOC host page: flag the SSR metadata so themes hide the
+    // right-hand TOC without a hydration flash (the composed page's compiled
+    // frontmatter carries the same flag for the post-mount metadata source).
+    const isAsTocHost = !!asTocPages?.hosts?.[slug?.replace(/^\//, "") || "index"]
+
     return {
         groups,
         breadcrumbs,
         navlinks,
         hiddenPages,
-        metadata: slugFrontmatter
+        metadata: isAsTocHost
+            ? { ...(slugFrontmatter || {} as Metadata), asTocHost: true }
+            : slugFrontmatter
     }
+}
+
+// Minimal structural view of globalThis.__xydAsTocPages (owned by
+// @xyd-js/plugin-docs — read through the global to avoid a framework →
+// plugin-docs dependency).
+interface AsTocPagesLike {
+    hosts: Record<string, { indexFile: string, sections: Array<{ page: string, file: string, id: string }> }>
+    pages: Record<string, { host: string, id: string, indicator?: boolean, breadcrumbs?: boolean }>
+}
+
+/** Host slug → the URL it serves at ("index" → "/", "docs" → "/docs"). */
+function asTocHostHref(host: string): string {
+    if (host === "index") return "/"
+    if (host.endsWith("/index")) return safePageLink(host.slice(0, -"/index".length))
+    return safePageLink(host)
 }
 
 function filterNavigation(settings: Settings, slug: string): Sidebar[] {
@@ -370,6 +415,11 @@ function mapNavToLinks(
             })
             return
         }
+        // sidebar-as-TOC group: its pages are sections of the host page, not
+        // navigable routes — never part of the prev/next sequence.
+        if (asTocEnabled(group.asToc)) {
+            return
+        }
         if (group.pages) {
             group.pages.forEach((pageItem, pageIndex) => {
                 let pageName = ""
@@ -378,6 +428,10 @@ function mapNavToLinks(
                 } else if ("virtual" in pageItem) {
                     pageName = pageItem.page
                 } else if ("pages" in pageItem) {
+                    // Nested asToc group → sections, not pages (see above).
+                    if (asTocEnabled((pageItem as Sidebar).asToc)) {
+                        return
+                    }
                     // This is a nested Sidebar, use BFS to resolve all pages
                     const resolvedPages = findResolvedPagesBFS(pageItem)
                     if (resolvedPages.length > 0) {
@@ -472,6 +526,8 @@ function findResolvedPagesBFS(sidebar: Sidebar): string[] {
         } else if ("page" in current && typeof current === "object") {
             resolvedPages.push((current as { page: string }).page)
         } else if ("pages" in current && current.pages) {
+            // asToc subtrees are non-navigable — never resolved as pages.
+            if (asTocEnabled((current as Sidebar).asToc)) continue
             // Add all pages from this nested sidebar to the queue
             queue.push(...current.pages)
         }

--- a/packages/xyd-framework/packages/react/components/FwBreadcrumbs.tsx
+++ b/packages/xyd-framework/packages/react/components/FwBreadcrumbs.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { Breadcrumbs } from "@xyd-js/components/writer";
 
 import { useBreadcrumbs, useAppearance } from "../contexts";
+import { useAsTocActiveSection } from "../lib";
 import { displayBreadcrumbs } from "../utils";
 import { FwLink } from "./FwLink";
 
@@ -10,10 +11,25 @@ export function FwBreadcrumbs() {
     const fwBreadcrumbs = useBreadcrumbs()
     const appearance = useAppearance()
 
+    // sidebar-as-TOC host page: the static breadcrumbs are empty (the host is
+    // an index page), so follow the section being READ instead — the scroll-spy
+    // publishes "Group / Section" and this re-renders as the reader scrolls.
+    // Effect-driven (null during SSR/hydration), disabled per group via
+    // `asToc: { breadcrumbs: false }`.
+    const asTocSection = useAsTocActiveSection()
+
+    let items = (fwBreadcrumbs as any) || []
+    if (asTocSection?.breadcrumbs && asTocSection.title) {
+        items = [
+            ...(asTocSection.group ? [{ title: asTocSection.group, href: "" }] : []),
+            { title: asTocSection.title, href: asTocSection.href },
+        ]
+    }
+
     // `content.breadcrumbs` is `boolean | { links?, rootLevel? }` (both default true):
     // links:false → plain text; rootLevel:false → drop the top tab/route crumb.
     const breadcrumbs = displayBreadcrumbs(
-        (fwBreadcrumbs as any) || [],
+        items,
         appearance?.content?.breadcrumbs,
     )
 

--- a/packages/xyd-framework/packages/react/components/FwSidebar.tsx
+++ b/packages/xyd-framework/packages/react/components/FwSidebar.tsx
@@ -15,6 +15,7 @@ import { FwWebEditorSidebarTop } from "./FwWebEditorSidebarTop";
 import { FwSidebarMobileHeaderItems } from "./FwSidebarMobileHeaderItems";
 import { FwSidebarFilter } from "./FwSidebarFilter";
 import { FwSidebarComponent } from "./FwSidebarComponent";
+import { FwSidebarAsToc } from "./FwSidebarAsToc";
 import type { FwSidebarItemElementProps, FwSidebarItemProps } from "./FwSidebarItem";
 import { useSidebarTree } from "./FwSidebarTree";
 import { FwLogo } from "./FwLogo";
@@ -78,24 +79,29 @@ export function FwSidebar(props: FwSidebarProps) {
     </>
 
     return <SidebarFilterProvider>
-        <Sidebar
-            footerItems={sidebarFooterAnchors && sidebarFooterAnchors}
-            fixedTop={fixedTop}
-            scrollShadow={appearance?.sidebar?.scrollShadow}
-            scrollTransition={appearance?.sidebar?.scrollTransition}
-            groupCase={appearance?.sidebar?.groupCase}
-            scroll={appearance?.sidebar?.scroll}
-        >
-            <Surface target={SurfaceTarget.SidebarTop} />
+        {/* sidebar-as-TOC: on an asToc host page this drives the sidebar
+            highlight from scroll position and intercepts asToc item clicks;
+            elsewhere it renders children untouched. */}
+        <FwSidebarAsToc>
+            <Sidebar
+                footerItems={sidebarFooterAnchors && sidebarFooterAnchors}
+                fixedTop={fixedTop}
+                scrollShadow={appearance?.sidebar?.scrollShadow}
+                scrollTransition={appearance?.sidebar?.scrollTransition}
+                groupCase={appearance?.sidebar?.groupCase}
+                scroll={appearance?.sidebar?.scroll}
+            >
+                <Surface target={SurfaceTarget.SidebarTop} />
 
-            <FwSidebarTopAnchors />
+                <FwSidebarTopAnchors />
 
-            <FwWebEditorSidebarTop />
+                <FwWebEditorSidebarTop />
 
-            <FwSidebarMobileHeaderItems />
+                <FwSidebarMobileHeaderItems />
 
-            <FwSidebarTabsDropdown />
-        </Sidebar>
+                <FwSidebarTabsDropdown />
+            </Sidebar>
+        </FwSidebarAsToc>
     </SidebarFilterProvider>
 }
 

--- a/packages/xyd-framework/packages/react/components/FwSidebarAsToc.tsx
+++ b/packages/xyd-framework/packages/react/components/FwSidebarAsToc.tsx
@@ -1,0 +1,170 @@
+import React, { createContext, useContext, useEffect, useMemo, useRef, useState } from "react"
+
+import { SidebarActiveProvider, setAsTocActiveSection, type AsTocActiveSection } from "../lib"
+import { useMetadata, useSidebarGroups } from "../contexts"
+
+import type { FwSidebarItemElementProps } from "./FwSidebarItem"
+
+// ---------------------------------------------------------------------------
+// sidebar-as-TOC scroll-spy (`asToc: true` sidebar groups)
+//
+// On a composed host page (metadata.asTocHost), the sidebar's asToc items act
+// as the page's table of contents: this provider watches the composed page's
+// `[data-astoc-section]` wrappers with the same algorithm as the right-hand
+// TOC (window scroll listener, active = last section whose top crossed 20% of
+// the viewport, bottom-of-page → last) and drives the sidebar highlight via
+// the existing SidebarActiveProvider override. Item clicks are intercepted
+// (preventDefault → smooth scroll + history.replaceState) so they never
+// route-navigate while on the host page; off-host the items stay normal links
+// to `<host>#<section>`.
+//
+// When NOT on a host page it renders children untouched — in particular it
+// must not mount a SidebarActiveProvider, which would shadow an outer one
+// (the API editor mounts its own scroll-spy provider above the sidebar).
+// ---------------------------------------------------------------------------
+
+interface IFwSidebarAsTocContext {
+    /** true when the current page is an asToc host (scroll-spy active) */
+    enabled: boolean
+    /** click interceptor for asToc items — scrolls instead of navigating */
+    onItemClick: (e: React.MouseEvent, href?: string) => void
+}
+
+const noop = () => { }
+
+const FwSidebarAsTocContext = createContext<IFwSidebarAsTocContext>({
+    enabled: false,
+    onItemClick: noop,
+})
+
+export function useSidebarAsToc() {
+    return useContext(FwSidebarAsTocContext)
+}
+
+function hashIdOf(href?: string): string {
+    const i = href ? href.indexOf("#") : -1
+    return i === -1 ? "" : href!.slice(i + 1)
+}
+
+export function FwSidebarAsToc({ children }: { children: React.ReactNode }) {
+    const meta = useMetadata()
+    const groups = useSidebarGroups()
+    const enabled = !!(meta as any)?.asTocHost
+
+    // section id → sidebar item (href + title + owning group + resolved
+    // breadcrumbs flag), from the asToc items' hash hrefs. The active entry is
+    // published to the asToc store so content-column UI (FwBreadcrumbs) can
+    // show "Group / Section" for the section being read.
+    const sectionById = useMemo(() => {
+        const map = new Map<string, AsTocActiveSection>()
+        if (!enabled) return map
+        const walk = (items: FwSidebarItemElementProps[] | undefined, groupName: string) => {
+            for (const item of items || []) {
+                const id = item.asToc ? hashIdOf(item.href) : ""
+                if (id) {
+                    map.set(id, {
+                        href: item.href,
+                        title: item.sidebarTitle || item.title || "",
+                        group: groupName,
+                        breadcrumbs: typeof item.asToc === "object"
+                            ? item.asToc.breadcrumbs !== false
+                            : true,
+                    })
+                }
+                if (item.items) walk(item.items, groupName)
+            }
+        }
+        for (const group of groups || []) {
+            walk(group.items, typeof group.group === "string" ? group.group : "")
+        }
+        return map
+    }, [enabled, groups])
+
+    // Effect-driven only (SSR renders no scroll-spy active item — same pattern
+    // as the right-hand TOC, so there is no hydration mismatch).
+    const [activeHref, setActiveHref] = useState<string | undefined>(undefined)
+    const ignoreScrollRef = useRef(false)
+
+    useEffect(() => {
+        if (!enabled) return
+
+        function handleScroll() {
+            if (ignoreScrollRef.current) {
+                ignoreScrollRef.current = false
+                return
+            }
+            const sections = Array.from(
+                document.querySelectorAll<HTMLElement>("[data-astoc-section]")
+            ).filter((el) => el.id)
+            if (!sections.length) return
+
+            const viewportHeight = window.innerHeight
+            const threshold = viewportHeight * 0.2
+
+            let active = sections[0].id
+            for (const el of sections) {
+                if (el.getBoundingClientRect().top <= threshold) {
+                    active = el.id
+                } else {
+                    break
+                }
+            }
+
+            const totalHeight = document.documentElement.scrollHeight
+            if (totalHeight > viewportHeight && window.pageYOffset + viewportHeight >= totalHeight - 1) {
+                active = sections[sections.length - 1].id
+            }
+
+            const section = sectionById.get(active) || null
+            setActiveHref(section?.href)
+            setAsTocActiveSection(section)
+        }
+
+        window.addEventListener("scroll", handleScroll)
+        handleScroll()
+        return () => {
+            window.removeEventListener("scroll", handleScroll)
+            setAsTocActiveSection(null)
+        }
+    }, [enabled, sectionById])
+
+    // Mount-time hash scroll: neither router scrolls to a hash on its own
+    // (@xyd-js/router deliberately skips it), so landing on /#section-id from
+    // an off-host click must scroll here.
+    useEffect(() => {
+        if (!enabled) return
+        const id = decodeURIComponent((window.location.hash || "").slice(1))
+        if (!id || !sectionById.has(id)) return
+        document.getElementById(id)?.scrollIntoView()
+    }, [enabled, sectionById])
+
+    const value = useMemo<IFwSidebarAsTocContext>(() => ({
+        enabled,
+        onItemClick(e, href) {
+            const id = hashIdOf(href)
+            if (!id) return
+            const el = document.getElementById(id)
+            // Section not in this DOM (off-host page) → let the Link navigate
+            // to <host>#<id>; the mount-time hash scroll takes it from there.
+            if (!el) return
+            e.preventDefault()
+            ignoreScrollRef.current = true
+            setActiveHref(href)
+            setAsTocActiveSection(sectionById.get(id) || null)
+            el.scrollIntoView({ behavior: "smooth" })
+            history.replaceState(null, "", `#${id}`)
+        },
+    }), [enabled, sectionById])
+
+    if (!enabled) {
+        return <FwSidebarAsTocContext value={{ enabled: false, onItemClick: noop }}>
+            {children}
+        </FwSidebarAsTocContext>
+    }
+
+    return <FwSidebarAsTocContext value={value}>
+        <SidebarActiveProvider activeHref={activeHref}>
+            {children}
+        </SidebarActiveProvider>
+    </FwSidebarAsTocContext>
+}

--- a/packages/xyd-framework/packages/react/components/FwSidebarItem.tsx
+++ b/packages/xyd-framework/packages/react/components/FwSidebarItem.tsx
@@ -7,9 +7,18 @@ import { UISidebar } from "@xyd-js/ui";
 
 import { Surface } from "./Surfaces";
 import { FwSidebarComponent } from "./FwSidebarComponent";
+import { useSidebarAsToc } from "./FwSidebarAsToc";
 import { FooSidebarItemProps, useFooSidebar, useSidebarActive } from "../lib";
 import { useSidebarFilter } from "../contexts";
 import { sidebarItemMatchesQuery } from "../utils";
+
+/** Resolved sidebar-as-TOC behavior flags carried on groups + their items. */
+export interface FwSidebarAsTocProps {
+    /** TOC-style vertical track line on the group (default true) */
+    indicator?: boolean
+    /** host-page breadcrumbs follow this group's active section (default true) */
+    breadcrumbs?: boolean
+}
 
 export interface FwSidebarItemProps {
     group: string
@@ -19,6 +28,9 @@ export interface FwSidebarItemProps {
     items: FwSidebarItemElementProps[]
 
     icon?: string
+
+    /** sidebar-as-TOC group — its items scroll to sections of the host page */
+    asToc?: boolean | FwSidebarAsTocProps
 }
 
 export function FwSidebarItem(props: FwSidebarItemProps) {
@@ -33,6 +45,9 @@ export function FwSidebarItem(props: FwSidebarItemProps) {
 
     const icon = props.icon ? <Icon name={props.icon || ""} size={16} /> : null
 
+    // NOTE: sidebar-as-TOC groups are NOT wrapped here — CONSECUTIVE asToc
+    // groups must share ONE TOC track line, so the [data-astoc] wrapper is
+    // applied a level up, in useSidebarTree (which chunks adjacent groups).
     return <>
         {
             props.group && <UISidebar.ItemHeader icon={icon}>
@@ -68,6 +83,7 @@ export function FwSidebarItem(props: FwSidebarItemProps) {
                 items={item.items}
                 active={item.active}
                 icon={item.icon}
+                asToc={item.asToc}
             />
         })}
     </>
@@ -100,6 +116,11 @@ export interface FwSidebarItemElementProps extends FooSidebarItemProps {
 
     /** Props passed to the custom `component`. */
     componentProps?: Record<string, any>
+
+    /** sidebar-as-TOC item — href is `<host>#<section>`; on the host page a
+     *  click scrolls to the section instead of navigating. Object form carries
+     *  the owning group's resolved behavior flags. */
+    asToc?: boolean | FwSidebarAsTocProps
 }
 
 // Whether an injected active href lives anywhere under these items (drives a
@@ -114,6 +135,7 @@ function containsHref(items: FwSidebarItemElementProps[] | undefined, href: stri
 FwSidebarItem.Item = function FwSidebarItem(props: FwSidebarItemElementProps) {
     const { active } = useFooSidebar()
     const { activeHref } = useSidebarActive()
+    const asTocSidebar = useSidebarAsToc()
     const { query } = useSidebarFilter()
     const [isActive, setActive] = active(props)
 
@@ -144,7 +166,14 @@ FwSidebarItem.Item = function FwSidebarItem(props: FwSidebarItemElementProps) {
         return null
     }
 
-    function handleClick() {
+    function handleClick(e: React.MouseEvent) {
+        // sidebar-as-TOC item on its host page: scroll to the section instead
+        // of navigating (the provider preventDefaults; off-host it lets the
+        // link navigate to <host>#<section>).
+        if (props.asToc && asTocSidebar.enabled) {
+            asTocSidebar.onItemClick(e, props.href)
+        }
+
         if (!nested) {
             return
         }
@@ -243,6 +272,7 @@ FwSidebarItem.Item = function FwSidebarItem(props: FwSidebarItemElementProps) {
                             active={active(item)[0]}
                             icon={item.icon}
                             pageMeta={item.pageMeta}
+                            asToc={item.asToc}
                         />)
                     }
                 </>}

--- a/packages/xyd-framework/packages/react/components/FwSidebarTree.tsx
+++ b/packages/xyd-framework/packages/react/components/FwSidebarTree.tsx
@@ -1,11 +1,13 @@
 import React, {} from "react";
 import {useLocation} from "react-router";
 
+import {UISidebar} from "@xyd-js/ui";
+
 import {useSidebarGroups} from "../contexts";
 import {useSidebarActive} from "../lib";
 import {trailingSlash} from "../utils";
 
-import {FwSidebarItem, FwSidebarItemElementProps} from "./FwSidebarItem";
+import {FwSidebarItem, FwSidebarItemElementProps, FwSidebarItemProps} from "./FwSidebarItem";
 
 export function useSidebarTree(): [React.ReactElement[], { initialActiveItems: any[] }] {
     const location = useLocation()
@@ -19,16 +21,47 @@ export function useSidebarTree(): [React.ReactElement[], { initialActiveItems: a
 
     // The tree STRUCTURE depends only on the groups — memoize it separately so a
     // changing active href (scroll) doesn't rebuild the whole tree.
+    //
+    // sidebar-as-TOC: CONSECUTIVE asToc groups (with the indicator enabled)
+    // share ONE [data-astoc] wrapper — headers included — so a single
+    // continuous TOC track line spans them (per-group wrappers would draw a
+    // broken line per group). A group with `indicator: false` (or any
+    // non-asToc group) ends the run.
     const sidebarTree = React.useMemo(
-        () =>
-            groups?.map((group, index) => <FwSidebarItem
-                // `index + group.group` is NaN for a groupless group (flat items,
-                // pageless component wrap) → key collisions. Index is stable +
-                // unique here (groups don't reorder).
-                key={`group-${index}-${group.group ?? ""}`}
-                {...group}
-                groupIndex={index}
-            />) || [],
+        () => {
+            const nodes: React.ReactElement[] = []
+            let run: React.ReactElement[] = []
+
+            const flushRun = () => {
+                if (!run.length) return
+                nodes.push(
+                    <UISidebar.ItemGroup asToc key={`astoc-run-${nodes.length}`}>
+                        {run}
+                    </UISidebar.ItemGroup>
+                )
+                run = []
+            }
+
+            groups?.forEach((group, index) => {
+                const el = <FwSidebarItem
+                    // `index + group.group` is NaN for a groupless group (flat items,
+                    // pageless component wrap) → key collisions. Index is stable +
+                    // unique here (groups don't reorder).
+                    key={`group-${index}-${group.group ?? ""}`}
+                    {...group}
+                    groupIndex={index}
+                />
+                if (asTocIndicatorOf(group)) {
+                    run.push(el)
+                } else {
+                    flushRun()
+                    nodes.push(el)
+                }
+            })
+            flushRun()
+
+            return nodes
+        },
         [groups],
     )
 
@@ -58,6 +91,12 @@ export function useSidebarTree(): [React.ReactElement[], { initialActiveItems: a
     }, [groups, effectiveHref])
 
     return [sidebarTree, {initialActiveItems}]
+}
+
+/** asToc group with the TOC track line enabled (`indicator` defaults true). */
+function asTocIndicatorOf(group: FwSidebarItemProps): boolean {
+    return !!group.asToc
+        && (typeof group.asToc !== "object" || group.asToc.indicator !== false)
 }
 
 function recursiveSearch(items: FwSidebarItemElementProps[], href: string, levels: any[] = []) {

--- a/packages/xyd-framework/packages/react/components/index.ts
+++ b/packages/xyd-framework/packages/react/components/index.ts
@@ -18,6 +18,7 @@ export {FwNav} from "./FwNav";
 export {FwNavLinks} from "./FwNavLinks";
 
 export {FwSidebar} from "./FwSidebar";
+export {FwSidebarAsToc, useSidebarAsToc} from "./FwSidebarAsToc";
 
 export {FwSegmentLogoTrailing} from "./FwSegmentLogoTrailing";
 

--- a/packages/xyd-framework/packages/react/lib/asTocStore.ts
+++ b/packages/xyd-framework/packages/react/lib/asTocStore.ts
@@ -1,0 +1,47 @@
+import { useSyncExternalStore } from "react"
+
+// ---------------------------------------------------------------------------
+// sidebar-as-TOC active-section store.
+//
+// The scroll-spy lives in the SIDEBAR tree (FwSidebarAsToc), but the active
+// section also drives UI in the CONTENT column (FwBreadcrumbs shows
+// "Group / Section" on the composed host page). Those trees have no shared
+// provider ancestor, so the active section is published through this tiny
+// module-level store instead of a context. SSR snapshot is null — consumers
+// render their static state on the server and pick the section up after
+// hydration (same effect-driven pattern as the scroll-spy itself).
+// ---------------------------------------------------------------------------
+
+export interface AsTocActiveSection {
+    /** the sidebar item href, e.g. "/#operating-systems-linux" */
+    href: string
+    /** section page title (from its frontmatter) */
+    title: string
+    /** owning sidebar group name, "" when the group is unnamed */
+    group: string
+    /** the group's resolved `breadcrumbs` option */
+    breadcrumbs: boolean
+}
+
+let activeSection: AsTocActiveSection | null = null
+const listeners = new Set<() => void>()
+
+export function setAsTocActiveSection(next: AsTocActiveSection | null) {
+    if (next === activeSection) return
+    if (next && activeSection && next.href === activeSection.href) return
+    activeSection = next
+    for (const listener of listeners) listener()
+}
+
+function subscribe(listener: () => void) {
+    listeners.add(listener)
+    return () => listeners.delete(listener)
+}
+
+const getSnapshot = () => activeSection
+const getServerSnapshot = () => null
+
+/** The section the reader is currently in on an asToc host page, or null. */
+export function useAsTocActiveSection(): AsTocActiveSection | null {
+    return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}

--- a/packages/xyd-framework/packages/react/lib/index.ts
+++ b/packages/xyd-framework/packages/react/lib/index.ts
@@ -9,3 +9,9 @@ export {
     SidebarActiveProvider,
     useSidebarActive,
 } from "./SidebarActive";
+
+export {
+    setAsTocActiveSection,
+    useAsTocActiveSection,
+    type AsTocActiveSection,
+} from "./asTocStore";

--- a/packages/xyd-host/app/docPaths.ts
+++ b/packages/xyd-host/app/docPaths.ts
@@ -1,4 +1,4 @@
-import {PageURL, Settings, Sidebar, SidebarNavigation} from "@xyd-js/core";
+import {PageURL, Settings, Sidebar, SidebarNavigation, asTocEnabled} from "@xyd-js/core";
 
 export function docPaths(navigation: Settings['navigation']) {
     if (!navigation?.sidebar && !navigation?.languages?.length) return [];
@@ -35,8 +35,9 @@ export function docPaths(navigation: Settings['navigation']) {
             }
         }
 
-        // Process items in the sidebar group
-        if ("pages" in sidebarGroup && sidebarGroup.pages?.length) {
+        // Process items in the sidebar group. asToc groups' pages are TOC
+        // sections of the host page, not prerenderable routes — skip them.
+        if ("pages" in sidebarGroup && sidebarGroup.pages?.length && !asTocEnabled((sidebarGroup as Sidebar).asToc)) {
             processSidebarItems(sidebarGroup.pages);
         }
         });
@@ -58,8 +59,9 @@ export function docPaths(navigation: Settings['navigation']) {
                 }
             }
 
-            // If item has pages, process them
-            if ("pages" in item && item.pages?.length) {
+            // If item has pages, process them (asToc groups excluded — their
+            // pages are sections of the host page, not routes)
+            if ("pages" in item && item.pages?.length && !asTocEnabled((item as Sidebar).asToc)) {
                 item.pages.forEach((page) => {
                     if (typeof page === 'string') {
                         // Add the page path

--- a/packages/xyd-host/app/pathRoutes.ts
+++ b/packages/xyd-host/app/pathRoutes.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 
 import { RouteConfigEntry, index } from "@react-router/dev/routes";
 
-import { Settings, SidebarNavigation } from "@xyd-js/core";
+import { Settings, SidebarNavigation, asTocEnabled } from "@xyd-js/core";
 import { layout, route } from "@react-router/dev/routes";
 
 type Route = {
@@ -87,8 +87,11 @@ function extractNestedRoutes(
                 routes.push({ id: routeMatch, path: routeMatch + "/*" });
             }
 
-            // Recursively process nested pages within this route
-            if (item.pages && Array.isArray(item.pages)) {
+            // Recursively process nested pages within this route. asToc
+            // groups' pages are TOC sections of the host page — they must NOT
+            // become routes (non-routable; prerendering them would also trip
+            // React Router's ssr:false loader-export validation).
+            if (item.pages && Array.isArray(item.pages) && !asTocEnabled((item as any).asToc)) {
                 extractNestedRoutes(item.pages as SidebarNavigation, routes, route || parentRoute)
             }
         } else if (!parentRoute) {

--- a/packages/xyd-plugin-docs/__tests__/asToc.test.ts
+++ b/packages/xyd-plugin-docs/__tests__/asToc.test.ts
@@ -15,21 +15,20 @@ import { collectAsTocPages, mergeAsTocPages, asTocFileMap, sectionIdFor, mapNavi
  * - mapNavigationToPagePathMapping must EXCLUDE those pages (non-routable),
  *   byte-parity with the Rust gate in crates/xyd_settings/src/pagemap.rs.
  *
- * Tests chdir into a tmp workspace so the fs probes (md-wins-over-mdx,
- * missing-file skip) run deterministically.
+ * Tests probe files in a tmp workspace via the walks' explicit `cwd` option
+ * (md-wins-over-mdx, missing-file skip) — deterministic and chdir-free.
  */
 describe("sidebar-as-TOC", () => {
     let tmpDir: string;
-    let prevCwd: string;
 
+    // NO process.chdir here — it is unsupported in vitest worker threads
+    // (xyd-content's package-local vitest 1.x runs the threads pool). The
+    // walks take an explicit cwd instead, matching the Rust port's signature.
     beforeEach(() => {
-        prevCwd = process.cwd();
         tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "xyd-astoc-test-"));
-        process.chdir(tmpDir);
     });
 
     afterEach(() => {
-        process.chdir(prevCwd);
         fs.rmSync(tmpDir, { recursive: true, force: true });
     });
 
@@ -56,7 +55,7 @@ describe("sidebar-as-TOC", () => {
             const res = collectAsTocPages(nav([
                 { group: "OS", asToc: true, pages: ["os/linux", "os/windows"] },
                 { group: "Normal", pages: ["other"] },
-            ]));
+            ]), { cwd: tmpDir });
 
             expect(Object.keys(res.hosts)).toEqual(["index"]);
             expect(res.hosts["index"].indexFile).toBe("");
@@ -74,7 +73,7 @@ describe("sidebar-as-TOC", () => {
 
             const res = collectAsTocPages(nav([
                 { group: "OS", asToc: true, pages: ["os/linux"] },
-            ]));
+            ]), { cwd: tmpDir });
 
             expect(res.hosts["index"].indexFile).toBe("index.md");
         });
@@ -84,7 +83,7 @@ describe("sidebar-as-TOC", () => {
 
             const res = collectAsTocPages(nav([
                 { group: "OS", asToc: true, pages: ["os/linux", "os/missing"] },
-            ]));
+            ]), { cwd: tmpDir });
 
             expect(res.hosts["index"].sections.map(s => s.page)).toEqual(["os/linux"]);
             expect(res.pages["os/missing"]).toBeUndefined();
@@ -99,7 +98,7 @@ describe("sidebar-as-TOC", () => {
                     route: "/docs",
                     pages: [{ group: "Deep", asToc: true, pages: ["docs/deep/a"] }],
                 },
-            ]));
+            ]), { cwd: tmpDir });
 
             expect(Object.keys(res.hosts)).toEqual(["docs"]);
             expect(res.hosts["docs"].indexFile).toBe("docs.md");
@@ -123,7 +122,7 @@ describe("sidebar-as-TOC", () => {
                         },
                     ],
                 },
-            ]));
+            ]), { cwd: tmpDir });
 
             expect(res.hosts["index"].sections.map(s => s.page)).toEqual(["a/x", "a/y"]);
         });
@@ -133,7 +132,7 @@ describe("sidebar-as-TOC", () => {
 
             const res = collectAsTocPages(
                 nav([{ group: "OS", asToc: true, pages: ["pl/os/linux"] }]),
-                { hostPrefix: "pl/" }
+                { hostPrefix: "pl/", cwd: tmpDir }
             );
 
             expect(Object.keys(res.hosts)).toEqual(["pl/index"]);
@@ -147,7 +146,7 @@ describe("sidebar-as-TOC", () => {
                 { group: "OS", asToc: true, pages: ["os/linux"] },
                 { group: "Resources", pages: [] },
                 { group: "Lang", asToc: true, pages: ["lang/python"] },
-            ]));
+            ]), { cwd: tmpDir });
 
             expect(res.hosts["index"].sections.map(s => s.id)).toEqual(["os-linux", "lang-python"]);
         });
@@ -161,7 +160,7 @@ describe("sidebar-as-TOC", () => {
                 { group: "OS", asToc: {}, pages: ["os/linux"] },
                 { group: "Lang", asToc: { indicator: false, breadcrumbs: false }, pages: ["lang/python"] },
                 { group: "Off", asToc: false, pages: ["off/page"] },
-            ]));
+            ]), { cwd: tmpDir });
 
             expect(res.pages["os/linux"]).toEqual({ host: "index", id: "os-linux", indicator: true, breadcrumbs: true });
             expect(res.pages["lang/python"]).toEqual({ host: "index", id: "lang-python", indicator: false, breadcrumbs: false });
@@ -210,7 +209,7 @@ describe("sidebar-as-TOC", () => {
                         { group: "RoutedToc", asToc: true, pages: ["guides/routed"] },
                     ]
                 },
-            ]) as any);
+            ]) as any, tmpDir);
 
             expect(mapping).toEqual({
                 "normal": "normal.md",

--- a/packages/xyd-plugin-docs/__tests__/asToc.test.ts
+++ b/packages/xyd-plugin-docs/__tests__/asToc.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import type { Navigation } from "@xyd-js/core";
+
+import { collectAsTocPages, mergeAsTocPages, asTocFileMap, sectionIdFor, mapNavigationToPagePathMapping } from "../src";
+
+/**
+ * sidebar-as-TOC data plane:
+ * - collectAsTocPages walks the navigation (mirroring the pagemap traversal)
+ *   and records every `asToc: true` group's pages as sections of their host
+ *   page ("index" for top-level groups, the route slug under a SidebarRoute).
+ * - mapNavigationToPagePathMapping must EXCLUDE those pages (non-routable),
+ *   byte-parity with the Rust gate in crates/xyd_settings/src/pagemap.rs.
+ *
+ * Tests chdir into a tmp workspace so the fs probes (md-wins-over-mdx,
+ * missing-file skip) run deterministically.
+ */
+describe("sidebar-as-TOC", () => {
+    let tmpDir: string;
+    let prevCwd: string;
+
+    beforeEach(() => {
+        prevCwd = process.cwd();
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "xyd-astoc-test-"));
+        process.chdir(tmpDir);
+    });
+
+    afterEach(() => {
+        process.chdir(prevCwd);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function write(rel: string, content = "# x\n") {
+        const abs = path.join(tmpDir, rel);
+        fs.mkdirSync(path.dirname(abs), { recursive: true });
+        fs.writeFileSync(abs, content);
+    }
+
+    const nav = (sidebar: any[]): Navigation => ({ sidebar }) as Navigation;
+
+    describe("sectionIdFor", () => {
+        it("slugs a page path deterministically", () => {
+            expect(sectionIdFor("operating-systems/linux")).toBe("operating-systems-linux");
+            expect(sectionIdFor("./docs/a/b")).toBe("docs-a-b");
+        });
+    });
+
+    describe("collectAsTocPages", () => {
+        it("collects a top-level asToc group under the index host", () => {
+            write("os/linux.md");
+            write("os/windows.md");
+
+            const res = collectAsTocPages(nav([
+                { group: "OS", asToc: true, pages: ["os/linux", "os/windows"] },
+                { group: "Normal", pages: ["other"] },
+            ]));
+
+            expect(Object.keys(res.hosts)).toEqual(["index"]);
+            expect(res.hosts["index"].indexFile).toBe("");
+            expect(res.hosts["index"].sections).toEqual([
+                { page: "os/linux", file: "os/linux.md", id: "os-linux" },
+                { page: "os/windows", file: "os/windows.md", id: "os-windows" },
+            ]);
+            expect(res.pages["os/linux"]).toEqual({ host: "index", id: "os-linux", indicator: true, breadcrumbs: true });
+        });
+
+        it("records the host's own intro file when present (md wins over mdx)", () => {
+            write("index.mdx");
+            write("index.md");
+            write("os/linux.md");
+
+            const res = collectAsTocPages(nav([
+                { group: "OS", asToc: true, pages: ["os/linux"] },
+            ]));
+
+            expect(res.hosts["index"].indexFile).toBe("index.md");
+        });
+
+        it("silently skips missing section files (pagemap parity)", () => {
+            write("os/linux.md");
+
+            const res = collectAsTocPages(nav([
+                { group: "OS", asToc: true, pages: ["os/linux", "os/missing"] },
+            ]));
+
+            expect(res.hosts["index"].sections.map(s => s.page)).toEqual(["os/linux"]);
+            expect(res.pages["os/missing"]).toBeUndefined();
+        });
+
+        it("uses the route slug as host for groups under a SidebarRoute", () => {
+            write("docs.md");
+            write("docs/deep/a.md");
+
+            const res = collectAsTocPages(nav([
+                {
+                    route: "/docs",
+                    pages: [{ group: "Deep", asToc: true, pages: ["docs/deep/a"] }],
+                },
+            ]));
+
+            expect(Object.keys(res.hosts)).toEqual(["docs"]);
+            expect(res.hosts["docs"].indexFile).toBe("docs.md");
+            expect(res.pages["docs/deep/a"]).toEqual({ host: "docs", id: "docs-deep-a", indicator: true, breadcrumbs: true });
+        });
+
+        it("finds asToc groups nested inside normal groups and flattens nested subgroups", () => {
+            write("a/x.md");
+            write("a/y.md");
+
+            const res = collectAsTocPages(nav([
+                {
+                    group: "Outer",
+                    pages: [
+                        "outer-page",
+                        {
+                            group: "Inner", asToc: true, pages: [
+                                "a/x",
+                                { group: "Sub", pages: ["a/y"] },
+                            ]
+                        },
+                    ],
+                },
+            ]));
+
+            expect(res.hosts["index"].sections.map(s => s.page)).toEqual(["a/x", "a/y"]);
+        });
+
+        it("prefixes the top-level host in i18n mode", () => {
+            write("pl/os/linux.md");
+
+            const res = collectAsTocPages(
+                nav([{ group: "OS", asToc: true, pages: ["pl/os/linux"] }]),
+                { hostPrefix: "pl/" }
+            );
+
+            expect(Object.keys(res.hosts)).toEqual(["pl/index"]);
+        });
+
+        it("keeps walk order across multiple asToc groups sharing a host", () => {
+            write("os/linux.md");
+            write("lang/python.md");
+
+            const res = collectAsTocPages(nav([
+                { group: "OS", asToc: true, pages: ["os/linux"] },
+                { group: "Resources", pages: [] },
+                { group: "Lang", asToc: true, pages: ["lang/python"] },
+            ]));
+
+            expect(res.hosts["index"].sections.map(s => s.id)).toEqual(["os-linux", "lang-python"]);
+        });
+
+        it("object form enables and resolves options; false disables", () => {
+            write("os/linux.md");
+            write("lang/python.md");
+            write("off/page.md");
+
+            const res = collectAsTocPages(nav([
+                { group: "OS", asToc: {}, pages: ["os/linux"] },
+                { group: "Lang", asToc: { indicator: false, breadcrumbs: false }, pages: ["lang/python"] },
+                { group: "Off", asToc: false, pages: ["off/page"] },
+            ]));
+
+            expect(res.pages["os/linux"]).toEqual({ host: "index", id: "os-linux", indicator: true, breadcrumbs: true });
+            expect(res.pages["lang/python"]).toEqual({ host: "index", id: "lang-python", indicator: false, breadcrumbs: false });
+            expect(res.pages["off/page"]).toBeUndefined();
+        });
+    });
+
+    describe("mergeAsTocPages / asTocFileMap", () => {
+        it("merges hosts and builds the flat file map", () => {
+            const a = {
+                hosts: { index: { indexFile: "", sections: [{ page: "x", file: "x.md", id: "x" }] } },
+                pages: { x: { host: "index", id: "x", indicator: true, breadcrumbs: true } },
+            };
+            const b = {
+                hosts: { index: { indexFile: "index.md", sections: [{ page: "y", file: "y.md", id: "y" }] } },
+                pages: { y: { host: "index", id: "y", indicator: true, breadcrumbs: true } },
+            };
+            const merged = mergeAsTocPages(a, b);
+            expect(merged.hosts["index"].sections.map(s => s.page)).toEqual(["x", "y"]);
+            expect(merged.hosts["index"].indexFile).toBe("index.md");
+            expect(asTocFileMap(merged)).toEqual({ x: "x.md", y: "y.md" });
+        });
+    });
+
+    describe("mapNavigationToPagePathMapping gate", () => {
+        it("excludes asToc pages at all three walk points (files exist!)", () => {
+            write("index.md");
+            write("normal.md");
+            write("os/linux.md");
+            write("nested/inner.md");
+            write("guides/welcome.md");
+            write("guides/routed.md");
+
+            const mapping = mapNavigationToPagePathMapping(nav([
+                {
+                    group: "Docs", pages: [
+                        "normal",
+                        { group: "NestedToc", asToc: true, pages: ["nested/inner"] },
+                    ]
+                },
+                { group: "TopToc", asToc: true, pages: ["os/linux"] },
+                { group: "ObjectToc", asToc: { indicator: false }, pages: ["nested/inner"] },
+                {
+                    route: "/guides", pages: [
+                        { group: "G", pages: ["guides/welcome"] },
+                        { group: "RoutedToc", asToc: true, pages: ["guides/routed"] },
+                    ]
+                },
+            ]) as any);
+
+            expect(mapping).toEqual({
+                "normal": "normal.md",
+                "guides/welcome": "guides/welcome.md",
+            });
+        });
+    });
+});

--- a/packages/xyd-plugin-docs/src/asToc.ts
+++ b/packages/xyd-plugin-docs/src/asToc.ts
@@ -1,0 +1,194 @@
+import fs from "fs";
+import path from "path";
+
+import type { Navigation, PageURL, Sidebar, SidebarRoute, ResolvedAsTocOptions } from "@xyd-js/core";
+import { asTocOptions } from "@xyd-js/core";
+
+// ---------------------------------------------------------------------------
+// sidebar-as-TOC (`asToc: true` sidebar groups)
+//
+// Pages of an `asToc` group are NOT real pages: they get no route/prerender —
+// instead their markdown is injected as sections into the enclosing route's
+// index page (the "host"), and the sidebar items scroll-spy over those
+// sections. This module is the data plane: a cheap pure-JS walk (run for both
+// engines, native pagemap or not) that mirrors the pagemap traversal and
+// records which pages compose into which host.
+// ---------------------------------------------------------------------------
+
+export interface AsTocSection {
+    /** the sidebar page reference, e.g. "operating-systems/linux" */
+    page: string;
+    /** resolved cwd-relative file with extension, e.g. "operating-systems/linux.md" */
+    file: string;
+    /** deterministic section anchor id (page path with "/" → "-") */
+    id: string;
+}
+
+export interface AsTocHost {
+    /** the host's own intro file ("index.md" / "<route>.md"), "" when none exists */
+    indexFile: string;
+    /** sections in sidebar walk order (across ALL asToc groups sharing the host) */
+    sections: AsTocSection[];
+}
+
+export interface AsTocPages {
+    /** host slug (e.g. "index", "docs") → composition recipe */
+    hosts: Record<string, AsTocHost>;
+    /**
+     * section page slug → its host + anchor id (for hrefs, 404s, exclusions)
+     * + the owning group's RESOLVED behavior options (indicator/breadcrumbs).
+     */
+    pages: Record<string, { host: string; id: string } & ResolvedAsTocOptions>;
+}
+
+declare global {
+    // Set at pluginDocs() boot; read by mapSettingsToProps (hrefs/titles/
+    // navlinks), the page loaders (composition + 404), docPaths and search
+    // (exclusions). Absent when no asToc groups are configured.
+    var __xydAsTocPages: AsTocPages | undefined;
+}
+
+/** Section anchor id for a sidebar page reference — heading-independent. */
+export function sectionIdFor(page: string): string {
+    return page.replace(/^\.?\//, "").replace(/\//g, "-");
+}
+
+export interface CollectAsTocOptions {
+    /** base dir for file probes (default process.cwd()) */
+    cwd?: string;
+    /** i18n locale prefix (e.g. "pl/") for the top-level host slug */
+    hostPrefix?: string;
+    /** injectable existence probe for tests */
+    exists?: (relPath: string) => boolean;
+}
+
+/**
+ * Walk a navigation tree (already i18n-prefixed, same as the pagemap walk) and
+ * collect every `asToc: true` group's pages, grouped by their host page:
+ * `"<hostPrefix>index"` for top-level groups, the route slug for groups under a
+ * `SidebarRoute`. Only STRING pages become sections (virtual/component entries
+ * inside asToc groups are ignored); missing files are silently skipped —
+ * parity with the pagemap walk. Nested groups inside an asToc group contribute
+ * their string pages too (the whole subtree is non-routable).
+ */
+export function collectAsTocPages(
+    navigation: Navigation | undefined,
+    options: CollectAsTocOptions = {}
+): AsTocPages {
+    const cwd = options.cwd || process.cwd();
+    const hostPrefix = options.hostPrefix || "";
+    const exists = options.exists || ((rel: string) => fs.existsSync(path.join(cwd, rel)));
+
+    const result: AsTocPages = { hosts: {}, pages: {} };
+
+    function existingFilePath(basePath: string): string | null {
+        const md = `${basePath}.md`;
+        if (exists(md)) return md;
+        const mdx = `${basePath}.mdx`;
+        if (exists(mdx)) return mdx;
+        return null;
+    }
+
+    function hostFor(hostSlug: string): AsTocHost {
+        let host = result.hosts[hostSlug];
+        if (!host) {
+            // The host's own intro file sits at the host slug itself
+            // ("index.md" at root, "docs.md" for route "/docs").
+            host = { indexFile: existingFilePath(hostSlug) || "", sections: [] };
+            result.hosts[hostSlug] = host;
+        }
+        return host;
+    }
+
+    /** Collect every descendant string page of an asToc group as sections. */
+    function collectGroup(pages: PageURL[] | undefined, hostSlug: string, opts: ResolvedAsTocOptions) {
+        for (const page of pages || []) {
+            if (typeof page === "string") {
+                const file = existingFilePath(page);
+                if (!file) continue;
+                const id = sectionIdFor(page);
+                hostFor(hostSlug).sections.push({ page, file, id });
+                result.pages[page] = { host: hostSlug, id, ...opts };
+            } else if (page && typeof page === "object" && "pages" in page) {
+                collectGroup((page as Sidebar).pages, hostSlug, opts);
+            }
+            // virtual/component entries: not composable — ignored (v1)
+        }
+    }
+
+    /** Walk non-asToc pages looking for nested asToc groups. */
+    function findNested(pages: PageURL[] | undefined, hostSlug: string) {
+        for (const page of pages || []) {
+            if (!page || typeof page !== "object" || !("pages" in page)) continue;
+            const group = page as Sidebar;
+            const opts = asTocOptions(group.asToc);
+            if (opts) {
+                collectGroup(group.pages, hostSlug, opts);
+            } else {
+                findNested(group.pages, hostSlug);
+            }
+        }
+    }
+
+    const topHost = `${hostPrefix}index`;
+
+    for (const entry of navigation?.sidebar || []) {
+        if (typeof entry === "string") continue; // flat-only sidebars have no groups
+        if (!entry || typeof entry !== "object") continue;
+
+        if ("pages" in entry && "route" in entry) {
+            // SidebarRoute — host is the route slug itself.
+            const route = (entry as SidebarRoute).route || "";
+            const routeHost = route.replace(/^\//, "").replace(/\/$/, "") || topHost;
+            for (const item of (entry as SidebarRoute).pages || []) {
+                if (!item || typeof item !== "object" || !("pages" in item)) continue;
+                const group = item as Sidebar;
+                const opts = asTocOptions(group.asToc);
+                if (opts) {
+                    collectGroup(group.pages, routeHost, opts);
+                } else {
+                    findNested(group.pages, routeHost);
+                }
+            }
+        } else if ("pages" in entry) {
+            const group = entry as Sidebar;
+            const opts = asTocOptions(group.asToc);
+            if (opts) {
+                collectGroup(group.pages, topHost, opts);
+            } else {
+                findNested(group.pages, topHost);
+            }
+        }
+    }
+
+    // Drop hosts that ended up with no sections (all files missing).
+    for (const [slug, host] of Object.entries(result.hosts)) {
+        if (!host.sections.length) delete result.hosts[slug];
+    }
+
+    return result;
+}
+
+/** Merge locale-scoped collections into one (boot merges per-language walks). */
+export function mergeAsTocPages(target: AsTocPages, source: AsTocPages): AsTocPages {
+    for (const [slug, host] of Object.entries(source.hosts)) {
+        const existing = target.hosts[slug];
+        if (existing) {
+            existing.sections.push(...host.sections);
+            if (!existing.indexFile) existing.indexFile = host.indexFile;
+        } else {
+            target.hosts[slug] = host;
+        }
+    }
+    Object.assign(target.pages, source.pages);
+    return target;
+}
+
+/** Flat `sectionSlug → file` map — merged into frontmatter lookups for titles. */
+export function asTocFileMap(asTocPages: AsTocPages | undefined): Record<string, string> {
+    const map: Record<string, string> = {};
+    for (const host of Object.values(asTocPages?.hosts || {})) {
+        for (const s of host.sections) map[s.page] = s.file;
+    }
+    return map;
+}

--- a/packages/xyd-plugin-docs/src/index.ts
+++ b/packages/xyd-plugin-docs/src/index.ts
@@ -1,4 +1,4 @@
-import { Navigation, Settings, LanguageNavigation, TranslationCatalog } from "@xyd-js/core";
+import { Navigation, Settings, LanguageNavigation, TranslationCatalog, asTocEnabled } from "@xyd-js/core";
 import type { Plugin as VitePlugin } from "vite";
 import { RouteConfigEntry } from "@react-router/dev/routes";
 import type { PageURL, Sidebar, SidebarRoute } from "@xyd-js/core";
@@ -131,8 +131,11 @@ import { cliPreset } from "./presets/cli";
 import type { PluginOutput, Plugin } from "./types";
 import { ensureAndCleanupVirtualFolder } from "./presets/uniform";
 import { settingsNative } from "./native";
+import { collectAsTocPages, mergeAsTocPages, type AsTocPages } from "./asToc";
 
 export { readSettings } from "./presets/docs/settings"
+export { collectAsTocPages, mergeAsTocPages, asTocFileMap, sectionIdFor } from "./asToc"
+export type { AsTocPages, AsTocHost, AsTocSection } from "./asToc"
 
 // S6+ W6: the nav→pagepath walk (the "batched" existsSync-eliminating pass)
 // runs in Rust (crates/xyd_settings) when the native core is present. The
@@ -434,6 +437,11 @@ export async function pluginDocs(options?: PluginDocsOptions): Promise<PluginOut
         globalThis.__xydI18nTranslations = loaded
     }
 
+    // sidebar-as-TOC data plane: which pages compose into which host page.
+    // Collected alongside the pagepath walks (per locale in i18n mode) so the
+    // key spaces match; empty ⇒ no asToc groups configured.
+    const asTocPages: AsTocPages = { hosts: {}, pages: {} }
+
     if (settings?.navigation) {
         if (i18n) {
             // Catalog-only mode: when a language entry omits sidebar/tabs/etc.,
@@ -461,9 +469,11 @@ export async function pluginDocs(options?: PluginDocsOptions): Promise<PluginOut
                 }
                 const subMapping = resolvePagePathMapping(localeNav)
                 Object.assign(pagePathMapping, subMapping)
+                mergeAsTocPages(asTocPages, collectAsTocPages(localeNav, { hostPrefix: localePrefix }))
             }
         } else {
             pagePathMapping = resolvePagePathMapping(settings?.navigation)
+            mergeAsTocPages(asTocPages, collectAsTocPages(settings?.navigation))
         }
     } else {
         console.warn("No navigation found in settings")
@@ -483,13 +493,25 @@ export async function pluginDocs(options?: PluginDocsOptions): Promise<PluginOut
         pagePathMapping["index"] = indexPage
     }
 
+    // sidebar-as-TOC hosts: make every host slug routable. A host without its
+    // own intro file maps to its first section's file — the mapping entry is
+    // what drives prerender/404/sitemap; the page loaders always rebuild the
+    // actual content from __xydAsTocPages.hosts[slug] (composition), so what
+    // the entry points at only affects fallback metadata.
+    globalThis.__xydAsTocPages = Object.keys(asTocPages.hosts).length ? asTocPages : undefined
+    for (const [hostSlug, host] of Object.entries(asTocPages.hosts)) {
+        if (!pagePathMapping[hostSlug]) {
+            pagePathMapping[hostSlug] = host.indexFile || host.sections[0].file
+        }
+    }
+
     return {
         vitePlugins,
         settings,
         routes,
         basePath,
         pagePathMapping,
-        hasIndexPage: !!indexPage
+        hasIndexPage: !!indexPage || !!asTocPages.hosts["index"]
     }
 }
 
@@ -652,7 +674,7 @@ function prefixSidebarPages(sidebar: any[], prefix: string) {
 }
 
 // TODO: in the future better algorithm - we should be .md/.mdx faster than checking fs here
-function mapNavigationToPagePathMapping(navigation: Navigation) {
+export function mapNavigationToPagePathMapping(navigation: Navigation) {
     const mapping: Record<string, string> = {}
 
     function getExistingFilePath(basePath: string): string | null {
@@ -685,6 +707,10 @@ function mapNavigationToPagePathMapping(navigation: Navigation) {
                     mapping[pagePath] = existingPath
                 }
             } else if (typeof page === 'object' && 'pages' in page) {
+                // asToc group: its pages are TOC sections of the host page,
+                // not routable pages — skip the whole subtree (collected
+                // separately by collectAsTocPages).
+                if (asTocEnabled((page as Sidebar).asToc)) continue
                 // Handle nested sidebar
                 processPages(page.pages || [])
             }
@@ -701,6 +727,8 @@ function mapNavigationToPagePathMapping(navigation: Navigation) {
             // Handle SidebarRoute
             for (const item of sidebar.pages) {
                 if (item?.pages) {
+                    // asToc group under a route — sections, not pages.
+                    if (asTocEnabled((item as Sidebar).asToc)) continue
                     processPages(item.pages)
                 } else if (typeof item === 'string') {
                     // Handle direct string pages in SidebarRoute
@@ -711,7 +739,8 @@ function mapNavigationToPagePathMapping(navigation: Navigation) {
                 }
             }
         } else if ('pages' in sidebar) {
-            // Handle Sidebar
+            // Handle Sidebar (top-level asToc group — sections, not pages)
+            if (asTocEnabled((sidebar as Sidebar).asToc)) continue
             processPages(sidebar.pages || [])
         }
     }

--- a/packages/xyd-plugin-docs/src/index.ts
+++ b/packages/xyd-plugin-docs/src/index.ts
@@ -674,17 +674,19 @@ function prefixSidebarPages(sidebar: any[], prefix: string) {
 }
 
 // TODO: in the future better algorithm - we should be .md/.mdx faster than checking fs here
-export function mapNavigationToPagePathMapping(navigation: Navigation) {
+// `cwd` scopes the file probes (defaults to process.cwd(), matching the Rust
+// port's explicit cwd argument); mapping VALUES stay cwd-relative either way.
+export function mapNavigationToPagePathMapping(navigation: Navigation, cwd?: string) {
     const mapping: Record<string, string> = {}
 
     function getExistingFilePath(basePath: string): string | null {
         const mdPath = `${basePath}.md`
         const mdxPath = `${basePath}.mdx`
 
-        if (fs.existsSync(mdPath)) {
+        if (fs.existsSync(cwd ? path.join(cwd, mdPath) : mdPath)) {
             return mdPath
         }
-        if (fs.existsSync(mdxPath)) {
+        if (fs.existsSync(cwd ? path.join(cwd, mdxPath) : mdxPath)) {
             return mdxPath
         }
         return null

--- a/packages/xyd-plugin-docs/src/pages/page.tsx
+++ b/packages/xyd-plugin-docs/src/pages/page.tsx
@@ -6,7 +6,7 @@ import { useMemo, useContext, useState, ReactElement, SVGProps, useEffect } from
 import { redirect, ScrollRestoration, useLocation, useNavigation } from "react-router";
 
 import { MetadataMap, Metadata, Settings } from "@xyd-js/core"
-import { ContentFS } from "@xyd-js/content"
+import { ContentFS, composeAsTocRaw, isAsTocSectionPage } from "@xyd-js/content"
 import { markdownPlugins } from "@xyd-js/content/md"
 import { pageMetaLayout } from "@xyd-js/framework";
 import { mapSettingsToProps } from "@xyd-js/framework/hydration";
@@ -232,10 +232,24 @@ export async function loader({ request }: { request: any }) {
 
     if (pagePath && !shellOnly) {
         timedebug.compile
-        code = await contentFs.compile(pagePath)
-        rawPage = await contentFs.readRaw(pagePath)
+        // sidebar-as-TOC host: compose the page from its asToc groups'
+        // section files instead of the mapped single file.
+        const composed = await composeAsTocRaw(slug)
+        if (composed) {
+            rawPage = composed.raw
+            code = await contentFs.compileContent(composed.raw, composed.filePath)
+        } else {
+            code = await contentFs.compile(pagePath)
+            rawPage = await contentFs.readRaw(pagePath)
+        }
         timedebug.compileEnd
     } else if (!pagePath) {
+        // sidebar-as-TOC section pages are NOT real pages — a direct visit is
+        // a 404, never a redirect (their content lives on the host page).
+        if (isAsTocSectionPage(slug)) {
+            timedebug.totalEnd
+            throw new Response("Not Found", { status: 404 })
+        }
         const resp = redirectFallback()
         if (resp) {
             timedebug.totalEnd

--- a/packages/xyd-themes/src/Theme.tsx
+++ b/packages/xyd-themes/src/Theme.tsx
@@ -68,7 +68,9 @@ export abstract class Theme {
 
     protected useHideToc() {
         const meta = useMetadata()
-        return meta?.layout === "wide" || meta?.layout === "reader" || meta?.layout === "page"
+        // asTocHost: the sidebar IS the page's TOC (sidebar-as-TOC composed
+        // page) — the right-hand TOC would duplicate it.
+        return meta?.layout === "wide" || meta?.layout === "reader" || meta?.layout === "page" || meta?.asTocHost === true
     }
 
     protected useHideSidebar() {

--- a/packages/xyd-ui/src/components/Sidebar/Sidebar.styles.tsx
+++ b/packages/xyd-ui/src/components/Sidebar/Sidebar.styles.tsx
@@ -21,9 +21,62 @@ export const SidebarHost = css`
             & > * {
                 padding-bottom: 4px;
             }
-            
+
             & + [part="item"] {
                 margin-top: 24px;
+            }
+        }
+
+        /* sidebar-as-TOC groups (asToc + indicator enabled): CONSECUTIVE
+           groups share ONE wrapper — headers included — so a single
+           continuous TOC track line spans them (the right-hand TOC's look).
+           The active section paints its own segment of the track (same
+           tokens as xyd-toc), replacing the sidebar's built-in active mark. */
+        [part="item-group"][data-astoc="true"] {
+            position: relative;
+            display: block;
+            padding-left: 10px;
+            margin-top: 24px;
+
+            /* the wrapper carries the group separation — the first header's
+               own top margin would push the track above it as a stray line */
+            [part="item-header"]:first-child {
+                margin-top: 0;
+            }
+
+            /* sidebar filter matched nothing inside → no items, no track */
+            &:not(:has(li)) {
+                display: none;
+            }
+
+            &::before {
+                content: "";
+                position: absolute;
+                top: 4px;
+                bottom: 4px;
+                left: 0;
+                width: 2px;
+                border-radius: 2px;
+                background-color: var(--xyd-toc-bgcolor);
+            }
+
+            [part="item"] {
+                position: relative;
+            }
+            [part="item"]:has(> * > [part="primary-item"][data-active="true"])::before {
+                content: "";
+                position: absolute;
+                top: 2px;
+                bottom: 2px;
+                left: -10px;
+                width: 2px;
+                border-radius: 2px;
+                background-color: var(--xyd-toc-scroll-bgcolor);
+                transition: top .2s ease, bottom .2s ease;
+            }
+            /* the track replaces the built-in active mark */
+            [part="primary-item"][data-active="true"]::before {
+                display: none;
             }
         }
         [part="scroll-shadow"]::before {

--- a/packages/xyd-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/xyd-ui/src/components/Sidebar/Sidebar.tsx
@@ -67,8 +67,8 @@ export interface UISidebarItemProps {
     onClick?: (v: any) => void
 }
 
-UISidebar.ItemGroup = function SidebarItemGroup({ children }: { children: React.ReactNode }) {
-    return <div part="item-group">
+UISidebar.ItemGroup = function SidebarItemGroup({ children, asToc }: { children: React.ReactNode, asToc?: boolean }) {
+    return <div part="item-group" data-astoc={asToc ? "true" : undefined}>
         {children}
     </div>
 }


### PR DESCRIPTION
… with sidebar scroll-spy

Sidebar groups can declare asToc (boolean or { indicator, breadcrumbs }): their pages stop being routes — content is composed into the enclosing route's index page as anchored sections, sidebar items scroll to them with scroll-spy active marking, the right-hand TOC is hidden, and consecutive asToc groups share one continuous TOC track line in the sidebar. Host-page breadcrumbs follow the section being read. Normal groups mix freely.

Gated in both pagemap implementations (JS walk + Rust crates/xyd_settings used by the native binary) plus routes, prerender, search, navlinks, and the dev preload. Composed sections get join spacing + scroll-margin under sticky headers. E2E suite runs both engines; unit tests cover the collector, composition, config normalization, and the Rust parity fixture.