### PR TITLE
feat(navigation): nested items in sidebar-dropdown segments — inline …

### DIFF
--- a/__tests__/e2e/1.navigation/6.sidebar-dropdown-nested/docs.json
+++ b/__tests__/e2e/1.navigation/6.sidebar-dropdown-nested/docs.json
@@ -1,0 +1,41 @@
+{
+    "theme": {
+        "name": "poetry"
+    },
+    "navigation": {
+        "segments": [
+            {
+                "route": "docs",
+                "appearance": "sidebarDropdown",
+                "pages": [
+                    { "title": "Guides", "page": "docs/guides", "href": "docs/guides/index", "icon": "book" },
+                    { "title": "Reference", "page": "docs/reference", "href": "docs/reference/index", "icon": "braces" },
+                    {
+                        "title": "SDKs",
+                        "icon": "package",
+                        "description": "Client libraries",
+                        "pages": [
+                            { "title": "JavaScript SDK", "page": "docs/sdk/js", "href": "docs/sdk/js/index", "icon": "code" },
+                            { "title": "Python SDK", "page": "docs/sdk/py", "href": "docs/sdk/py/index" }
+                        ]
+                    },
+                    {
+                        "title": "Deployment",
+                        "pages": [
+                            { "title": "Docker", "page": "docs/deploy/docker", "href": "docs/deploy/docker/index" },
+                            { "title": "Kubernetes", "page": "docs/deploy/k8s", "href": "docs/deploy/k8s/index" }
+                        ]
+                    }
+                ]
+            }
+        ],
+        "sidebar": [
+            { "route": "/docs/guides", "pages": [{ "group": "Guides", "pages": ["docs/guides/index", "docs/guides/writing"] }] },
+            { "route": "/docs/reference", "pages": [{ "group": "Reference", "pages": ["docs/reference/index"] }] },
+            { "route": "/docs/sdk/js", "pages": [{ "group": "JavaScript SDK", "pages": ["docs/sdk/js/index"] }] },
+            { "route": "/docs/sdk/py", "pages": [{ "group": "Python SDK", "pages": ["docs/sdk/py/index"] }] },
+            { "route": "/docs/deploy/docker", "pages": [{ "group": "Docker", "pages": ["docs/deploy/docker/index"] }] },
+            { "route": "/docs/deploy/k8s", "pages": [{ "group": "Kubernetes", "pages": ["docs/deploy/k8s/index"] }] }
+        ]
+    }
+}

--- a/__tests__/e2e/1.navigation/6.sidebar-dropdown-nested/docs/deploy/docker/index.md
+++ b/__tests__/e2e/1.navigation/6.sidebar-dropdown-nested/docs/deploy/docker/index.md
@@ -1,0 +1,11 @@
+---
+title: Docker Deployment
+---
+
+# Docker Deployment
+
+Content for Docker Deployment.
+
+## Details
+
+More about Docker Deployment.

--- a/__tests__/e2e/1.navigation/6.sidebar-dropdown-nested/docs/deploy/k8s/index.md
+++ b/__tests__/e2e/1.navigation/6.sidebar-dropdown-nested/docs/deploy/k8s/index.md
@@ -1,0 +1,11 @@
+---
+title: Kubernetes Deployment
+---
+
+# Kubernetes Deployment
+
+Content for Kubernetes Deployment.
+
+## Details
+
+More about Kubernetes Deployment.

--- a/__tests__/e2e/1.navigation/6.sidebar-dropdown-nested/docs/guides/index.md
+++ b/__tests__/e2e/1.navigation/6.sidebar-dropdown-nested/docs/guides/index.md
@@ -1,0 +1,11 @@
+---
+title: Guides Overview
+---
+
+# Guides Overview
+
+Content for Guides Overview.
+
+## Details
+
+More about Guides Overview.

--- a/__tests__/e2e/1.navigation/6.sidebar-dropdown-nested/docs/guides/writing.md
+++ b/__tests__/e2e/1.navigation/6.sidebar-dropdown-nested/docs/guides/writing.md
@@ -1,0 +1,11 @@
+---
+title: Writing Guides
+---
+
+# Writing Guides
+
+Content for Writing Guides.
+
+## Details
+
+More about Writing Guides.

--- a/__tests__/e2e/1.navigation/6.sidebar-dropdown-nested/docs/reference/index.md
+++ b/__tests__/e2e/1.navigation/6.sidebar-dropdown-nested/docs/reference/index.md
@@ -1,0 +1,11 @@
+---
+title: Reference Overview
+---
+
+# Reference Overview
+
+Content for Reference Overview.
+
+## Details
+
+More about Reference Overview.

--- a/__tests__/e2e/1.navigation/6.sidebar-dropdown-nested/docs/sdk/js/index.md
+++ b/__tests__/e2e/1.navigation/6.sidebar-dropdown-nested/docs/sdk/js/index.md
@@ -1,0 +1,11 @@
+---
+title: JavaScript SDK Overview
+---
+
+# JavaScript SDK Overview
+
+Content for JavaScript SDK Overview.
+
+## Details
+
+More about JavaScript SDK Overview.

--- a/__tests__/e2e/1.navigation/6.sidebar-dropdown-nested/docs/sdk/py/index.md
+++ b/__tests__/e2e/1.navigation/6.sidebar-dropdown-nested/docs/sdk/py/index.md
@@ -1,0 +1,11 @@
+---
+title: Python SDK Overview
+---
+
+# Python SDK Overview
+
+Content for Python SDK Overview.
+
+## Details
+
+More about Python SDK Overview.

--- a/__tests__/e2e/1.navigation/6.sidebar-dropdown-nested/sidebar-dropdown-nested.test.ts
+++ b/__tests__/e2e/1.navigation/6.sidebar-dropdown-nested/sidebar-dropdown-nested.test.ts
@@ -1,0 +1,164 @@
+import { test, expect, Page } from '@playwright/test';
+
+import { createXydServer, createXydBunServer, XydServer } from '../../utils/xyd-server';
+
+// Nested items in a sidebar-dropdown segment: a `pages` entry may itself be
+// `{ title, icon?, description?, pages: [...] }` — it renders as an inline-
+// expandable GROUP row inside the dropdown popover (accordion), children
+// indented; leaves keep normal link behavior. The group containing the ACTIVE
+// page auto-expands; expansion state resets when the popover closes. Run on
+// BOTH engines (shared render path; the framework/ui dists differ per engine
+// packaging).
+const ENGINES: { name: string; make: (dir: string) => Promise<XydServer> }[] = [
+    { name: 'bun', make: (dir) => createXydBunServer(dir) },
+    { name: 'vite', make: (dir) => createXydServer(dir) },
+];
+
+for (const engine of ENGINES) {
+    test.describe(`navigation — sidebar-dropdown nested (${engine.name} engine)`, () => {
+        // One dev server per engine (parallel workers would each boot their own
+        // server and vite cold boots exceed the 2-minute start timeout).
+        test.describe.configure({ mode: 'serial' });
+
+        let server: XydServer;
+
+        test.beforeAll(async () => {
+            server = await engine.make(__dirname);
+        });
+
+        test.afterAll(async () => {
+            await server?.stop();
+        });
+
+        async function goto(page: Page, path: string) {
+            await page.goto(server.getUrl(path));
+            await page.waitForLoadState('networkidle');
+        }
+
+        const dropdown = (page: Page) => page.locator('aside[part="sidebar"] xyd-sidebar-tabs-dropdown');
+        const trigger = (page: Page) => dropdown(page).locator('[part="dropdown-trigger"]');
+        const list = (page: Page) => dropdown(page).locator('[part="dropdown-list"]');
+        const groupRow = (page: Page, title: string) =>
+            list(page).locator(`button[part="dropdown-listitem"][data-group]`, { hasText: title });
+
+        test('the switcher renders; trigger shows the active section; click opens the list', async ({ page }) => {
+            await goto(page, '/docs/guides/index');
+
+            await expect(trigger(page)).toBeVisible();
+            await expect(trigger(page).locator('[part="dropdown-label"]')).toHaveText('Guides');
+
+            await trigger(page).click();
+            await expect(list(page)).toBeVisible();
+        });
+
+        test('leaf entries are links and navigate (popover closes)', async ({ page }) => {
+            await goto(page, '/docs/guides/index');
+            await trigger(page).click();
+
+            const reference = list(page).locator('a[part="dropdown-listitem"]', { hasText: 'Reference' });
+            await expect(reference).toHaveAttribute('href', /\/docs\/reference\/index$/);
+
+            await reference.click();
+            await expect.poll(() => page.evaluate(() => window.location.pathname))
+                .toContain('/docs/reference/index');
+            await expect(list(page)).toHaveCount(0);
+        });
+
+        test('a nested group renders as a collapsed button row (icon, description, chevron — not a link)', async ({ page }) => {
+            await goto(page, '/docs/guides/index');
+            await trigger(page).click();
+
+            const sdks = groupRow(page, 'SDKs');
+            await expect(sdks).toHaveCount(1);
+            await expect(list(page).locator('a[data-group]')).toHaveCount(0);
+
+            await expect(sdks.locator('[part="dropdown-icon"]')).toHaveCount(1);
+            await expect(sdks.locator('[part="dropdown-description"]')).toHaveText('Client libraries');
+            await expect(sdks.locator('[part="dropdown-chevron"]')).toHaveCount(1);
+            await expect(sdks).toHaveAttribute('aria-expanded', 'false');
+            await expect(list(page).locator('[part="dropdown-sublist"]')).toHaveCount(0);
+        });
+
+        test('clicking a group expands its children inline (popover stays open); clicking again collapses', async ({ page }) => {
+            await goto(page, '/docs/guides/index');
+            await trigger(page).click();
+
+            const sdks = groupRow(page, 'SDKs');
+            await sdks.click();
+
+            await expect(sdks).toHaveAttribute('aria-expanded', 'true');
+            const sublist = list(page).locator('[part="dropdown-sublist"]');
+            await expect(sublist).toHaveCount(1);
+            await expect(sublist.locator('a[part="dropdown-listitem"]')).toHaveCount(2);
+            await expect(sublist).toBeVisible();
+            // the popover did NOT close
+            await expect(list(page)).toBeVisible();
+
+            // container-level indent (survives theme listitem-padding overrides)
+            const padding = await sublist.evaluate((el) => getComputedStyle(el).paddingLeft);
+            expect(parseFloat(padding)).toBeGreaterThanOrEqual(14);
+
+            // chevron rotated when expanded
+            const transform = await sdks.locator('[part="dropdown-chevron"]')
+                .evaluate((el) => getComputedStyle(el).transform);
+            expect(transform).not.toBe('none');
+
+            await sdks.click();
+            await expect(sdks).toHaveAttribute('aria-expanded', 'false');
+            await expect(list(page).locator('[part="dropdown-sublist"]')).toHaveCount(0);
+        });
+
+        test('clicking a nested child navigates, closes the popover, and the trigger shows the child', async ({ page }) => {
+            await goto(page, '/docs/guides/index');
+            await trigger(page).click();
+            await groupRow(page, 'SDKs').click();
+
+            await list(page).locator('a[part="dropdown-listitem"]', { hasText: 'JavaScript SDK' }).click();
+
+            await expect.poll(() => page.evaluate(() => window.location.pathname))
+                .toContain('/docs/sdk/js/index');
+            await expect(list(page)).toHaveCount(0);
+            await expect(trigger(page).locator('[part="dropdown-label"]')).toHaveText('JavaScript SDK');
+        });
+
+        test('on a nested child page its group auto-expands and the child is selected', async ({ page }) => {
+            await goto(page, '/docs/sdk/py/index');
+
+            await expect(trigger(page).locator('[part="dropdown-label"]')).toHaveText('Python SDK');
+            await trigger(page).click();
+
+            await expect(groupRow(page, 'SDKs')).toHaveAttribute('aria-expanded', 'true');
+            const py = list(page).locator('a[part="dropdown-listitem"]', { hasText: 'Python SDK' });
+            await expect(py).toHaveAttribute('aria-selected', 'true');
+            await expect(py.locator('[part="chevron-check"] svg')).toHaveCount(1);
+
+            // the OTHER group stays collapsed
+            await expect(groupRow(page, 'Deployment')).toHaveAttribute('aria-expanded', 'false');
+        });
+
+        test('Escape closes the popover', async ({ page }) => {
+            await goto(page, '/docs/guides/index');
+            await trigger(page).click();
+            await expect(list(page)).toBeVisible();
+
+            await page.keyboard.press('Escape');
+            await expect(list(page)).toHaveCount(0);
+        });
+
+        test('expansion state resets when the popover closes', async ({ page }) => {
+            await goto(page, '/docs/guides/index');
+            await trigger(page).click();
+
+            await groupRow(page, 'Deployment').click();
+            await expect(groupRow(page, 'Deployment')).toHaveAttribute('aria-expanded', 'true');
+
+            await page.keyboard.press('Escape');
+            await expect(list(page)).toHaveCount(0);
+
+            await trigger(page).click();
+            // fresh state: active page (Guides) is not inside any group → both collapsed
+            await expect(groupRow(page, 'Deployment')).toHaveAttribute('aria-expanded', 'false');
+            await expect(groupRow(page, 'SDKs')).toHaveAttribute('aria-expanded', 'false');
+        });
+    });
+}

--- a/packages/xyd-core/src/types/settings.ts
+++ b/packages/xyd-core/src/types/settings.ts
@@ -971,6 +971,17 @@ export interface NavigationItem {
   dropdownMenu?: NavigationItem[] | DropdownMenu;
 
   /**
+   * Nested navigation items — recursive. Honored ONLY by sidebar-dropdown
+   * surfaces (`navigation.sidebarDropdown` and `appearance: "sidebarDropdown"`
+   * segments): an entry with `pages` (typically without `page`/`href`) renders
+   * as an inline-expandable GROUP row inside the dropdown popover — clicking
+   * it expands its children (indented) within the same popover. `title`,
+   * `icon`, and `description` apply to the group row. Other appearances
+   * (tabs, logoTrailing) ignore nesting.
+   */
+  pages?: NavigationItem[];
+
+  /**
    * How the `dropdownMenu` opens. Defaults to `"hover"`.
    */
   trigger?: "hover" | "click";

--- a/packages/xyd-framework/__tests__/segmentSidebarDropdown.test.ts
+++ b/packages/xyd-framework/__tests__/segmentSidebarDropdown.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+
+import type { NavigationItem } from "@xyd-js/core";
+
+import { flattenNavigationPages, findActiveNavigationPage } from "../packages/react/utils/segmentSidebarDropdown";
+
+/**
+ * Sidebar-dropdown nesting helpers: a NavigationItem inside a sidebarDropdown
+ * segment (or the global `navigation.sidebarDropdown`) may declare nested
+ * `pages` — an inline-expandable GROUP in the dropdown. Matching logic
+ * flattens that nesting; for flat configs both helpers behave exactly like
+ * the flat `findLast` they replaced.
+ */
+
+const NESTED: NavigationItem[] = [
+    { title: "Guides", page: "docs/guides", icon: "book" },
+    { title: "Reference", page: "docs/reference" },
+    {
+        title: "SDKs", icon: "package", pages: [
+            { title: "JavaScript SDK", page: "docs/sdk/js" },
+            { title: "Python SDK", page: "docs/sdk/py" },
+        ],
+    },
+    {
+        title: "Deployment", pages: [
+            { title: "Docker", page: "docs/deploy/docker" },
+            {
+                title: "Cloud", pages: [
+                    { title: "Kubernetes", page: "docs/deploy/k8s" },
+                ],
+            },
+        ],
+    },
+];
+
+describe("flattenNavigationPages", () => {
+    it("is identity-shaped for flat configs (order preserved)", () => {
+        const flat: NavigationItem[] = [
+            { title: "A", page: "a" },
+            { title: "B", page: "b" },
+        ];
+        expect(flattenNavigationPages(flat)).toEqual(flat);
+    });
+
+    it("flattens depth-first, parents before children", () => {
+        expect(flattenNavigationPages(NESTED).map(i => i.title)).toEqual([
+            "Guides", "Reference",
+            "SDKs", "JavaScript SDK", "Python SDK",
+            "Deployment", "Docker", "Cloud", "Kubernetes",
+        ]);
+    });
+
+    it("handles undefined/empty", () => {
+        expect(flattenNavigationPages(undefined)).toEqual([]);
+        expect(flattenNavigationPages([])).toEqual([]);
+    });
+});
+
+describe("findActiveNavigationPage", () => {
+    it("matches a top-level leaf by route prefix", () => {
+        expect(findActiveNavigationPage(NESTED, "/docs/guides/intro")?.title).toBe("Guides");
+    });
+
+    it("matches a NESTED leaf by route prefix", () => {
+        expect(findActiveNavigationPage(NESTED, "/docs/sdk/py/quickstart")?.title).toBe("Python SDK");
+        expect(findActiveNavigationPage(NESTED, "/docs/deploy/k8s/setup")?.title).toBe("Kubernetes");
+    });
+
+    it("group rows without a page never match", () => {
+        // "/docs/sdk" is under no leaf prefix; SDKs itself has no `page`
+        expect(findActiveNavigationPage(NESTED, "/docs/sdk")).toBeNull();
+    });
+
+    it("last declared match wins (findLast semantics)", () => {
+        const overlapping: NavigationItem[] = [
+            { title: "Docs", page: "docs" },
+            { title: "SDK JS", pages: [{ title: "Deep", page: "docs/sdk/js" }] },
+        ];
+        expect(findActiveNavigationPage(overlapping, "/docs/sdk/js/intro")?.title).toBe("Deep");
+    });
+
+    it("no match → null", () => {
+        expect(findActiveNavigationPage(NESTED, "/other/page")).toBeNull();
+        expect(findActiveNavigationPage(undefined, "/docs/guides")).toBeNull();
+    });
+});

--- a/packages/xyd-framework/packages/react/components/FwSidebarTabsDropdown.tsx
+++ b/packages/xyd-framework/packages/react/components/FwSidebarTabsDropdown.tsx
@@ -3,7 +3,7 @@ import React from "react"
 import { useSettings } from "../contexts"
 
 import { Icon } from "@xyd-js/components/writer"
-import { SidebarTabsDropdown, UISidebar } from "@xyd-js/ui"
+import { SidebarTabsDropdown, UISidebar, type SidebarTabsDropdownOption } from "@xyd-js/ui"
 
 import { useActivePage, useActiveSegment, useMatchedSegmentSidebarDropdown } from "../hooks"
 import { NavigationItem } from "@xyd-js/core"
@@ -22,8 +22,10 @@ import { pageLink, segmentAppearanceOptions } from "../utils"
 export function FwSidebarTabsDropdown({ fixed = false }: { fixed?: boolean } = {}) {
     const settings = useSettings()
 
-    const activeSegment = useActiveSegment()
     const matchedSegmentSidebarDropdown = useMatchedSegmentSidebarDropdown()
+    // Resolve active against the DROPDOWN segment's own pages (nested groups
+    // flattened) — a co-routed `tabs` segment must not shadow nested leaves.
+    const activeSegment = useActiveSegment(matchedSegmentSidebarDropdown)
 
     const activePage = useActivePage(true)
 
@@ -66,28 +68,31 @@ function $NavigationItemsSidebarTabs({ items, active }: { items: NavigationItem[
         return null
     }
 
+    // Recursive: an item with nested `pages` becomes a GROUP option (inline-
+    // expandable row in the dropdown); its children map the same way.
+    function toOption(item: NavigationItem): SidebarTabsDropdownOption {
+        let href: string | null = null
 
+        if (typeof item.href === "string") {
+            href = pageLink(item.href)
+        }
+
+        if (!href && typeof item.page === "string") {
+            href = pageLink(item.page)
+        }
+
+        return {
+            label: item.title ?? "",
+            description: item.description,
+            value: item.page || item.href || "",
+            icon: item.icon ? <Icon name={item.icon} size={18} /> : null,
+            href: href,
+            items: item.pages?.length ? item.pages.map(toOption) : undefined,
+        }
+    }
 
     return <SidebarTabsDropdown
-        options={items.map(item => {
-            let href: string | null = null
-
-            if (typeof item.href === "string") {
-                href = pageLink(item.href)
-            }
-
-            if (!href && typeof item.page === "string") {
-                href = pageLink(item.page)
-            }
-
-            return {
-                label: item.title ?? "",
-                description: item.description,
-                value: item.page || item.href || "",
-                icon: item.icon ? <Icon name={item.icon} size={18} /> : null,
-                href: href
-            }
-        })}
+        options={items.map(toOption)}
         value={active || ""}
     />
 }

--- a/packages/xyd-framework/packages/react/hooks/useActivePage.ts
+++ b/packages/xyd-framework/packages/react/hooks/useActivePage.ts
@@ -1,7 +1,7 @@
 import { useMatches } from "react-router";
 
 import { useSettings } from "../contexts";
-import { pageLink } from "../utils";
+import { pageLink, flattenNavigationPages } from "../utils";
 import { useMatchedSubNav } from "./useMatchedSubNav";
 
 export function useActivePage(match: boolean = false) {
@@ -13,7 +13,8 @@ export function useActivePage(match: boolean = false) {
 
     const navigationItems = [
         ...(settings?.navigation?.tabs || []),
-        ...(settings?.navigation?.sidebarDropdown || []),
+        // flattened: nested sidebar-dropdown group children resolve as active
+        ...flattenNavigationPages(settings?.navigation?.sidebarDropdown || []),
         ...(settings?.webeditor?.header || [])
     ]
 

--- a/packages/xyd-framework/packages/react/hooks/useActiveSegment.ts
+++ b/packages/xyd-framework/packages/react/hooks/useActiveSegment.ts
@@ -1,15 +1,24 @@
 import { useLocation } from "react-router";
-import { pageLink, trailingSlash } from "../utils";
+
+import { Segment } from "@xyd-js/core";
+
+import { findActiveNavigationPage } from "../utils";
 import { useMatchedSegment } from "./useMatchedSegment";
 
-export function useActiveSegment() {
+/**
+ * The `page` of the segment item matching the current pathname (route-prefix,
+ * last declared match wins), or "". By default the segment comes from
+ * {@link useMatchedSegment}; pass `segment` to resolve against a SPECIFIC
+ * segment's own pages (the sidebar-dropdown switcher does this so nested
+ * `pages` groups resolve against the dropdown's items, not a co-routed tabs
+ * segment). Nested groups are flattened — a group row itself (no `page`)
+ * never becomes active, its leaves do.
+ */
+export function useActiveSegment(segment?: Segment | null) {
     const location = useLocation()
-    const pathname = trailingSlash(location.pathname)
     const matchedSegment = useMatchedSegment()
 
-    const active = matchedSegment?.pages?.findLast(item => {
-        return pathname.startsWith(pageLink(item.page || ""))
-    })
+    const seg = segment ?? matchedSegment
 
-    return active?.page || ""
+    return findActiveNavigationPage(seg?.pages, location.pathname)?.page || ""
 }

--- a/packages/xyd-framework/packages/react/hooks/useMatchedSegment.ts
+++ b/packages/xyd-framework/packages/react/hooks/useMatchedSegment.ts
@@ -3,6 +3,7 @@ import { useMatches } from "react-router";
 import { Segment } from "@xyd-js/core";
 
 import { useSettings } from "../contexts";
+import { flattenNavigationPages } from "../utils";
 
 // TODO: better data structures
 export function useMatchedSegment(): Segment | null {
@@ -21,7 +22,8 @@ export function useMatchedSegment(): Segment | null {
         if (matches?.find(m => sanitizeUrl(m.id) === sanitizeUrl(item.route as string))) {
             return true
         }
-        return item.pages?.find?.(page => {
+        // flattened: nested sidebar-dropdown group children match too
+        return flattenNavigationPages(item.pages).find(page => {
             return sanitizeUrl(page.page || "") === sanitizeUrl(lastMatchId || "")
         })
     })

--- a/packages/xyd-framework/packages/react/hooks/useMatchedSegmentSidebarDropdown.ts
+++ b/packages/xyd-framework/packages/react/hooks/useMatchedSegmentSidebarDropdown.ts
@@ -2,7 +2,7 @@ import { Segment } from "@xyd-js/core";
 import { useLocation } from "react-router";
 
 import { useSettings } from "../contexts";
-import { pageLink, trailingSlash, segmentAppearanceKind } from "../utils";
+import { pageLink, trailingSlash, segmentAppearanceKind, flattenNavigationPages } from "../utils";
 
 /**
  * The `appearance: "sidebarDropdown"` segment scoped to the current route — a
@@ -26,7 +26,8 @@ export function useMatchedSegmentSidebarDropdown(): Segment | null {
         if (segmentAppearanceKind(seg) !== "sidebarDropdown") return false
         if (typeof seg.route === "string" && !pathname.startsWith(pageLink(seg.route))) return false
 
-        const sectionPrefixes = (seg.pages || []).filter(p => typeof p.page === "string")
+        // flattened: nested group children count as member sections too
+        const sectionPrefixes = flattenNavigationPages(seg.pages).filter(p => typeof p.page === "string")
         if (!sectionPrefixes.length) return true
         return sectionPrefixes.some(p => pathname.startsWith(pageLink(p.page as string)))
     }) || null

--- a/packages/xyd-framework/packages/react/utils/index.ts
+++ b/packages/xyd-framework/packages/react/utils/index.ts
@@ -37,3 +37,8 @@ export {
     segmentAppearanceKind,
     segmentAppearanceOptions,
 } from "./segmentAppearance"
+
+export {
+    flattenNavigationPages,
+    findActiveNavigationPage,
+} from "./segmentSidebarDropdown"

--- a/packages/xyd-framework/packages/react/utils/segmentSidebarDropdown.ts
+++ b/packages/xyd-framework/packages/react/utils/segmentSidebarDropdown.ts
@@ -1,0 +1,38 @@
+import type { NavigationItem } from "@xyd-js/core"
+
+import { pageLink } from "./pageLink"
+import { trailingSlash } from "./trailingSlash"
+
+// Sidebar-dropdown nesting helpers. A NavigationItem inside
+// `navigation.sidebarDropdown` or a sidebarDropdown segment's `pages` may
+// itself declare `pages: [...]` — an inline-expandable GROUP row in the
+// dropdown. Matching logic must see through that nesting; these helpers are
+// identity operations for flat (non-nested) configs.
+
+/** Depth-first flatten of nested navigation items (parents before children). */
+export function flattenNavigationPages(pages?: NavigationItem[]): NavigationItem[] {
+    const out: NavigationItem[] = []
+    for (const item of pages || []) {
+        out.push(item)
+        if (item.pages?.length) {
+            out.push(...flattenNavigationPages(item.pages))
+        }
+    }
+    return out
+}
+
+/**
+ * The item whose `page` route-prefix matches `pathname` — the LAST declared
+ * match wins (deepest-declared semantics, same as the flat `findLast` this
+ * replaces). Group rows without a `page` never match.
+ */
+export function findActiveNavigationPage(
+    pages: NavigationItem[] | undefined,
+    pathname: string,
+): NavigationItem | null {
+    const normalized = trailingSlash(pathname)
+    return flattenNavigationPages(pages).findLast(item => {
+        if (typeof item.page !== "string" || !item.page) return false
+        return normalized.startsWith(pageLink(item.page))
+    }) || null
+}

--- a/packages/xyd-ui/src/components/SidebarTabsDropdown/SidebarTabsDropdown.styles.tsx
+++ b/packages/xyd-ui/src/components/SidebarTabsDropdown/SidebarTabsDropdown.styles.tsx
@@ -162,6 +162,25 @@ export const DropdownHost = css`
                 background: var(--dark16);
             }
         }
+
+        /* Nested GROUP row (option with \`items\`): a button that expands its
+           children inline. The chevron points right when collapsed, down when
+           expanded (the trigger-scoped rotations above don't apply here). */
+        [part="dropdown-listitem"][data-group="true"] span[part="dropdown-chevron"] {
+            transform: rotate(0deg);
+        }
+        [part="dropdown-listitem"][data-group="true"][aria-expanded="true"] span[part="dropdown-chevron"] {
+            transform: rotate(90deg);
+        }
+
+        /* Inline-expanded children of a group row. The indent lives on the
+           CONTAINER (not per-item padding) so theme listitem-padding
+           overrides — e.g. terrarium's — keep the nesting visible. */
+        [part="dropdown-sublist"] {
+            display: flex;
+            flex-direction: column;
+            padding-left: var(--xyd-sidebar-tabs-dropdown-sublist-indent, 14px);
+        }
     }
 `;
 

--- a/packages/xyd-ui/src/components/SidebarTabsDropdown/SidebarTabsDropdown.tsx
+++ b/packages/xyd-ui/src/components/SidebarTabsDropdown/SidebarTabsDropdown.tsx
@@ -12,6 +12,12 @@ export interface SidebarTabsDropdownOption {
     href?: string | null;
     description?: string;
     icon?: React.ReactNode | string;
+    /**
+     * Nested options — the entry renders as an inline-expandable GROUP row
+     * (a button, not a link): clicking it expands its children indented
+     * inside the same popover. Recursive.
+     */
+    items?: SidebarTabsDropdownOption[];
 }
 
 export interface SidebarTabsDropdownProps {
@@ -19,9 +25,43 @@ export interface SidebarTabsDropdownProps {
     value: string;
 }
 
+/** Depth-first flatten (parents before children). */
+function flattenOptions(options: SidebarTabsDropdownOption[]): SidebarTabsDropdownOption[] {
+    const out: SidebarTabsDropdownOption[] = []
+    for (const opt of options) {
+        out.push(opt)
+        if (opt.items?.length) out.push(...flattenOptions(opt.items))
+    }
+    return out
+}
+
+/** True when `value` matches an option anywhere in this subtree. */
+function containsValue(option: SidebarTabsDropdownOption, value: string): boolean {
+    if (value && option.value === value) return true
+    return !!option.items?.some(child => containsValue(child, value))
+}
+
+/** First selectable LEAF (groups have no meaningful value). */
+function firstLeaf(options: SidebarTabsDropdownOption[]): SidebarTabsDropdownOption | undefined {
+    for (const opt of options) {
+        if (opt.items?.length) {
+            const leaf = firstLeaf(opt.items)
+            if (leaf) return leaf
+        } else {
+            return opt
+        }
+    }
+    return undefined
+}
+
+/** Stable expansion key for a group row. */
+function groupKey(option: SidebarTabsDropdownOption, path: string): string {
+    return `${path}:${option.value || option.label}`
+}
+
 // TODO: for some reason icon as string does not work
 export function SidebarTabsDropdown({ options, value }: SidebarTabsDropdownProps) {
-    const selected = options.find(opt => opt.value === value) || options[0];
+    const selected = flattenOptions(options).find(opt => opt.value === value) || firstLeaf(options)
     const [open, setOpen] = useState(false)
 
     return <xyd-sidebar-tabs-dropdown className={cn.DropdownHost}>
@@ -42,13 +82,65 @@ export function SidebarTabsDropdown({ options, value }: SidebarTabsDropdownProps
             </Popover.Trigger>
 
             <Popover.Content part="dropdown-list" align="start" sideOffset={2}>
-                {options.map(opt => (
-                    <Link
-                        key={opt.value}
-                        part={"dropdown-listitem"}
-                        aria-selected={opt.value === value}
-                        to={opt.href || opt.value}
-                        onClick={() => setOpen(false)}
+                {/* The list is an inner component so the expansion state lives
+                    with the (non-portaled, non-forceMounted) content — it
+                    unmounts on close, so reopening starts fresh with only the
+                    ACTIVE option's group(s) expanded. */}
+                <$DropdownList
+                    options={options}
+                    value={value}
+                    onNavigate={() => setOpen(false)}
+                />
+            </Popover.Content>
+        </Popover.Root>
+    </xyd-sidebar-tabs-dropdown>
+}
+
+function $DropdownList({ options, value, onNavigate }: {
+    options: SidebarTabsDropdownOption[]
+    value: string
+    onNavigate: () => void
+}) {
+    // Groups whose subtree holds the active value start expanded.
+    const [expanded, setExpanded] = useState<Set<string>>(() => {
+        const initial = new Set<string>()
+        const seed = (opts: SidebarTabsDropdownOption[], path: string) => {
+            opts.forEach((opt, index) => {
+                if (!opt.items?.length) return
+                const key = groupKey(opt, `${path}/${index}`)
+                if (containsValue(opt, value)) initial.add(key)
+                seed(opt.items, `${path}/${index}`)
+            })
+        }
+        seed(options, "")
+        return initial
+    })
+
+    function toggle(key: string) {
+        setExpanded(prev => {
+            const next = new Set(prev)
+            if (next.has(key)) next.delete(key)
+            else next.add(key)
+            return next
+        })
+    }
+
+    const renderItems = (opts: SidebarTabsDropdownOption[], path: string) =>
+        opts.map((opt, index) => {
+            const itemKey = opt.value || opt.label || String(index)
+
+            // GROUP row: inline-expandable, never navigates or closes the popover.
+            if (opt.items?.length) {
+                const key = groupKey(opt, `${path}/${index}`)
+                const isExpanded = expanded.has(key)
+
+                return <React.Fragment key={itemKey}>
+                    <button
+                        type="button"
+                        part="dropdown-listitem"
+                        data-group="true"
+                        aria-expanded={isExpanded}
+                        onClick={() => toggle(key)}
                     >
                         <IconWrapper icon={opt.icon} />
 
@@ -57,14 +149,38 @@ export function SidebarTabsDropdown({ options, value }: SidebarTabsDropdownProps
                             {opt.description && <span part="dropdown-description">{opt.description}</span>}
                         </span>
 
-                        <span part="chevron-check">
-                            {opt.value === value && <CheckvronCheck />}
+                        <span part="dropdown-chevron">
+                            <Chevron />
                         </span>
-                    </Link>
-                ))}
-            </Popover.Content>
-        </Popover.Root>
-    </xyd-sidebar-tabs-dropdown>
+                    </button>
+
+                    {isExpanded && <div part="dropdown-sublist" role="group">
+                        {renderItems(opt.items, `${path}/${index}`)}
+                    </div>}
+                </React.Fragment>
+            }
+
+            return <Link
+                key={itemKey}
+                part={"dropdown-listitem"}
+                aria-selected={opt.value === value}
+                to={opt.href || opt.value}
+                onClick={onNavigate}
+            >
+                <IconWrapper icon={opt.icon} />
+
+                <span part="dropdown-label-group">
+                    <span part="dropdown-label">{opt.label}</span>
+                    {opt.description && <span part="dropdown-description">{opt.description}</span>}
+                </span>
+
+                <span part="chevron-check">
+                    {opt.value === value && <CheckvronCheck />}
+                </span>
+            </Link>
+        })
+
+    return <>{renderItems(options, "")}</>
 }
 
 function IconWrapper({ icon }: { icon: React.ReactNode | string }) {

--- a/packages/xyd-ui/src/components/SidebarTabsDropdown/index.ts
+++ b/packages/xyd-ui/src/components/SidebarTabsDropdown/index.ts
@@ -1,1 +1,2 @@
 export { SidebarTabsDropdown } from "./SidebarTabsDropdown";
+export type { SidebarTabsDropdownOption } from "./SidebarTabsDropdown";


### PR DESCRIPTION
…accordion groups

A sidebarDropdown segment's pages entry (and the global navigation.sidebarDropdown) may itself declare pages: [...] — it renders as an inline-expandable GROUP row inside the dropdown popover: clicking expands another level of items (indented, with their own icons/descriptions), clicking a child navigates and the trigger shows the child. The group containing the active section auto-expands on open; expansion state resets when the popover closes. Leaves mix freely with groups.

Active matching flattens nesting everywhere (identity for flat configs), and useActiveSegment resolves against the dropdown segment's own pages so a co-routed tabs segment can't shadow nested leaves. Pure chrome — no routes/pagemap impact. E2E suite runs both engines; unit tests pin the flatten/find-active helpers.