### PR TITLE
fix(hydration): load an asToc host page's own frontmatter

### DIFF
--- a/packages/xyd-framework/packages/hydration/mapSettingsToProps.ts
+++ b/packages/xyd-framework/packages/hydration/mapSettingsToProps.ts
@@ -66,6 +66,19 @@ export async function mapSettingsToProps(
             }
         }
         frontmatters = await pageFrontMatters(filteredNav, fmMapping) as MetadataMap
+
+        // An asToc HOST is implied by the route, not declared as a page, so the
+        // walk above never reaches it and its own frontmatter was dropped —
+        // `layout`, `icon`, `maxTocDepth` and the SEO fields were all inert on
+        // exactly the pages most likely to set them. Load it directly.
+        for (const [hostSlug, host] of Object.entries(asTocPages?.hosts || {})) {
+            if (!host.indexFile || frontmatters[hostSlug]) continue
+            const hostMatter = await pageFrontMatters(
+                [{ pages: [hostSlug] }] as Sidebar[],
+                { ...fmMapping, [hostSlug]: host.indexFile },
+            ) as MetadataMap
+            if (hostMatter[hostSlug]) frontmatters[hostSlug] = hostMatter[hostSlug]
+        }
     }
 
     const slugFrontmatter = frontmatters[slug] || null


### PR DESCRIPTION
A sidebar-as-TOC host is implied by its route — the group declares the SECTION pages and the host is inferred — so the frontmatter walk, which follows declared pages, never reached it. `slugFrontmatter` was undefined, and the metadata the theme receives collapsed to `{ asTocHost: true }` and nothing else.

The merge that builds it was already correct. It simply had nothing to merge, so `layout`, `icon`, `maxTocDepth`, `sidebarTitle` and every SEO field were inert on composed pages — which are exactly the pages likely to set a layout, since they are index pages rather than prose.

Found by setting `layout: wide` on a card grid and watching nothing happen: the attribute terrarium keys its full-width rule off (`:not([data-layout="wide"])`) was never emitted, because the value never arrived.

The host's index file is already known — `asTocPages.hosts[slug].indexFile`, the same field the composer reads — so this loads it directly rather than widening the walk, and skips any host whose frontmatter was already resolved.