### PR TITLE
fix(sidebar): even out the space above the first row

### DIFF
--- a/packages/xyd-ui/src/components/Sidebar/Sidebar.styles.tsx
+++ b/packages/xyd-ui/src/components/Sidebar/Sidebar.styles.tsx
@@ -27,6 +27,13 @@ export const SidebarHost = css`
             }
         }
 
+        /* An asToc wrapper that FOLLOWS real content owes it separation. */
+        [part="item"] + [part="item-group"][data-astoc="true"],
+        [part="item-header"] + [part="item-group"][data-astoc="true"],
+        [part="item-group"] + [part="item-group"][data-astoc="true"] {
+            margin-top: 24px;
+        }
+
         /* sidebar-as-TOC groups (asToc + indicator enabled): CONSECUTIVE
            groups share ONE wrapper — headers included — so a single
            continuous TOC track line spans them (the right-hand TOC's look).
@@ -36,11 +43,24 @@ export const SidebarHost = css`
             position: relative;
             display: block;
             padding-left: 10px;
-            margin-top: 24px;
+            /* Separation is owed only to something ABOVE. A leading zero-height
+               wrapper means :first-child cannot be relied on here, so the margin
+               is applied by adjacency instead — otherwise an asToc page's first
+               row sat 24px lower than a heading-less or named-group one, and the
+               list visibly jumped when moving between them. */
+            margin-top: 0;
 
             /* the wrapper carries the group separation — the first header's
                own top margin would push the track above it as a stray line */
             [part="item-header"]:first-child {
+                margin-top: 0;
+            }
+
+            /* ...and separation is only owed to something ABOVE. As the list's
+               first child there is nothing to separate from, so the 24px reads
+               as a stray top offset — which is why an asToc page's first item
+               sat lower than a heading-less or named-group one. */
+            &:first-child {
                 margin-top: 0;
             }
 
@@ -113,6 +133,15 @@ export const SidebarHost = css`
             overflow-x: hidden;
             height: 100%;
             padding: var(--xyd-sidebar-padding);
+        }
+
+        /* With a pinned region above, its own bottom padding is the clear space
+           over the first row. With no pinned region the list is flush against
+           the top of the sidebar and the first row reads as cramped, so the list
+           supplies that space itself — 24px, the same separation the sidebar
+           already uses between groups. */
+        [part="fixed"]:empty + [part="list"] {
+            padding-top: 24px;
         }
 
         /* scroll="sidebar": the WHOLE sidebar scrolls (scrollbar spans its full


### PR DESCRIPTION
The gap above the first sidebar row depended on which kind of element happened to be first, so the list visibly jumped when moving between sections.

**An asToc group carried its separation as a top margin.** 24px is right between groups and wrong at the top, where there is nothing above to separate from — so a composed page's first row sat 24px lower than a heading-less or named-group one. It cannot be keyed on `:first-child`: the list begins with zero-height wrappers, so the group is never the first child and such a rule silently matches nothing. It is applied by adjacency instead — the same way the divider between groups is already expressed.

**A sidebar with no pinned region was flush against its own top.** With a pinned region, that region's bottom padding is the clear space over the first row and the list's own top padding is zeroed. With none, the list fell back to 8px and the first row read as cramped. It now supplies 24px itself, the separation this sidebar already uses between groups.

