### PR TITLE
feat(navigation): source pages — page URL decoupled from the file path

### DIFF
--- a/__tests__/e2e/1.navigation/8.virtual-pages/docs.json
+++ b/__tests__/e2e/1.navigation/8.virtual-pages/docs.json
@@ -1,0 +1,26 @@
+{
+    "theme": {
+        "name": "poetry"
+    },
+    "navigation": {
+        "sidebar": [
+            {
+                "route": "docs",
+                "pages": [
+                    {
+                        "group": "Get Started",
+                        "pages": ["docs/index"]
+                    },
+                    {
+                        "group": "Logs",
+                        "pages": [
+                            { "page": "docs/angular/logs", "source": "docs/logs.angular" },
+                            { "page": "docs/bun/logs", "source": "docs/logs.bun" },
+                            { "virtual": "docs/logs.node", "page": "docs/node/logs" }
+                        ]
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/__tests__/e2e/1.navigation/8.virtual-pages/docs/index.md
+++ b/__tests__/e2e/1.navigation/8.virtual-pages/docs/index.md
@@ -1,0 +1,7 @@
+---
+title: Introduction
+---
+
+# Introduction
+
+Pick your runtime in the Logs section.

--- a/__tests__/e2e/1.navigation/8.virtual-pages/docs/logs.angular.md
+++ b/__tests__/e2e/1.navigation/8.virtual-pages/docs/logs.angular.md
@@ -1,0 +1,7 @@
+---
+title: Angular Logs
+---
+
+# Angular Logs
+
+angular-logs-marker — served from `docs/logs.angular.md` at `/docs/angular/logs`.

--- a/__tests__/e2e/1.navigation/8.virtual-pages/docs/logs.bun.md
+++ b/__tests__/e2e/1.navigation/8.virtual-pages/docs/logs.bun.md
@@ -1,0 +1,7 @@
+---
+title: Bun Logs
+---
+
+# Bun Logs
+
+bun-logs-marker — served from `docs/logs.bun.md` at `/docs/bun/logs`.

--- a/__tests__/e2e/1.navigation/8.virtual-pages/docs/logs.node.md
+++ b/__tests__/e2e/1.navigation/8.virtual-pages/docs/logs.node.md
@@ -1,0 +1,7 @@
+---
+title: Node Logs
+---
+
+# Node Logs
+
+node-logs-marker — raw virtual form.

--- a/__tests__/e2e/1.navigation/8.virtual-pages/virtual-pages.test.ts
+++ b/__tests__/e2e/1.navigation/8.virtual-pages/virtual-pages.test.ts
@@ -1,0 +1,84 @@
+import { test, expect, Page } from '@playwright/test';
+
+import { createXydServer, createXydBunServer, XydServer } from '../../utils/xyd-server';
+
+// Virtual/source pages: a page's URL decoupled from its markdown file path.
+// `{ "page": "docs/angular/logs", "source": "docs/logs.angular" }` serves
+// `docs/logs.angular.md` at `/docs/angular/logs` (the sugar is normalized to
+// the uniform-era `{ virtual, page }` form, which stays supported raw).
+// Run on BOTH engines.
+const ENGINES: { name: string; make: (dir: string) => Promise<XydServer> }[] = [
+    { name: 'bun', make: (dir) => createXydBunServer(dir) },
+    { name: 'vite', make: (dir) => createXydServer(dir) },
+];
+
+for (const engine of ENGINES) {
+    test.describe(`navigation — virtual/source pages (${engine.name} engine)`, () => {
+        // One dev server per engine (parallel workers each boot their own and
+        // vite cold boots exceed the 2-minute start timeout).
+        test.describe.configure({ mode: 'serial' });
+
+        let server: XydServer;
+
+        test.beforeAll(async () => {
+            server = await engine.make(__dirname);
+        });
+
+        test.afterAll(async () => {
+            await server?.stop();
+        });
+
+        async function goto(page: Page, path: string) {
+            await page.goto(server.getUrl(path));
+            await page.waitForLoadState('networkidle');
+        }
+
+        test('source pages serve the mapped file at the pretty URL', async ({ page }) => {
+            await goto(page, '/docs/angular/logs');
+            await expect(page.locator('h1').first()).toHaveText('Angular Logs');
+            await expect(page.locator('main, body').first()).toContainText('angular-logs-marker');
+
+            await goto(page, '/docs/bun/logs');
+            await expect(page.locator('h1').first()).toHaveText('Bun Logs');
+            await expect(page.locator('main, body').first()).toContainText('bun-logs-marker');
+        });
+
+        test('the raw { virtual, page } form keeps working', async ({ page }) => {
+            await goto(page, '/docs/node/logs');
+            await expect(page.locator('h1').first()).toHaveText('Node Logs');
+            await expect(page.locator('main, body').first()).toContainText('node-logs-marker');
+        });
+
+        test('sidebar links point at the pretty URLs, labeled from the files\' frontmatter', async ({ page }) => {
+            await goto(page, '/docs/index');
+
+            // duplicated in DOM (mobile drawer) — assert on the VISIBLE one
+            const angular = page.locator('a[part="item-link"][href="/docs/angular/logs"]:visible').first();
+            await expect(angular).toBeVisible();
+            await expect(angular).toContainText('Angular Logs');
+            await expect(page.locator('a[part="item-link"][href="/docs/bun/logs"]:visible').first()).toContainText('Bun Logs');
+
+            // clicking navigates to the pretty URL and renders the mapped file
+            await angular.click();
+            await page.waitForURL('**/docs/angular/logs');
+            await expect(page.locator('h1').first()).toHaveText('Angular Logs');
+        });
+
+        test('prev/next navlinks travel between the pretty URLs', async ({ page }) => {
+            await goto(page, '/docs/angular/logs');
+            const next = page.locator('a[href="/docs/bun/logs"]:visible').last();
+            await expect(next).toBeVisible();
+            await next.click();
+            await page.waitForURL('**/docs/bun/logs');
+            await expect(page.locator('h1').first()).toHaveText('Bun Logs');
+        });
+
+        test('the FILE path is not a URL — only the pretty URL serves the page', async ({ page }) => {
+            await page.goto(server.getUrl('/docs/logs.angular'));
+            await page.waitForLoadState('networkidle');
+            // not in navigation → not in the page-path mapping → 404/redirect,
+            // never the page content
+            expect(await page.content()).not.toContain('angular-logs-marker');
+        });
+    });
+}

--- a/crates/xyd_settings/fixtures/pagemap/content/guides/logs.angular.md
+++ b/crates/xyd_settings/fixtures/pagemap/content/guides/logs.angular.md
@@ -1,0 +1,1 @@
+# Angular logs

--- a/crates/xyd_settings/fixtures/pagemap/expected.json
+++ b/crates/xyd_settings/fixtures/pagemap/expected.json
@@ -2,5 +2,6 @@
   "content/docs/intro": "content/docs/intro.md",
   "content/docs/setup": "content/docs/setup.mdx",
   "content/docs/api/users": "content/docs/api/users.md",
-  "content/guides/welcome": "content/guides/welcome.md"
+  "content/guides/welcome": "content/guides/welcome.md",
+  "guides/angular/logs": "content/guides/logs.angular.md"
 }

--- a/crates/xyd_settings/fixtures/pagemap/nav.json
+++ b/crates/xyd_settings/fixtures/pagemap/nav.json
@@ -1,8 +1,68 @@
 {
   "sidebar": [
-    { "group": "Docs", "pages": ["content/docs/intro", "content/docs/setup", { "group": "API", "pages": ["content/docs/api/users", "content/docs/api/missing"] }, { "group": "NestedToc", "asToc": true, "pages": ["content/toc/nested"] }] },
-    { "group": "TopToc", "asToc": true, "pages": ["content/toc/alpha"] },
-    { "group": "ObjectToc", "asToc": { "indicator": false }, "pages": ["content/toc/beta"] },
-    { "route": "/guides", "pages": [{ "group": "G", "pages": ["content/guides/welcome"] }, { "group": "RoutedToc", "asToc": true, "pages": ["content/toc/routed"] }, "content/guides/toplevel-missing"] }
+    {
+      "group": "Docs",
+      "pages": [
+        "content/docs/intro",
+        "content/docs/setup",
+        {
+          "group": "API",
+          "pages": [
+            "content/docs/api/users",
+            "content/docs/api/missing"
+          ]
+        },
+        {
+          "group": "NestedToc",
+          "asToc": true,
+          "pages": [
+            "content/toc/nested"
+          ]
+        }
+      ]
+    },
+    {
+      "group": "TopToc",
+      "asToc": true,
+      "pages": [
+        "content/toc/alpha"
+      ]
+    },
+    {
+      "group": "ObjectToc",
+      "asToc": {
+        "indicator": false
+      },
+      "pages": [
+        "content/toc/beta"
+      ]
+    },
+    {
+      "route": "/guides",
+      "pages": [
+        {
+          "group": "G",
+          "pages": [
+            "content/guides/welcome",
+            {
+              "virtual": "content/guides/logs.missing",
+              "page": "guides/missing/logs"
+            }
+          ]
+        },
+        {
+          "group": "RoutedToc",
+          "asToc": true,
+          "pages": [
+            "content/toc/routed"
+          ]
+        },
+        "content/guides/toplevel-missing",
+        {
+          "virtual": "content/guides/logs.angular",
+          "page": "guides/angular/logs"
+        }
+      ]
+    }
   ]
 }

--- a/crates/xyd_settings/src/pagemap.rs
+++ b/crates/xyd_settings/src/pagemap.rs
@@ -100,29 +100,12 @@ impl<'a> Walker<'a> {
                     let has_pages = obj.contains_key("pages");
                     let has_route = obj.contains_key("route");
                     if has_pages && has_route {
-                        // (b) SidebarRoute: for each item — nested pages recurse,
-                        // bare strings resolve directly; a direct virtual object
-                        // is NOT handled (the JS asymmetry — preserved).
+                        // (b) SidebarRoute: items are regular pages — strings,
+                        // groups (asToc-gated in process_pages), and virtual/
+                        // source leaves (URL ≠ file path) directly under the
+                        // route. Mirrors the JS walker exactly.
                         if let Some(items) = obj.get("pages").and_then(|p| p.as_array()) {
-                            for item in items {
-                                match item {
-                                    Value::Object(io) if io.contains_key("pages") => {
-                                        if let Some(nested) =
-                                            io.get("pages").and_then(|p| p.as_array())
-                                        {
-                                            if !is_as_toc(io) {
-                                                self.process_pages(nested);
-                                            }
-                                        }
-                                    }
-                                    Value::String(s) => {
-                                        if let Some(p) = existing_file_path(self.cwd, s) {
-                                            self.set(s, p);
-                                        }
-                                    }
-                                    _ => {}
-                                }
-                            }
+                            self.process_pages(items);
                         }
                     } else if has_pages {
                         // (c) plain Sidebar group

--- a/packages/xyd-core/src/types/settings.ts
+++ b/packages/xyd-core/src/types/settings.ts
@@ -830,7 +830,32 @@ export interface ComponentPageImport {
 /**
  * Page URL type
  */
-export type PageURL = string | VirtualPage | Sidebar | ComponentPage;
+export type PageURL = string | VirtualPage | SourcePage | Sidebar | ComponentPage;
+
+/**
+ * A page whose URL differs from its markdown file path.
+ *
+ * Sugar for the {@link VirtualPage} object form — normalized at boot
+ * (`{ page, source }` → `{ virtual: source, page }`), so the whole engine
+ * only ever sees the virtual shape. Use it when several files should share a
+ * URL scheme, e.g. per-framework variants:
+ *
+ * ```json
+ * { "page": "docs/angular/logs", "source": "docs/logs.angular" }
+ * { "page": "docs/bun/logs",     "source": "docs/logs.bun" }
+ * ```
+ */
+export interface SourcePage {
+  /** The URL the page serves at. */
+  page: string;
+
+  /** The markdown file path, extension-less — like a string page entry
+   * (`docs/logs.angular` → `docs/logs.angular.md`/`.mdx`). */
+  source: string;
+
+  /** Optional sidebar label override. */
+  title?: string;
+}
 
 /**
  * @internal

--- a/packages/xyd-framework/packages/hydration/mapSettingsToProps.ts
+++ b/packages/xyd-framework/packages/hydration/mapSettingsToProps.ts
@@ -139,7 +139,10 @@ export async function mapSettingsToProps(
             && !("pages" in page)
             && !("group" in page)
 
-        if (typeof page !== "string" && !("virtual" in page) && !isTitledPageRef) {
+        // `source` pages ({ page, source }) are normalized to { virtual, page }
+        // at boot (plugin-docs normalizeSourcePages) — excluding them here is
+        // for the TYPE narrowing (required `source` key), not a runtime path.
+        if (typeof page !== "string" && !("virtual" in page) && !("source" in page) && !isTitledPageRef) {
             const items = page.pages
                 ?.map((p) => mapItems(p, page, nav))
                 ?.filter(Boolean)

--- a/packages/xyd-host/app/pathRoutes.ts
+++ b/packages/xyd-host/app/pathRoutes.ts
@@ -93,6 +93,11 @@ function extractNestedRoutes(
             // React Router's ssr:false loader-export validation).
             if (item.pages && Array.isArray(item.pages) && !asTocEnabled((item as any).asToc)) {
                 extractNestedRoutes(item.pages as SidebarNavigation, routes, route || parentRoute)
+            } else if (!parentRoute && !('route' in item) && 'page' in item && typeof (item as any).page === "string" && (item as any).page) {
+                // Top-level flat leaf OBJECT (a virtual/source page outside any
+                // SidebarRoute) — routed exactly like a top-level string page.
+                const page = (item as any).page.startsWith("/") ? (item as any).page : `/${(item as any).page}`;
+                routes.push({ id: page, path: page });
             }
         } else if (!parentRoute) {
             const page = item.startsWith("/") ? item : `/${item}`;

--- a/packages/xyd-plugin-docs/__tests__/sourcePages.test.ts
+++ b/packages/xyd-plugin-docs/__tests__/sourcePages.test.ts
@@ -1,0 +1,116 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { Navigation } from "@xyd-js/core";
+import { describe, expect, it } from "vitest";
+
+import { mapNavigationToPagePathMapping, normalizeSourcePages, prefixSidebarPages } from "../src/index";
+
+// `{ page, source }` — a page whose URL differs from its markdown file path.
+// The sugar is normalized at boot into the long-supported `{ virtual, page }`
+// form, so every walker (JS + Rust pagemaps, sidebar, docPaths, search, i18n)
+// only ever sees the virtual shape. No process.chdir — the mapping builder
+// takes an explicit cwd.
+
+describe("normalizeSourcePages", () => {
+    it("rewrites { page, source } leaves everywhere: route groups, nested groups, top level, i18n sidebars", () => {
+        const nav: Navigation = {
+            sidebar: [
+                { page: "top/pretty", source: "top/file" } as any,
+                {
+                    route: "docs",
+                    pages: [
+                        {
+                            group: "Logs",
+                            pages: [
+                                { page: "docs/angular/logs", source: "docs/logs.angular" },
+                                { group: "Nested", pages: [{ page: "docs/bun/logs", source: "docs/logs.bun" }] },
+                                "docs/plain",
+                            ],
+                        },
+                    ],
+                } as any,
+            ],
+            languages: [
+                { language: "pl", sidebar: [{ route: "docs", pages: [{ page: "docs/a", source: "docs/b" }] }] } as any,
+            ],
+        };
+
+        normalizeSourcePages(nav);
+
+        expect(nav.sidebar![0]).toEqual({ page: "top/pretty", virtual: "top/file" });
+        const group = (nav.sidebar![1] as any).pages[0];
+        expect(group.pages[0]).toEqual({ page: "docs/angular/logs", virtual: "docs/logs.angular" });
+        expect(group.pages[1].pages[0]).toEqual({ page: "docs/bun/logs", virtual: "docs/logs.bun" });
+        expect(group.pages[2]).toBe("docs/plain"); // strings untouched
+        expect((nav.languages![0].sidebar![0] as any).pages[0]).toEqual({ page: "docs/a", virtual: "docs/b" });
+    });
+
+    it("preserves extra props, leaves other shapes alone, and is idempotent", () => {
+        const titledRef = { page: "docs/x", title: "X" }; // titled page ref — NOT a source page
+        const rawVirtual = { virtual: ".cache/y", page: "docs/y" };
+        const component = { component: "Foo", page: "p", source: "s" }; // component wins
+        const nav: Navigation = {
+            sidebar: [
+                { route: "docs", pages: [{ page: "docs/z", source: "docs/z.file", title: "Z" }, titledRef, rawVirtual, component] } as any,
+            ],
+        };
+
+        normalizeSourcePages(nav);
+        const pages = (nav.sidebar![0] as any).pages;
+        expect(pages[0]).toEqual({ page: "docs/z", virtual: "docs/z.file", title: "Z" });
+        expect(pages[1]).toEqual({ page: "docs/x", title: "X" });
+        expect(pages[2]).toEqual({ virtual: ".cache/y", page: "docs/y" });
+        expect(pages[3]).toEqual({ component: "Foo", page: "p", source: "s" });
+
+        const once = JSON.parse(JSON.stringify(nav));
+        normalizeSourcePages(nav);
+        expect(JSON.parse(JSON.stringify(nav))).toEqual(once);
+    });
+});
+
+describe("mapNavigationToPagePathMapping with virtual/source pages", () => {
+    it("maps the pretty URL to the real file (dotted stems survive extension probing)", () => {
+        const dir = fs.mkdtempSync(path.join(os.tmpdir(), "xyd-sourcepages-"));
+        try {
+            fs.mkdirSync(path.join(dir, "docs"), { recursive: true });
+            fs.writeFileSync(path.join(dir, "docs", "logs.angular.md"), "# Angular logs\n");
+
+            const nav: Navigation = {
+                sidebar: [{
+                    route: "docs",
+                    pages: [
+                        { page: "docs/angular/logs", source: "docs/logs.angular" },
+                        { page: "docs/missing/logs", source: "docs/logs.missing" },
+                    ],
+                } as any],
+            };
+            normalizeSourcePages(nav);
+            const mapping = mapNavigationToPagePathMapping(nav, dir);
+
+            expect(mapping["docs/angular/logs"]).toBe("docs/logs.angular.md");
+            expect(mapping["docs/missing/logs"]).toBeUndefined(); // no file → no entry
+            expect(mapping["docs/logs.angular"]).toBeUndefined(); // the FILE path is not a URL
+        } finally {
+            fs.rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});
+
+describe("prefixSidebarPages on normalized entries (i18n)", () => {
+    it("locale-prefixes BOTH the file path and the URL", () => {
+        const sidebar = [{
+            route: "docs",
+            pages: [{ page: "docs/angular/logs", source: "docs/logs.angular" }],
+        }] as any[];
+        normalizeSourcePages({ sidebar } as Navigation);
+        prefixSidebarPages(sidebar, "pl/");
+
+        expect(sidebar[0].route).toBe("/pl/docs");
+        expect(sidebar[0].pages[0]).toEqual({
+            page: "pl/docs/angular/logs",
+            virtual: "pl/docs/logs.angular",
+        });
+    });
+});

--- a/packages/xyd-plugin-docs/src/asToc.ts
+++ b/packages/xyd-plugin-docs/src/asToc.ts
@@ -111,8 +111,17 @@ export function collectAsTocPages(
                 result.pages[page] = { host: hostSlug, id, ...opts };
             } else if (page && typeof page === "object" && "pages" in page) {
                 collectGroup((page as Sidebar).pages, hostSlug, opts);
+            } else if (page && typeof page === "object" && "virtual" in page && (page as any).page) {
+                // A virtual/source page (URL ≠ file path) composes like a
+                // string page — file from `virtual`, section id from `page`.
+                const p = page as { virtual: string; page: string };
+                const file = existingFilePath(p.virtual);
+                if (!file) continue;
+                const id = sectionIdFor(p.page);
+                hostFor(hostSlug).sections.push({ page: p.page, file, id });
+                result.pages[p.page] = { host: hostSlug, id, ...opts };
             }
-            // virtual/component entries: not composable — ignored (v1)
+            // component entries: not composable — ignored (v1)
         }
     }
 

--- a/packages/xyd-plugin-docs/src/index.ts
+++ b/packages/xyd-plugin-docs/src/index.ts
@@ -412,6 +412,11 @@ export async function pluginDocs(options?: PluginDocsOptions): Promise<PluginOut
 
     let pagePathMapping: Record<string, string> = {}
 
+    // `{ page, source }` sugar → the `{ virtual, page }` form BEFORE anything
+    // walks navigation (i18n inheritance/prefixing, the JS/Rust pagemaps, the
+    // client settings) — downstream only ever sees the long-supported shape.
+    normalizeSourcePages(settings?.navigation)
+
     // Derive i18n state once. Subsequent steps (path mapping, route generation,
     // sitemap, prehydration) read from globalThis.__xydI18n.
     const i18n = deriveI18n(settings)
@@ -641,7 +646,41 @@ export function inheritTopLevelNavigation(settings: Settings) {
 // reference, virtual page, and SidebarRoute.route. Mutates in place. Called
 // once at boot for non-default locales so that downstream code (path
 // mapping, route generation, sidebar rendering) all share one key space.
-function prefixSidebarPages(sidebar: any[], prefix: string) {
+/**
+ * Normalize `{ page, source }` sidebar entries (the user-facing sugar for a
+ * page whose URL differs from its file path) into the `{ virtual, page }`
+ * form the whole engine already understands — JS + Rust pagemaps, sidebar
+ * rendering, docPaths, search, i18n prefixing. Mutates in place; extra props
+ * (`title`, …) are preserved. Idempotent — normalized entries have no
+ * `source` left. Exported for tests.
+ */
+export function normalizeSourcePages(navigation?: Navigation | null) {
+    if (!navigation) return
+
+    const normalizeEntry = (entry: any) => {
+        if (!entry || typeof entry !== "object") return
+        if (Array.isArray(entry.pages)) {
+            for (const child of entry.pages) normalizeEntry(child)
+            return
+        }
+        if (
+            typeof entry.page === "string" &&
+            typeof entry.source === "string" &&
+            !("virtual" in entry) &&
+            !("component" in entry)
+        ) {
+            entry.virtual = entry.source
+            delete entry.source
+        }
+    }
+
+    for (const item of navigation.sidebar || []) normalizeEntry(item)
+    for (const lang of navigation.languages || []) {
+        for (const item of lang.sidebar || []) normalizeEntry(item)
+    }
+}
+
+export function prefixSidebarPages(sidebar: any[], prefix: string) {
     for (const item of sidebar) {
         if (typeof item === "string") continue // top-level handled below
         if (!item || typeof item !== "object") continue
@@ -727,20 +766,10 @@ export function mapNavigationToPagePathMapping(navigation: Navigation, cwd?: str
             sidebarFlatOnly = true
             break
         } else if ('pages' in sidebar && "route" in sidebar) {
-            // Handle SidebarRoute
-            for (const item of sidebar.pages) {
-                if (item?.pages) {
-                    // asToc group under a route — sections, not pages.
-                    if (asTocEnabled((item as Sidebar).asToc)) continue
-                    processPages(item.pages)
-                } else if (typeof item === 'string') {
-                    // Handle direct string pages in SidebarRoute
-                    const existingPath = getExistingFilePath(item)
-                    if (existingPath) {
-                        mapping[item] = existingPath
-                    }
-                }
-            }
+            // Handle SidebarRoute — items are regular pages: strings, groups
+            // (asToc-gated inside processPages), and virtual/source leaves
+            // (URL ≠ file path) directly under the route.
+            processPages(sidebar.pages as PageURL[])
         } else if ('pages' in sidebar) {
             // Handle Sidebar (top-level asToc group — sections, not pages)
             if (asTocEnabled((sidebar as Sidebar).asToc)) continue


### PR DESCRIPTION
Sidebar leaves accept { page: "docs/angular/logs", source: "docs/logs.angular" } — serve a markdown file at a URL that differs from its path (per-framework variants of one doc sharing a clean URL scheme). Sugar for the uniform-era { virtual, page } form: normalizeSourcePages rewrites it at boot (before i18n, the JS/Rust pagemaps and the client settings), so every existing walker — sidebar, navlinks, breadcrumbs, docPaths, search, locale prefixing, llms.txt, sitemap — works unchanged on both engines. The raw virtual form stays public; SourcePage joins the core PageURL union.

Gap fixes shipped with it:
- both pagemap walkers' SidebarRoute branch dropped a virtual leaf DIRECTLY under a route (a deliberately mirrored JS/Rust asymmetry) — both now feed route items through the shared page processor
- pathRoutes routes top-level flat leaf objects like top-level strings
- collectAsTocPages composes virtual leaves as asToc sections

Covered by plugin-docs sourcePages unit tests (chdir-free), the Rust pagemap fixture (virtual-under-route + dotted stem), and a 10-test e2e matrix on both engines incl. the compiled binary (dev + static build + XYD_NATIVE=0 parity).